### PR TITLE
Fix breaking `ColocL2GTable` when no data is available

### DIFF
--- a/apps/genetics/src/sections/studyLocus/ColocL2GTable/ColocL2GTable.jsx
+++ b/apps/genetics/src/sections/studyLocus/ColocL2GTable/ColocL2GTable.jsx
@@ -125,7 +125,11 @@ const ColocL2GTable = ({ variantId, studyId }) => {
     }
   );
 
-  if (queryResult && queryResult.studyLocus2GeneTable.rows) {
+  if (
+    queryResult &&
+    queryResult.studyLocus2GeneTable.rows &&
+    queryResult.studyLocus2GeneTable.rows.length > 0
+  ) {
     tableData = getData(queryResult.studyLocus2GeneTable.rows);
   }
 


### PR DESCRIPTION
The `getData()` function will return `false` if length of provided array is 0, which in this case will be used to overwrite the empty array that is used as a default value for `tableData`.

See the following example: https://genetics.opentargets.org/study-locus/GCST009337/18_29921527_G_A