### PR TITLE
Update Legend component for Molecular Interactions widget

### DIFF
--- a/apps/platform/src/components/Legend.jsx
+++ b/apps/platform/src/components/Legend.jsx
@@ -4,7 +4,12 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faQuestionCircle } from '@fortawesome/free-solid-svg-icons';
 import { colorRange } from '../constants';
 
-function Legend() {
+function Legend({ url, urlLabel, hideLink }) {
+  const linkUrl = url
+    ? url
+    : 'https://platform-docs.opentargets.org/associations#association-scores';
+  const linkLabel = urlLabel ? urlLabel : 'Score';
+
   return (
     <div>
       <span
@@ -36,9 +41,11 @@ function Legend() {
           1
         </div>
       </div>
-      <Link href="https://platform-docs.opentargets.org/associations#association-scores">
-        <FontAwesomeIcon icon={faQuestionCircle} size="xs" /> Score
-      </Link>
+      {hideLink ? null : (
+        <Link href={linkUrl}>
+          <FontAwesomeIcon icon={faQuestionCircle} size="xs" /> {linkLabel}
+        </Link>
+      )}
     </div>
   );
 }

--- a/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
+++ b/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
@@ -3,7 +3,7 @@ import client from '../../../client';
 import { withTheme, makeStyles } from '@material-ui/core';
 
 import DataTable from '../../../components/Table/DataTable';
-// import Legend from '../../../components/Legend';
+import Legend from '../../../components/Legend';
 import { colorRange } from '../../../constants';
 
 import Grid from '@material-ui/core/Grid';
@@ -343,7 +343,7 @@ function StringTab({ ensgId, symbol }) {
           rowsPerPageOptions={[10, 25, 50, 100]}
           loading={loading}
         />
-        {/* <Legend /> */}
+        <Legend url={"https://string-db.org/cgi/info"}   />
       </Grid>
     </Grid>
   );

--- a/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
+++ b/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
@@ -343,7 +343,7 @@ function StringTab({ ensgId, symbol }) {
           rowsPerPageOptions={[10, 25, 50, 100]}
           loading={loading}
         />
-        <Legend />
+        {/* <Legend /> */}
       </Grid>
     </Grid>
   );

--- a/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
+++ b/apps/platform/src/sections/target/MolecularInteractions/StringTab.jsx
@@ -3,7 +3,7 @@ import client from '../../../client';
 import { withTheme, makeStyles } from '@material-ui/core';
 
 import DataTable from '../../../components/Table/DataTable';
-import Legend from '../../../components/Legend';
+// import Legend from '../../../components/Legend';
 import { colorRange } from '../../../constants';
 
 import Grid from '@material-ui/core/Grid';


### PR DESCRIPTION
Update the Legend component to support config props for the info link; fix incorrect Legend link in the String table (Molecular interactions widget). As per [issue 2747](https://github.com/opentargets/issues/issues/2747).