### PR TITLE
Adding new targets to the search suggestion lists.

### DIFF
--- a/apps/platform/src/pages/HomePage/ppSearchExamples.js
+++ b/apps/platform/src/pages/HomePage/ppSearchExamples.js
@@ -2,6 +2,9 @@ const searchExamples = {
   targets: [
     { label: 'WRN', id: 'ENSG00000165392' },
     { label: 'KRAS', id: 'ENSG00000133703' },
+    { label: 'WDR7', id: 'ENSG00000091157' },
+    { label: 'PAK2', id: 'ENSG00000180370' },
+    { label: 'WDR7', id: 'ENSG00000091157' },
   ],
   diseases: [
     { label: 'Atopic Eczema', id: 'EFO_0000274' },


### PR DESCRIPTION
I have added a few more targets that are found in both the ot_crispr and validation lab datasets. 

I think we can keep the drugs as they are, as (as much as I am aware), none of the projects are focusing on any specific drugs.