### PR TITLE
Add functional consequence to Orphanet and Gene2Phenotype evidence

### DIFF
--- a/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
@@ -57,6 +57,8 @@ const columns = [
       : 
         (naLabel)
     ),
+    filterValue: ({ variantFunctionalConsequence }) =>
+      sentenceCase(variantFunctionalConsequence.label),
   },
   {
     id: 'allelicRequirements',

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
@@ -41,6 +41,24 @@ const columns = [
     },
   },
   {
+    id: 'variantFunctionalConsequence',
+    label: 'Functional consequence',
+    renderCell: ({ variantFunctionalConsequence }) => (
+      variantFunctionalConsequence ? (
+        <Link
+          external
+          to={`http://www.sequenceontology.org/browser/current_svn/term/${
+            variantFunctionalConsequence.id
+          }`}
+        >
+          {sentenceCase(variantFunctionalConsequence.label)}
+        </Link>
+      ) 
+      : 
+        (naLabel)
+    ),
+  },
+  {
     id: 'allelicRequirements',
     label: 'Allelic requirement',
     renderCell: ({ allelicRequirements }) =>

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
@@ -19,6 +19,10 @@ query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!) {
         target {
           approvedSymbol
         }
+        variantFunctionalConsequence{
+          id
+          label
+        }
       }
     }
   }

--- a/apps/platform/src/sections/evidence/Orphanet/Body.jsx
+++ b/apps/platform/src/sections/evidence/Orphanet/Body.jsx
@@ -53,7 +53,6 @@ const columns = [
     filterValue: ({ targetFromSource, targetFromSourceId }) =>
       `${targetFromSource} ${targetFromSourceId}`,
   },
-
   {
     id: 'variantFunctionalConsequence',
     label: 'Functional consequence',
@@ -71,8 +70,9 @@ const columns = [
       : 
         (naLabel)
     ),
+    filterValue: ({ variantFunctionalConsequence }) =>
+      sentenceCase(variantFunctionalConsequence.label),
   },
-
   {
     id: 'alleleOrigins',
     label: 'Allele origin',

--- a/apps/platform/src/sections/evidence/Orphanet/Body.jsx
+++ b/apps/platform/src/sections/evidence/Orphanet/Body.jsx
@@ -132,6 +132,14 @@ const exportColumns = [
     exportValue: row => row.alleleOrigins.join('; '),
   },
   {
+    label: 'Functional consequence',
+    exportValue: row => sentenceCase(row.variantFunctionalConsequence.label),
+  },
+  {
+    label: 'Functional consequence ID',
+    exportValue: row => row.variantFunctionalConsequence.id,
+  },
+  {
     label: 'Confidence',
     exportValue: row => row.confidence,
   },

--- a/apps/platform/src/sections/evidence/Orphanet/Body.jsx
+++ b/apps/platform/src/sections/evidence/Orphanet/Body.jsx
@@ -7,11 +7,12 @@ import Tooltip from '../../../components/Tooltip';
 import SectionItem from '../../../components/Section/SectionItem';
 import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import { DataTable } from '../../../components/Table';
-import { defaultRowsPerPageOptions } from '../../../constants';
+import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import { epmcUrl } from '../../../utils/urls';
 import Summary from './Summary';
 import Description from './Description';
 import { dataTypesMap } from '../../../dataTypes';
+import { sentenceCase } from '../../../utils/global';
 
 import ORPHANET_QUERY from './OrphanetQuery.gql';
 
@@ -52,6 +53,26 @@ const columns = [
     filterValue: ({ targetFromSource, targetFromSourceId }) =>
       `${targetFromSource} ${targetFromSourceId}`,
   },
+
+  {
+    id: 'variantFunctionalConsequence',
+    label: 'Functional consequence',
+    renderCell: ({ variantFunctionalConsequence }) => (
+      variantFunctionalConsequence ? (
+        <Link
+          external
+          to={`http://www.sequenceontology.org/browser/current_svn/term/${
+            variantFunctionalConsequence.id
+          }`}
+        >
+          {sentenceCase(variantFunctionalConsequence.label)}
+        </Link>
+      ) 
+      : 
+        (naLabel)
+    ),
+  },
+
   {
     id: 'alleleOrigins',
     label: 'Allele origin',

--- a/apps/platform/src/sections/evidence/Orphanet/OrphanetQuery.gql
+++ b/apps/platform/src/sections/evidence/Orphanet/OrphanetQuery.gql
@@ -25,6 +25,10 @@ query OrphanetQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
         alleleOrigins
         confidence
         literature
+        variantFunctionalConsequence{
+          id
+          label
+        }
       }
     }
   }


### PR DESCRIPTION
Add a "Functional consequence" column to Orphanet and Gene2Phenotype evidence widgets as per [this issue](https://github.com/opentargets/issues/issues/2640) 
Note: flagging as draft until G2P data is pending.