### PR TITLE
Fix subcellular location triggering re-rendering of target page

### DIFF
--- a/apps/platform/src/sections/target/SubcellularLocation/SubcellularViz.jsx
+++ b/apps/platform/src/sections/target/SubcellularLocation/SubcellularViz.jsx
@@ -1,4 +1,4 @@
-import React, { lazy, useEffect, useRef } from 'react';
+import React, { lazy, useEffect, useRef, Suspense } from 'react';
 import {
   Typography,
   List,
@@ -13,6 +13,7 @@ import { faMapMarkerAlt } from '@fortawesome/free-solid-svg-icons';
 
 import Link from '../../../components/Link';
 import { identifiersOrgLink, getUniprotIds } from '../../../utils/global';
+import LoadingBackdrop from '../../../components/LoadingBackdrop';
 
 const SwissbioViz = lazy(() => import('./SwissbioViz'));
 
@@ -171,23 +172,25 @@ function SubcellularViz({ data: target }) {
             key={i}
             className={classes.tabPanel}
           >
-            <SwissbioViz
-              taxonId="9606"
-              locationIds={sourcesLocations[s.id]
-                .map(l => parseLocationTerm(l.termSL))
-                .join()}
-              sourceId={s.id.toLowerCase()}
-            >
-              <Box ml={4} key={s.id}>
-                <Typography variant="h6">{s.label}</Typography>
-                Location for{' '}
-                <LocationLink
-                  sourceId={s.id}
-                  id={s.id === 'uniprot' ? uniprotId : target.id}
-                />
-                <LocationsList sls={sourcesLocations[s.id]} />
-              </Box>
-            </SwissbioViz>
+            <Suspense fallback={<LoadingBackdrop />}>
+              <SwissbioViz
+                taxonId="9606"
+                locationIds={sourcesLocations[s.id]
+                  .map(l => parseLocationTerm(l.termSL))
+                  .join()}
+                sourceId={s.id.toLowerCase()}
+              >
+                <Box ml={4} key={s.id}>
+                  <Typography variant="h6">{s.label}</Typography>
+                  Location for{' '}
+                  <LocationLink
+                    sourceId={s.id}
+                    id={s.id === 'uniprot' ? uniprotId : target.id}
+                  />
+                  <LocationsList sls={sourcesLocations[s.id]} />
+                </Box>
+              </SwissbioViz>
+            </Suspense>
           </div>
         ))}
       </SubcellularVizTabs>

--- a/apps/platform/src/sections/target/SubcellularLocation/SubcellularViz.jsx
+++ b/apps/platform/src/sections/target/SubcellularLocation/SubcellularViz.jsx
@@ -15,7 +15,9 @@ import Link from '../../../components/Link';
 import { identifiersOrgLink, getUniprotIds } from '../../../utils/global';
 import LoadingBackdrop from '../../../components/LoadingBackdrop';
 
-const SwissbioViz = lazy(() => import('./SwissbioViz'));
+const SwissbioViz = 'customElements' in window
+ ? lazy(() => import('./SwissbioViz')) 
+ : ({ children }) => <>{children}</>;
 
 const useStyles = makeStyles(theme => ({
   locationIcon: {


### PR DESCRIPTION
This PR addresses a re-rendering of the target page when the subcellular location viz is loaded as noted here https://github.com/opentargets/issues/issues/2654
This appeared to be caused by a missing <Suspense> element to wrap the lazy-loaded visualisation.