### PR TITLE
Fix body background color on scroll bounce

### DIFF
--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -7,7 +7,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <meta name="theme-color" content="#3489ca" />
+    <meta name="theme-color" content="#FFF" />
     <!-- Open Graph tags -->
     <meta property="og:title" content="Open Targets Platform" />
     <meta property="og:type" content="website" />


### PR DESCRIPTION
When scrolling passed the top or bottom of the page, a blue background is shown. This is good, but not desirable on PPP. https://github.com/opentargets/issues/issues/2589

After investigating a few options, I suggest simply **setting the background to** standard **white**:
 - simple solution that looks **consistent across browsers**
 - using theme colour (which would be different for PPP) is more fiddly and
 - theme colour would only work at the top of the page, as the footer is dark grey

