### PR TITLE
Fix display of forestplot in firefox browser

### DIFF
--- a/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
+++ b/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
@@ -169,7 +169,7 @@ const ForestPlot = ({
       .style('position', 'sticky')
       .style('flex-shrink', 0)
       .style('flex-grow', 0)
-      .style('top', plot_height - 2 * cfg.rowHeight)
+      .style('top', `${plot_height -2 * cfg.rowHeight}px`)
       .style('background-color', 'white');
 
     // clip trait name text (row width)

--- a/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
+++ b/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
@@ -375,7 +375,7 @@ const ForestPlot = ({
       .attr('fill', cfg.treeColor)
       .attr('text-anchor', 'middle')
       .attr('x', cfg.plotW / 2)
-      .style('font-size', 15)
+      .style('font-size', '15px')
       .style('font-family', '"Inter", sans-serif');
 
     // axis color

--- a/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
+++ b/apps/genetics/src/sections/variant/PheWASSection/ForestPlot.jsx
@@ -139,7 +139,7 @@ const ForestPlot = ({
       .attr('width', cfg.svgW)
       .attr('height', traits.length * cfg.rowHeight + 2 * cfg.rowHeight)
       .style('position', 'absolute')
-      .style('top', cfg.top_axis)
+      .style('top', `${cfg.top_axis}px`)
       .append('g');
 
     // set top row svg size and sticky


### PR DESCRIPTION
In Firefox browser there are a few issues with the forestplot:

![image](https://user-images.githubusercontent.com/62542407/200582093-b5b391ba-1cf3-4de7-ab7d-52aa4a715de0.png)

- bottom axis (bottomRow) of the forestplot is not displayed correctly
- svg is displayed at the wrong point as its 'top' style is not taken into account
- font size of axis title was not taken into account

All these issues were caused by the fact that chrome correctly implies 'px' after style statements where needed, but firefox does not. So I added px in the styles of the points aforementioned.