### PR TITLE
Remove domain from study and variant link on study locus page

### DIFF
--- a/apps/genetics/src/pages/StudyLocusPage/Header.jsx
+++ b/apps/genetics/src/pages/StudyLocusPage/Header.jsx
@@ -26,14 +26,14 @@ const StudyLocusHeader = ({ loading, data }) => {
           {studyId ? (
             <ExternalLink
               title="Study ID"
-              url={`https://genetics.opentargets.org/study/${studyId}`}
+              url={`/study/${studyId}`}
               id={studyId}
             />
           ) : null}
           {variantId ? (
             <ExternalLink
               title="Variant ID"
-              url={`https://genetics.opentargets.org/variant/${variantId}`}
+              url={`/variant/${variantId}`}
               id={variantId}
             />
           ) : null}


### PR DESCRIPTION
This PR makes the study and variant links in the study locus page header relative by removing the domain.