### PR TITLE
More robust handling of `platformUrl`

### DIFF
--- a/apps/genetics/src/components/Header/OTButtonLink.jsx
+++ b/apps/genetics/src/components/Header/OTButtonLink.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core';
-
+import config from '../../config';
 import { Button } from '../../ot-ui-components';
 
 const useStyles = makeStyles(() => ({
@@ -18,10 +18,7 @@ const OTButtonLink = ({ id, symbol }) => {
   const classes = useStyles();
   const btnLabel = `View ${symbol} in the Open Targets Platform`;
   return (
-    <a
-      href={`https://platform.opentargets.org/target/${id}`}
-      className={classes.link}
-    >
+    <a href={`${config.platformUrl}/target/${id}`} className={classes.link}>
       <Button className={classes.button}>{btnLabel}</Button>
     </a>
   );

--- a/apps/genetics/src/config.js
+++ b/apps/genetics/src/config.js
@@ -5,7 +5,9 @@ const config = {
   googleTagManagerID: window.configGoogleTagManagerID ?? null,
   helpdeskEmail: window.configHelpdeskEmail ?? 'helpdesk@opentargets.org',
   profile: window.configProfile ?? {},
-  platformUrl: window.configPlatformUrl ?? 'https://genetics.opentargets.org',
+  platformUrl: window.configPlatformUrl
+    ? window.configPlatformUrl.replace(/\/$/, '')
+    : 'https://platform.opentargets.org',
 };
 
 export default config;


### PR DESCRIPTION
When providing a value for `platformUrl` that contains a trailing slash, the corresponding links on the gene page will not work due to double slashes. This change removes the trailing slash from `platformUrl` if one exists.