### PR TITLE
Fix emtpy literature column in Gene2Phenotype evidence widget

### DIFF
--- a/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { List, ListItem, Typography } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
 
-import { DataTable, TableDrawer } from '../../../components/Table';
+import { DataTable } from '../../../components/Table';
 import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
 import { epmcUrl } from '../../../utils/urls';
@@ -11,6 +11,7 @@ import Link from '../../../components/Link';
 import SectionItem from '../../../components/Section/SectionItem';
 import { sentenceCase } from '../../../utils/global';
 import Tooltip from '../../../components/Tooltip';
+import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import OPEN_TARGETS_GENETICS_QUERY from './sectionQuery.gql';
 
 const g2pUrl = (studyId, symbol) =>
@@ -97,22 +98,14 @@ const columns = [
   },
   {
     id: 'literature',
+    label: 'Literature',
     renderCell: ({ literature }) => {
-      const literatureList =
-        literature?.reduce((acc, id) => {
-          if (id === 'NA') return acc;
-
-          return [
-            ...acc,
-            {
-              name: id,
-              url: epmcUrl(id),
-              group: 'literature',
-            },
-          ];
-        }, []) || [];
-
-      return <TableDrawer entries={literatureList} />;
+      const entries = literature
+        ? literature.map(id => {
+            return { name: id, url: epmcUrl(id), group: 'literature' };
+          })
+        : [];
+      return <PublicationsDrawer entries={entries} />;
     },
   },
 ];

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
@@ -134,7 +134,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
         <DataTable
           columns={columns}
           dataDownloader
-          dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
+          dataDownloaderFileStem={`${ensgId}-${efoId}-gene2phenotype`}
           rows={data.disease.evidences.rows}
           pageSize={10}
           rowsPerPageOptions={defaultRowsPerPageOptions}

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
@@ -19,6 +19,7 @@ query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!) {
         target {
           approvedSymbol
         }
+        literature
       }
     }
   }


### PR DESCRIPTION
Fix the empty literature column (showing as N/A) in the G2P widget, due to incorrect fields in query. Also refactor to use correct PublicationDrawer component. 
See [issue 2781](https://github.com/opentargets/issues/issues/2781)