### PR TITLE
Dockerise application

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,48 @@
+# dependencies
+node_modules
+
+# testing
+coverage
+
+# next.js
+.next/
+out/
+**/build
+**/dist
+**/dist-platform
+**/dist-genetics
+**/bundle-platform
+**/bundle-genetics
+
+# misc
+.DS_Store
+*.pem
+**/.env.local
+**/.env.development.local
+**/.env.test.local
+**/.env.production.local
+**/*.swp
+
+# debug
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+.pnpm-debug.log*
+
+# local env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# turbo
+.turbo
+# Local Netlify folder
+.netlify
+
+**/src/icons/sections
+
+**/tmp
+
+.git/
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:16 as build
+# make sure app variable is set and valid
+ARG app=""
+RUN : "${app:?Missing --build-arg app}"
+RUN case "$app" in platform) true;; genetics) true;; *) echo "variable 'app' must be set to either 'platform' or 'genetics'"; false;; esac
+# assert that a compatible yarn version is installed or fail
+RUN case `yarn --version` in 1.22*) true;; *) false;; esac
+# COPY package.json yarn.lock /tmp/$app-app/
+WORKDIR /tmp/app/
+COPY . ./
+RUN yarn --network-timeout 100000
+RUN yarn build:$app
+RUN mv ./apps/$app/bundle-$app/ ./bundle/
+
+FROM node:16
+RUN npm install --location=global serve
+COPY --from=build /tmp/app/bundle/ /var/www/app/
+WORKDIR /var/www/app/
+EXPOSE 80
+CMD ["serve", "--no-clipboard", "--single", "-l", "tcp://0.0.0.0:80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM node:16 as build
 # make sure `app` variable is set and valid
 ARG app=""
-RUN : "${app:?Missing --build-arg app}"
 RUN case "$app" in platform|genetics) true;; *) echo "variable 'app' must be set to either 'platform' or 'genetics'"; false;; esac
 # assert that a compatible yarn version is installed or fail
 RUN case `yarn --version` in 1.22*) true;; *) false;; esac

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM node:16 as build
-# make sure app variable is set and valid
+# make sure `app` variable is set and valid
 ARG app=""
 RUN : "${app:?Missing --build-arg app}"
-RUN case "$app" in platform) true;; genetics) true;; *) echo "variable 'app' must be set to either 'platform' or 'genetics'"; false;; esac
+RUN case "$app" in platform|genetics) true;; *) echo "variable 'app' must be set to either 'platform' or 'genetics'"; false;; esac
 # assert that a compatible yarn version is installed or fail
 RUN case `yarn --version` in 1.22*) true;; *) false;; esac
-# COPY package.json yarn.lock /tmp/$app-app/
 WORKDIR /tmp/app/
 COPY . ./
+# install dependencies and build specified app
 RUN yarn --network-timeout 100000
 RUN yarn build:$app
 RUN mv ./apps/$app/bundle-$app/ ./bundle/

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Genetics netlify preview
 A Docker image hosting either the Open Targets Platform or Open Targets Genetics web application can be built using the following command:
 
 ```sh
-docker build --tag {name:tag} --build-arg app={platform,genetics}
+docker build --tag {name:tag} --build-arg app={platform,genetics} .
 ```
 
 The `app` variable can be set to either `platform` or `genetics`, depending on which application should be built.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,24 @@ Genetics netlify preview
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/e00eea73-d8b7-4f88-9d16-7265144b54e1/deploy-status)](https://app.netlify.com/sites/ot-genetics/deploys)
 
+## Building and using a Docker image
+
+A Docker image hosting either the Open Targets Platform or Open Targets Genetics web application can be built using the following command:
+
+```sh
+docker build --tag {name:tag} --build-arg app={platform,genetics}
+```
+
+The `app` variable can be set to either `platform` or `genetics`, depending on which application should be built.
+
+Once the image is built, the application can be hosted as such:
+
+```sh
+docker run -it --rm -p 80:80 {name:tag}
+```
+
+The application is then locally accessible in the browser at: <http://localhost:80>
+
 ## Copyright
 
 Copyright 2014-2018 Biogen, Celgene Corporation, EMBL - European Bioinformatics Institute, GlaxoSmithKline, Takeda Pharmaceutical Company and Wellcome Sanger Institute


### PR DESCRIPTION
This PR adds instructions to create a Docker image running either the Open Targets Platform or Open Targets Genetics frontend. Choosing between the two applications is done using `--build-arg app={platform,genetics}`. Any value other than `platform` or `genetics` will result in an error during the build process. The respective application is built from source.

Do you see any issues with this? I hope you find it useful.