### PR TITLE
Refactor Route child to component prop

### DIFF
--- a/apps/platform/src/pages/TargetPage/TargetPage.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetPage.jsx
@@ -11,6 +11,8 @@ import { getUniprotIds } from '../../utils/global';
 import LoadingBackdrop from '../../components/LoadingBackdrop';
 import TARGET_PAGE_QUERY from './TargetPage.gql';
 
+import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
+
 const Profile = lazy(() => import('../TargetPage/Profile'));
 const ClassicAssociations = lazy(() =>
   import('../TargetPage/ClassicAssociations')
@@ -31,6 +33,7 @@ function TargetPage({ location, match }) {
   const crisprId = data?.target.dbXrefs.find(p => p.source === 'ProjectScore')
     ?.id;
 
+  
   return (
     <BasePage
       title={
@@ -77,16 +80,65 @@ function TargetPage({ location, match }) {
       </Tabs>
       <Suspense fallback={<LoadingBackdrop />}>
         <Switch>
-          <Route path={`${match.path}/associations`}>
-            <ClassicAssociations ensgId={ensgId} symbol={symbol} />
-          </Route>
-          <Route path={match.path}>
-            <Profile ensgId={ensgId} symbol={symbol} />
-          </Route>
+          <Route 
+            path={`${match.path}/associations`}
+            component={()=>(<ClassicAssociations ensgId={ensgId} symbol={symbol} />)}
+          />
+          <Route 
+            path={match.path}
+            component={()=>(<Profile ensgId={ensgId} symbol={symbol} />)}
+          />
         </Switch>
       </Suspense>
     </BasePage>
   );
+  
+  /*
+  return (
+    <BasePage
+      title={
+        location.pathname.includes('associations')
+          ? `Diseases associated with ${symbol}`
+          : `${symbol} profile page`
+      }
+      description={
+        location.pathname.includes('associations')
+          ? `Ranked list of diseases and phenotypes associated with ${symbol}`
+          : `Annotation information for ${symbol}`
+      }
+      location={location}
+    >
+      
+      <ScrollToTop />
+      <Header
+        loading={loading}
+        ensgId={ensgId}
+        uniprotIds={uniprotIds}
+        symbol={symbol}
+        name={approvedName}
+        crisprId={crisprId}
+      />
+
+      <RoutingTabs value={
+          location.pathname.includes('associations')
+            ? `${match.url}/associations`
+            : location.pathname
+        }>
+        <RoutingTab
+          label="Associated diseases"
+          path="/target/:ensgId/associations"
+          value={`${match.url}/associations`}
+          component={() => <ClassicAssociations ensgId={ensgId} symbol={symbol} /> }
+        />
+        <RoutingTab
+          label="Profile"
+          path="/target/:ensgId "
+          component={() => <Profile ensgId={ensgId} symbol={symbol} /> }
+        />
+      </RoutingTabs>
+    </BasePage>
+  );
+        */
 }
 
 export default TargetPage;

--- a/apps/platform/src/pages/TargetPage/TargetPage.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetPage.jsx
@@ -11,7 +11,6 @@ import { getUniprotIds } from '../../utils/global';
 import LoadingBackdrop from '../../components/LoadingBackdrop';
 import TARGET_PAGE_QUERY from './TargetPage.gql';
 
-// import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
 
 const Profile = lazy(() => import('../TargetPage/Profile'));
 const ClassicAssociations = lazy(() =>
@@ -92,53 +91,6 @@ function TargetPage({ location, match }) {
       </Suspense>
     </BasePage>
   );
-  
-  /*
-  return (
-    <BasePage
-      title={
-        location.pathname.includes('associations')
-          ? `Diseases associated with ${symbol}`
-          : `${symbol} profile page`
-      }
-      description={
-        location.pathname.includes('associations')
-          ? `Ranked list of diseases and phenotypes associated with ${symbol}`
-          : `Annotation information for ${symbol}`
-      }
-      location={location}
-    >
-      
-      <ScrollToTop />
-      <Header
-        loading={loading}
-        ensgId={ensgId}
-        uniprotIds={uniprotIds}
-        symbol={symbol}
-        name={approvedName}
-        crisprId={crisprId}
-      />
-
-      <RoutingTabs value={
-          location.pathname.includes('associations')
-            ? `${match.url}/associations`
-            : location.pathname
-        }>
-        <RoutingTab
-          label="Associated diseases"
-          path="/target/:ensgId/associations"
-          value={`${match.url}/associations`}
-          component={() => <ClassicAssociations ensgId={ensgId} symbol={symbol} /> }
-        />
-        <RoutingTab
-          label="Profile"
-          path="/target/:ensgId "
-          component={() => <Profile ensgId={ensgId} symbol={symbol} /> }
-        />
-      </RoutingTabs>
-    </BasePage>
-  );
-        */
 }
 
 export default TargetPage;

--- a/apps/platform/src/pages/TargetPage/TargetPage.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetPage.jsx
@@ -11,7 +11,7 @@ import { getUniprotIds } from '../../utils/global';
 import LoadingBackdrop from '../../components/LoadingBackdrop';
 import TARGET_PAGE_QUERY from './TargetPage.gql';
 
-import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
+// import { RoutingTab, RoutingTabs } from '../../components/RoutingTabs';
 
 const Profile = lazy(() => import('../TargetPage/Profile'));
 const ClassicAssociations = lazy(() =>


### PR DESCRIPTION
This PR addresses a bug in the target associations page filters https://github.com/opentargets/issues/issues/1633
It appears the filters on the target associations are not being reset when a searching for a new target, whilst they reset as expected on the disease associations.
Fully refactoring of the code to match the disease page breaks the sub-tabs (heatmap / bubbles / graph). Refactoring a small detail appears to work.