### PR TITLE
Update components for body with count POC

### DIFF
--- a/apps/platform/src/sections/evidence/CRISPR/Body.jsx
+++ b/apps/platform/src/sections/evidence/CRISPR/Body.jsx
@@ -53,12 +53,28 @@ const columns = [
   },
 ];
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.crisprSummary
+  );
+  const count = summaryData.crisprSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(CRISPR_QUERY, {
@@ -89,5 +105,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/CRISPR/CrisprQuery.gql
+++ b/apps/platform/src/sections/evidence/CRISPR/CrisprQuery.gql
@@ -1,10 +1,11 @@
-query CrisprQuery($ensemblId: String!, $efoId: String!) {
+query CrisprQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["crispr"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/CRISPR/index.js
+++ b/apps/platform/src/sections/evidence/CRISPR/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/CancerBiomarkers/Body.jsx
+++ b/apps/platform/src/sections/evidence/CancerBiomarkers/Body.jsx
@@ -11,6 +11,7 @@ import { defaultRowsPerPageOptions } from '../../../constants';
 import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import { epmcUrl } from '../../../utils/urls';
 import Description from './Description';
+import Summary from './Summary';
 import BiomarkersDrawer from './BiomarkersDrawer';
 
 import CANCER_BIOMARKERS_EVIDENCE_QUERY from './CancerBiomarkersEvidence.gql';
@@ -105,13 +106,28 @@ const columns = [
   },
 ];
 
-function Body(props) {
-  const { definition, id, label } = props;
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.CancerBiomarkersEvidenceFragment
+  );
+  const count = summaryData.cancerBiomarkersSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(CANCER_BIOMARKERS_EVIDENCE_QUERY, {
@@ -143,5 +159,3 @@ function Body(props) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/CancerBiomarkers/CancerBiomarkersEvidence.gql
+++ b/apps/platform/src/sections/evidence/CancerBiomarkers/CancerBiomarkersEvidence.gql
@@ -1,10 +1,11 @@
-query CancerBiomarkersQuery($ensemblId: String!, $efoId: String!) {
+query CancerBiomarkersQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["cancer_biomarkers"]
+      size: $size
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/CancerBiomarkers/index.js
+++ b/apps/platform/src/sections/evidence/CancerBiomarkers/index.js
@@ -16,4 +16,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/CancerGeneCensus/Body.jsx
+++ b/apps/platform/src/sections/evidence/CancerGeneCensus/Body.jsx
@@ -129,17 +129,29 @@ const useStyles = makeStyles({
   roleInCancerTitle: { marginRight: '.5rem' },
 });
 
-function Body({ definition, id, label }) {
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.CancerGeneCensusSummary
+  );
+  const count = summaryData.cancerGeneCensusSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
   const classes = useStyles();
-  const { ensgId: ensemblId, efoId } = id;
-  // const { data: summaryData } = usePlatformApi(
-  //   Summary.fragments.CancerGeneCensusSummary
-  // );
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
-    // size: summaryData.cancerGeneCensusSummary.count,
+    size: count,
   };
 
   const request = useQuery(CANCER_GENE_CENSUS_QUERY, {
@@ -195,5 +207,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/CancerGeneCensus/index.js
+++ b/apps/platform/src/sections/evidence/CancerGeneCensus/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/CancerGeneCensus/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/CancerGeneCensus/sectionQuery.gql
@@ -1,10 +1,11 @@
-query CancerGeneCensusQuery($ensemblId: String!, $efoId: String!) {
+query CancerGeneCensusQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["cancer_gene_census"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/Chembl/Body.jsx
+++ b/apps/platform/src/sections/evidence/Chembl/Body.jsx
@@ -213,10 +213,29 @@ function getColumns(classes) {
   ];
 }
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.ChemblSummaryFragment
+  );
+  const count = summaryData.chemblSummary.count;
 
-  const variables = { ensemblId, efoId };
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(CHEMBL_QUERY, {
     variables,
@@ -252,5 +271,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Chembl/ChemblQuery.gql
+++ b/apps/platform/src/sections/evidence/Chembl/ChemblQuery.gql
@@ -1,10 +1,11 @@
-query ChemblQuery($ensemblId: String!, $efoId: String!) {
+query ChemblQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["chembl"]
+      size: $size
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/Chembl/index.js
+++ b/apps/platform/src/sections/evidence/Chembl/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/ClinGen/Body.jsx
+++ b/apps/platform/src/sections/evidence/ClinGen/Body.jsx
@@ -96,13 +96,28 @@ const columns = [
   },
 ];
 
-function Body(props) {
-  const { definition, id, label } = props;
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.ClinGenSummaryFragment
+  );
+  const count = summaryData.clingenSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(CLINGEN_QUERY, {
@@ -134,5 +149,3 @@ function Body(props) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/ClinGen/ClingenQuery.gql
+++ b/apps/platform/src/sections/evidence/ClinGen/ClingenQuery.gql
@@ -1,10 +1,11 @@
-query ClingenQuery($ensemblId: String!, $efoId: String!) {
+query ClingenQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["clingen"]
+      size: $size
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/ClinGen/index.js
+++ b/apps/platform/src/sections/evidence/ClinGen/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/EVA/index.js
+++ b/apps/platform/src/sections/evidence/EVA/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/EVASomatic/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVASomatic/Body.jsx
@@ -223,13 +223,26 @@ const useStyles = makeStyles({
   roleInCancerTitle: { marginRight: '.5rem' },
 });
 
-function Body({ definition, id, label }) {
-  const classes = useStyles();
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.evaSomaticSummary
+  );
+  const count = summaryData.evaSomaticSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
 
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const classes = useStyles();
+  const { ensgId, efoId } = id;
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(EVA_SOMATIC_QUERY, {
@@ -281,5 +294,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/EVASomatic/EvaSomaticQuery.gql
+++ b/apps/platform/src/sections/evidence/EVASomatic/EvaSomaticQuery.gql
@@ -1,10 +1,11 @@
-query EvaSomaticQuery($ensemblId: String!, $efoId: String!) {
+query EvaSomaticQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["eva_somatic"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/EVASomatic/index.js
+++ b/apps/platform/src/sections/evidence/EVASomatic/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/EuropePmc/index.js
+++ b/apps/platform/src/sections/evidence/EuropePmc/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/ExpressionAtlas/Body.jsx
+++ b/apps/platform/src/sections/evidence/ExpressionAtlas/Body.jsx
@@ -114,12 +114,25 @@ const columns = [
   },
 ];
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.expressionAtlasSummary
+  );
+  const count = summaryData.expressionAtlasSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
 
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(EXPRESSION_ATLAS_QUERY, {
@@ -152,5 +165,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/ExpressionAtlas/ExpressionAtlasQuery.gql
+++ b/apps/platform/src/sections/evidence/ExpressionAtlas/ExpressionAtlasQuery.gql
@@ -1,10 +1,11 @@
-query ExpressionAtlasQuery($ensemblId: String!, $efoId: String!) {
+query ExpressionAtlasQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["expression_atlas"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/ExpressionAtlas/index.js
+++ b/apps/platform/src/sections/evidence/ExpressionAtlas/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/Body.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { List, ListItem, Typography } from '@material-ui/core';
 import { useQuery } from '@apollo/client';
-
+import usePlatformApi from '../../../hooks/usePlatformApi';
 import { DataTable, TableDrawer } from '../../../components/Table';
 import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 import Description from './Description';
@@ -12,6 +12,7 @@ import SectionItem from '../../../components/Section/SectionItem';
 import { sentenceCase } from '../../../utils/global';
 import Tooltip from '../../../components/Tooltip';
 import OPEN_TARGETS_GENETICS_QUERY from './sectionQuery.gql';
+import Summary from './Summary';
 
 const g2pUrl = (studyId, symbol) =>
   `https://www.ebi.ac.uk/gene2phenotype/search?panel=${studyId}&search_term=${symbol}`;
@@ -117,8 +118,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.Gene2PhenotypeSummaryFragment
+  );
+  const count = summaryData.gene2Phenotype.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(OPEN_TARGETS_GENETICS_QUERY, {
     variables,
@@ -129,7 +148,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.genetic_association}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}
@@ -146,5 +165,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/index.js
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Gene2Phenotype/sectionQuery.gql
@@ -1,10 +1,11 @@
-query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!) {
+query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["gene2phenotype"]
+      size: $size
     ) {
       rows {
         id

--- a/apps/platform/src/sections/evidence/GeneBurden/Body.jsx
+++ b/apps/platform/src/sections/evidence/GeneBurden/Body.jsx
@@ -301,5 +301,3 @@ export function BodyCore({ definition, id, label, count }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/GeneBurden/Body.jsx
+++ b/apps/platform/src/sections/evidence/GeneBurden/Body.jsx
@@ -12,6 +12,7 @@ import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import { epmcUrl } from '../../../utils/urls';
 import Description from './Description';
 import ScientificNotation from '../../../components/ScientificNotation';
+import Summary from './Summary';
 
 import GENE_BURDEN_QUERY from './GeneBurdenQuery.gql';
 
@@ -247,13 +248,25 @@ const columns = [
   },
 ];
 
-function Body(props) {
-  const { definition, id, label } = props;
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.geneBurdenSummary
+  );
+  const count = summaryData.geneBurdenSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
 
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(GENE_BURDEN_QUERY, {
@@ -277,7 +290,7 @@ function Body(props) {
             order="asc"
             sortBy="pValue"
             dataDownloader
-            dataDownloaderFileStem={`geneburden-${ensemblId}-${efoId}`}
+            dataDownloaderFileStem={`geneburden-${ensgId}-${efoId}`}
             showGlobalFilter
             rowsPerPageOptions={defaultRowsPerPageOptions}
             query={GENE_BURDEN_QUERY.loc.source.body}

--- a/apps/platform/src/sections/evidence/GeneBurden/GeneBurdenQuery.gql
+++ b/apps/platform/src/sections/evidence/GeneBurden/GeneBurdenQuery.gql
@@ -1,10 +1,11 @@
-query GeneBurdenQuery($ensemblId: String!, $efoId: String!) {
+query GeneBurdenQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["gene_burden"]
+      size: $size
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/GeneBurden/index.js
+++ b/apps/platform/src/sections/evidence/GeneBurden/index.js
@@ -12,4 +12,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/GenomicsEngland/Body.jsx
+++ b/apps/platform/src/sections/evidence/GenomicsEngland/Body.jsx
@@ -184,8 +184,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.GenomicsEnglandSummaryFragment
+  );
+  const count = summaryData.genomicsEngland.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(GENOMICS_ENGLAND_QUERY, {
     variables,
@@ -196,7 +214,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.genetic_association}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}
@@ -215,5 +233,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/GenomicsEngland/index.js
+++ b/apps/platform/src/sections/evidence/GenomicsEngland/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/GenomicsEngland/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/GenomicsEngland/sectionQuery.gql
@@ -1,10 +1,11 @@
-query GenomicsEnglandQuery($ensemblId: String!, $efoId: String!) {
+query GenomicsEnglandQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["genomics_england"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/Impc/Body.jsx
+++ b/apps/platform/src/sections/evidence/Impc/Body.jsx
@@ -114,9 +114,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.IMCPSummaryFragment
+  );
+  const count = summaryData.impc.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
 
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
   const request = useQuery(INTOGEN_QUERY, {
     variables,
   });
@@ -126,7 +143,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.animal_model}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}
@@ -134,7 +151,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
           dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
           rows={data.disease.evidences.rows}
           pageSize={5}
-          rowsPerPageOptions={defaultRowsPerPageOptions}
+          rowsPerPageOptions={[5].concat(defaultRowsPerPageOptions)}  // custom page size of 5 is not included in defaultRowsPerPageOptions
           showGlobalFilter
           query={INTOGEN_QUERY.loc.source.body}
           variables={variables}
@@ -143,5 +160,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Impc/index.js
+++ b/apps/platform/src/sections/evidence/Impc/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Impc/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Impc/sectionQuery.gql
@@ -1,10 +1,11 @@
-query impcQuery($ensemblId: String!, $efoId: String!) {
+query impcQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["impc"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/IntOgen/Body.jsx
+++ b/apps/platform/src/sections/evidence/IntOgen/Body.jsx
@@ -165,15 +165,28 @@ const useStyles = makeStyles({
   roleInCancerTitle: { marginRight: '.5rem' },
 });
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const classes = useStyles();
-  // const {
-  //   data: {
-  //     intOgen: { count: size },
-  //   },
-  // } = usePlatformApi(Summary.fragments.IntOgenSummaryFragment);
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.IntOgenSummaryFragment
+  );
+  const count = summaryData.intOgen.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
 
-  const variables = { ensemblId: ensgId, efoId, size: 10 };
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const classes = useStyles();
+  
+  const { ensgId, efoId } = id;
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(INTOGEN_QUERY, {
     variables,
@@ -184,7 +197,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.somatic_mutation}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={({
         disease: {
           evidences: { rows },

--- a/apps/platform/src/sections/evidence/IntOgen/Body.jsx
+++ b/apps/platform/src/sections/evidence/IntOgen/Body.jsx
@@ -241,5 +241,3 @@ export function BodyCore({ definition, id, label, count }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/IntOgen/Body.jsx
+++ b/apps/platform/src/sections/evidence/IntOgen/Body.jsx
@@ -218,7 +218,7 @@ export function BodyCore({ definition, id, label, count }) {
           <>
             <Box className={classes.roleInCancerBox}>
               <Typography className={classes.roleInCancerTitle}>
-                <b>{symbol}</b> role in cancer:
+                <b>{label.symbol}</b> role in cancer:
               </Typography>
               <ChipList items={roleInCancerItems} />
             </Box>

--- a/apps/platform/src/sections/evidence/IntOgen/index.js
+++ b/apps/platform/src/sections/evidence/IntOgen/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
@@ -145,13 +145,28 @@ const exportColumns = [
   },
 ];
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.OtCrisprSummary
+  );
+  const count = summaryData.OtCrisprSummary.count;
 
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
   const request = useQuery(CRISPR_QUERY, {
     variables: {
-      ensemblId,
+      ensemblId: ensgId,
       efoId,
+      size: count,
     },
   });
   const classes = useStyles();
@@ -172,7 +187,7 @@ function Body({ definition, id, label }) {
             rows={rows}
             dataDownloader
             dataDownloaderColumns={exportColumns}
-            dataDownloaderFileStem={`${ensemblId}-${efoId}-otcrispr`}
+            dataDownloaderFileStem={`${ensgId}-${efoId}-otcrispr`}
             showGlobalFilter
             sortBy="resourceScore"
             fixed
@@ -185,5 +200,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/OTCRISPR/OTCrisprQuery.gql
+++ b/apps/platform/src/sections/evidence/OTCRISPR/OTCrisprQuery.gql
@@ -1,10 +1,11 @@
-query CrisprQuery($ensemblId: String!, $efoId: String!) {
+query CrisprQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["ot_crispr"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/OTCRISPR/index.js
+++ b/apps/platform/src/sections/evidence/OTCRISPR/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/OTEncore/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTEncore/Body.jsx
@@ -245,12 +245,29 @@ const exportColumns = [
   },
 ];
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.otEncoreSummary
+  );
+  const count = summaryData.otEncoreSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+
   const request = useQuery(ENCORE_QUERY, {
     variables: {
-      ensemblId,
+      ensemblId: ensgId,
       efoId,
+      size: count,
     },
   });
   const classes = useStyles();
@@ -271,7 +288,7 @@ function Body({ definition, id, label }) {
             rows={rows}
             dataDownloader
             dataDownloaderColumns={exportColumns}
-            dataDownloaderFileStem={`${ensemblId}-${efoId}-otencore`}
+            dataDownloaderFileStem={`${ensgId}-${efoId}-otencore`}
             showGlobalFilter
             sortBy="geneticInteractionPValue"
             order="asc"
@@ -285,5 +302,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/OTEncore/OTEncoreQuery.gql
+++ b/apps/platform/src/sections/evidence/OTEncore/OTEncoreQuery.gql
@@ -1,10 +1,11 @@
-query EncoreQuery($ensemblId: String!, $efoId: String!) {
+query EncoreQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["encore"]
+      size: $size
     ) {
       rows {
         target {

--- a/apps/platform/src/sections/evidence/OTEncore/index.js
+++ b/apps/platform/src/sections/evidence/OTEncore/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
@@ -198,8 +198,24 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.OpenTargetsGeneticsSummaryFragment
+  );
+  const count = summaryData.openTargetsGenetics.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = { ensemblId: ensgId, efoId, size: count };
 
   const request = useQuery(OPEN_TARGETS_GENETICS_QUERY, {
     variables,
@@ -210,7 +226,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.genetic_association}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}
@@ -229,5 +245,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/OTGenetics/index.js
+++ b/apps/platform/src/sections/evidence/OTGenetics/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/OTGenetics/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/OTGenetics/sectionQuery.gql
@@ -1,10 +1,11 @@
-query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!) {
+query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["ot_genetics_portal"]
+      size: $size
     ) {
       rows {
         id

--- a/apps/platform/src/sections/evidence/OTValidation/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTValidation/Body.jsx
@@ -273,8 +273,24 @@ const exportColumns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.otValidationSummary
+  );
+  const count = summaryData.otValidationSummary.count;
+
+  if (!count || count < 1) {
+    return null;
+  }
+
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = { ensemblId: ensgId, efoId, size: count };
   const request = useQuery(VALIDATION_QUERY, {
     variables,
   });
@@ -285,7 +301,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.ot_validation_lab}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={({ disease }) => {
         const { rows } = disease.evidences;
         const hypothesis = _.uniqBy(
@@ -339,7 +355,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
                   }
                   showHelpIcon
                 >
-                  OTVL biomarker assessment for {symbol}
+                  OTVL biomarker assessment for {label.symbol}
                 </Tooltip>
               </Typography>
 
@@ -403,5 +419,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/OTValidation/OTValidationQuery.gql
+++ b/apps/platform/src/sections/evidence/OTValidation/OTValidationQuery.gql
@@ -1,10 +1,11 @@
-query ValidationQuery($ensemblId: String!, $efoId: String!) {
+query ValidationQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["ot_crispr_validation"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/OTValidation/index.js
+++ b/apps/platform/src/sections/evidence/OTValidation/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Orphanet/Body.jsx
+++ b/apps/platform/src/sections/evidence/Orphanet/Body.jsx
@@ -120,12 +120,26 @@ const exportColumns = [
   },
 ];
 
-function Body({ definition, id, label }) {
-  const { ensgId: ensemblId, efoId } = id;
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.OrphanetSummaryFragment
+  );
+  const count = summaryData.orphanetSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(ORPHANET_QUERY, {
@@ -147,7 +161,7 @@ function Body({ definition, id, label }) {
             columns={columns}
             rows={rows}
             dataDownloader
-            dataDownloaderFileStem={`orphanet-${ensemblId}-${efoId}`}
+            dataDownloaderFileStem={`orphanet-${ensgId}-${efoId}`}
             dataDownloaderColumns={exportColumns}
             showGlobalFilter
             rowsPerPageOptions={defaultRowsPerPageOptions}
@@ -159,5 +173,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Orphanet/OrphanetQuery.gql
+++ b/apps/platform/src/sections/evidence/Orphanet/OrphanetQuery.gql
@@ -1,10 +1,11 @@
-query OrphanetQuery($ensemblId: String!, $efoId: String!) {
+query OrphanetQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["orphanet"]
+      size: $size
     ) {
       count
       rows {

--- a/apps/platform/src/sections/evidence/Orphanet/index.js
+++ b/apps/platform/src/sections/evidence/Orphanet/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Progeny/Body.jsx
+++ b/apps/platform/src/sections/evidence/Progeny/Body.jsx
@@ -68,8 +68,27 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.ProgenySummaryFragment
+  );
+  const count = summaryData.progeny.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(PROGENY_QUERY, {
     variables,
@@ -80,7 +99,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.affected_pathway}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}
@@ -99,5 +118,3 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Progeny/index.js
+++ b/apps/platform/src/sections/evidence/Progeny/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Progeny/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Progeny/sectionQuery.gql
@@ -1,10 +1,11 @@
-query ProgenyQuery($ensemblId: String!, $efoId: String!) {
+query ProgenyQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["progeny"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/Reactome/Body.jsx
+++ b/apps/platform/src/sections/evidence/Reactome/Body.jsx
@@ -152,12 +152,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id, label }) {
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.reactomeSummary
+  );
+  const count = summaryData.reactomeSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
   const { ensgId: ensemblId, efoId } = id;
 
   const variables = {
     ensemblId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(REACTOME_QUERY, {
@@ -191,5 +205,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/Reactome/index.js
+++ b/apps/platform/src/sections/evidence/Reactome/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/Reactome/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/Reactome/sectionQuery.gql
@@ -1,10 +1,11 @@
-query reactomeQuery($ensemblId: String!, $efoId: String!) {
+query reactomeQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["reactome"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/SlapEnrich/Body.jsx
+++ b/apps/platform/src/sections/evidence/SlapEnrich/Body.jsx
@@ -118,5 +118,3 @@ export function BodyCore({ definition, id, label, count }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/SlapEnrich/Body.jsx
+++ b/apps/platform/src/sections/evidence/SlapEnrich/Body.jsx
@@ -69,8 +69,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.SlapEnrichSummaryFragment
+  );
+  const count = summaryData.slapEnrich.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId, efoId } = id;
+  const variables = {
+    ensemblId: ensgId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(SLAPENRICH_QUERY, {
     variables,
@@ -81,7 +99,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.affected_pathway}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}

--- a/apps/platform/src/sections/evidence/SlapEnrich/index.js
+++ b/apps/platform/src/sections/evidence/SlapEnrich/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/SlapEnrich/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/SlapEnrich/sectionQuery.gql
@@ -1,10 +1,11 @@
-query SlapEnrichQuery($ensemblId: String!, $efoId: String!) {
+query SlapEnrichQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["slapenrich"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/SysBio/Body.jsx
+++ b/apps/platform/src/sections/evidence/SysBio/Body.jsx
@@ -59,8 +59,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
-  const variables = { ensemblId: ensgId, efoId };
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.SysBioSummaryFragment
+  );
+  const count = summaryData.sysBio.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
+  const { ensgId: ensemblId, efoId } = id;
+  const variables = {
+    ensemblId,
+    efoId,
+    size: count,
+  };
 
   const request = useQuery(SYSBIO_QUERY, {
     variables,
@@ -71,7 +89,7 @@ function Body({ definition, id: { ensgId, efoId }, label: { symbol, name } }) {
       definition={definition}
       chipText={dataTypesMap.affected_pathway}
       request={request}
-      renderDescription={() => <Description symbol={symbol} name={name} />}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={data => (
         <DataTable
           columns={columns}

--- a/apps/platform/src/sections/evidence/SysBio/Body.jsx
+++ b/apps/platform/src/sections/evidence/SysBio/Body.jsx
@@ -106,5 +106,3 @@ export function BodyCore({ definition, id, label, count }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/SysBio/index.js
+++ b/apps/platform/src/sections/evidence/SysBio/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/SysBio/sectionQuery.gql
+++ b/apps/platform/src/sections/evidence/SysBio/sectionQuery.gql
@@ -1,10 +1,11 @@
-query SysBioQuery($ensemblId: String!, $efoId: String!) {
+query SysBioQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["sysbio"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/UniProtLiterature/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtLiterature/Body.jsx
@@ -79,12 +79,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id, label }) {
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.UniprotLiteratureSummary
+  );
+  const count = summaryData.uniprotLiteratureSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
   const { ensgId: ensemblId, efoId } = id;
 
   const variables = {
     ensemblId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(UNIPROT_LITERATURE_QUERY, {
@@ -116,4 +130,3 @@ function Body({ definition, id, label }) {
   );
 }
 
-export default Body;

--- a/apps/platform/src/sections/evidence/UniProtLiterature/UniprotLiteratureQuery.gql
+++ b/apps/platform/src/sections/evidence/UniProtLiterature/UniprotLiteratureQuery.gql
@@ -1,10 +1,11 @@
-query UniprotLiteratureQuery($ensemblId: String!, $efoId: String!) {
+query UniprotLiteratureQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["uniprot_literature"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/UniProtLiterature/index.js
+++ b/apps/platform/src/sections/evidence/UniProtLiterature/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';

--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -89,12 +89,26 @@ const columns = [
   },
 ];
 
-function Body({ definition, id, label }) {
+export function Body({ definition, id, label }) {
+  const { data: summaryData } = usePlatformApi(
+    Summary.fragments.UniprotVariantsSummary
+  );
+  const count = summaryData.uniprotVariantsSummary.count;
+  
+  if(!count || count < 1) {
+    return null
+  }
+
+  return <BodyCore definition={definition} id={id} label={label} count={count} />
+}
+
+export function BodyCore({ definition, id, label, count }) {
   const { ensgId: ensemblId, efoId } = id;
 
   const variables = {
     ensemblId,
     efoId,
+    size: count,
   };
 
   const request = useQuery(UNIPROT_VARIANTS_QUERY, {
@@ -126,5 +140,3 @@ function Body({ definition, id, label }) {
     />
   );
 }
-
-export default Body;

--- a/apps/platform/src/sections/evidence/UniProtVariants/UniprotVariantsQuery.gql
+++ b/apps/platform/src/sections/evidence/UniProtVariants/UniprotVariantsQuery.gql
@@ -1,10 +1,11 @@
-query UniprotVariantsQuery($ensemblId: String!, $efoId: String!) {
+query UniprotVariantsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
   disease(efoId: $efoId) {
     id
     evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["uniprot_variants"]
+      size: $size
     ) {
       rows {
         disease {

--- a/apps/platform/src/sections/evidence/UniProtVariants/index.js
+++ b/apps/platform/src/sections/evidence/UniProtVariants/index.js
@@ -10,4 +10,4 @@ export const definition = {
 };
 
 export { default as Summary } from './Summary';
-export { default as Body } from './Body';
+export * from './Body';


### PR DESCRIPTION
This PR refactors all the evidence widgets to use a size/count prop and to work from both the evidence page and the new AOTF page. This approach was chosen after initial investigation (see below the original scope).

Initial scope of the PR:
> Update Clinvar and Uniprot Variants widgets to use two separate options for the body component:
>  - one that fetches the `count` from the Summary, to be used on **evidence page** (essentially works like current evidence widgets)
>  - one that takes a `count` **prop** to be used without a Summary widget/fragment (like in the new associations on the fly)
> 
> Note: the Clinvar widget uses the same server side approach as currently in production.
> I've explored a slightly different option for the server side pagination where we query a fix size and include the count in the response: https://github.com/opentargets/ot-ui-apps/blob/lf-query-size/apps/platform/src/sections/evidence/EVA/Body.jsx#L262
> This could also be implemented here...
