### PR TITLE
Change finngen link from r5 to r6 in StudyPage Header

### DIFF
--- a/apps/genetics/src/pages/StudyPage/Header.jsx
+++ b/apps/genetics/src/pages/StudyPage/Header.jsx
@@ -44,7 +44,7 @@ const StudyHeader = ({ loading, data }) => {
           {studyId && studyId.startsWith('FINNGEN') ? (
             <ExternalLink
               title="FinnGen"
-              url={`https://r5.finngen.fi/pheno/${studyId.slice(11)}`}
+              url={`https://r6.finngen.fi/pheno/${studyId.slice(11)}`}
               id={studyId.slice(11)}
             />
           ) : null}


### PR DESCRIPTION
The link in the Header of the StudyPage still referred to the R5 version of the finngen data. See the link in the bottom of the screen for https://genetics.opentargets.org/study/FINNGEN_R6_I9_HYPERTENSION :
![image](https://user-images.githubusercontent.com/62542407/200522706-7f6ef596-ccab-4c3f-b63e-b9d58d4e92b1.png)



I changed this link to point to the R6 version at https://r6.finngen.fi/pheno/