### PR TITLE
Associations heatmaps: add column label for download

### DIFF
--- a/apps/platform/src/pages/DiseasePage/ClassicAssociationsTable.jsx
+++ b/apps/platform/src/pages/DiseasePage/ClassicAssociationsTable.jsx
@@ -160,6 +160,7 @@ function getColumns(efoId, classes) {
             {dt.label} {dt.isPrivate ? <PartnerLockIcon /> : null}
           </>
         ),
+        exportLabel: `${dt.label} ${dt.isPrivate ? 'Private' : ''}`,
         classes: {
           headerCell: classes.headerCell,
           innerLabel: classes.innerLabel,

--- a/apps/platform/src/pages/TargetPage/ClassicAssociationsTable.jsx
+++ b/apps/platform/src/pages/TargetPage/ClassicAssociationsTable.jsx
@@ -147,6 +147,7 @@ function getColumns(ensemblId, classes) {
             {dt.label} {dt.isPrivate ? <PartnerLockIcon /> : null}
           </>
         ),
+        exportLabel: `${dt.label} ${dt.isPrivate ? 'Private' : ''}`,
         classes: {
           headerCell: classes.headerCell,
           innerLabel: classes.innerLabel,


### PR DESCRIPTION
Specify a datatypes' column label for download. This fixes issue [Associations heatmaps columns headers are incorrect in downloaded file](https://github.com/opentargets/issues/issues/2814)

For private PPP fields we also append `Private` at the end (essentially in place of the lock icon), e.g. `otarProjectsPrivate` - @buniello do let me know if we do not want this and I'll remove it