### PR TITLE
Remove helpdesk email from widget error fallback (lf-error-message)

### DIFF
--- a/apps/genetics/public/profiles/default.js
+++ b/apps/genetics/public/profiles/default.js
@@ -3,6 +3,7 @@ var configProfile = {
   /* general items */
 
   helpdeskEmail: 'helpdesk@opentargets.org',
+  communityUrl: 'https://community.opentargets.org',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
 

--- a/apps/genetics/public/profiles/default.js
+++ b/apps/genetics/public/profiles/default.js
@@ -4,6 +4,7 @@ var configProfile = {
 
   helpdeskEmail: 'helpdesk@opentargets.org',
   communityUrl: 'https://community.opentargets.org',
+  communityTicketUrl: 'https://community.opentargets.org/c/community-feedback/bug-reports/34',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
 

--- a/apps/genetics/public/profiles/profile-partners.js
+++ b/apps/genetics/public/profiles/profile-partners.js
@@ -3,6 +3,7 @@ var configProfile = {
   /* general items */
 
   helpdeskEmail: 'helpdesk@opentargets.org',
+  communityUrl: 'https://community.opentargets.org',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
 

--- a/apps/genetics/public/profiles/profile-partners.js
+++ b/apps/genetics/public/profiles/profile-partners.js
@@ -4,6 +4,7 @@ var configProfile = {
 
   helpdeskEmail: 'helpdesk@opentargets.org',
   communityUrl: 'https://community.opentargets.org',
+  communityTicketUrl: 'https://community.opentargets.org/c/community-feedback/bug-reports/34',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
 

--- a/apps/genetics/src/components/ErrorBoundary.jsx
+++ b/apps/genetics/src/components/ErrorBoundary.jsx
@@ -13,8 +13,8 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = `Something went wrong. Please contact Open Targets at ${
-        config.helpdeskEmail
+      message = `Something went wrong. Please see our Open Targets Community at ${
+        config.profile.communityUrl
       }`,
     } = this.props;
 

--- a/apps/genetics/src/components/ErrorBoundary.jsx
+++ b/apps/genetics/src/components/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Typography } from '@material-ui/core';
 import config from '../config';
+import Link from './Link';
 
 class ErrorBoundary extends Component {
   state = {
@@ -13,9 +14,16 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = `Something went wrong. Please see our Open Targets Community at ${
-        config.profile.communityUrl
-      }`,
+      // public platform error message
+      message = (
+        <div>
+          Something went wrong. Please{' '}
+          <Link to={config.profile.communityTicketUrl} external>
+            submit a bug report
+          </Link>{' '}
+          on the Open Targets Community ({config.profile.communityUrl})
+        </div>
+      ),
     } = this.props;
 
     return this.state.hasError ? (

--- a/apps/platform/public/profiles/default.js
+++ b/apps/platform/public/profiles/default.js
@@ -4,6 +4,7 @@ var configProfile = {
 
   helpdeskEmail: 'helpdesk@opentargets.org',
   communityUrl: 'https://community.opentargets.org',
+  communityTicketUrl: 'https://community.opentargets.org/c/community-feedback/bug-reports/34',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
   // homepage logo subtitle (tagline)

--- a/apps/platform/public/profiles/default.js
+++ b/apps/platform/public/profiles/default.js
@@ -3,6 +3,7 @@ var configProfile = {
   /* general items */
 
   helpdeskEmail: 'helpdesk@opentargets.org',
+  communityUrl: 'https://community.opentargets.org',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
   // homepage logo subtitle (tagline)

--- a/apps/platform/public/profiles/profile-partners.js
+++ b/apps/platform/public/profiles/profile-partners.js
@@ -4,6 +4,7 @@ var configProfile = {
 
   helpdeskEmail: 'partner-support@opentargets.org',
   communityUrl: 'https://community.opentargets.org',
+  communityTicketUrl: 'https://community.opentargets.org/c/community-feedback/bug-reports/34',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
   // homepage logo subtitle (tagline)

--- a/apps/platform/public/profiles/profile-partners.js
+++ b/apps/platform/public/profiles/profile-partners.js
@@ -3,6 +3,7 @@ var configProfile = {
   /* general items */
 
   helpdeskEmail: 'partner-support@opentargets.org',
+  communityUrl: 'https://community.opentargets.org',
   // config navbar main menu (hamburger)
   // mainMenuItems: [],
   // homepage logo subtitle (tagline)

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -14,14 +14,29 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = 
-        config.profile.isPartnerPreview ? 
-          // PPP error message
-          (<div>Something went wrong. Please contact Open Targets at <Link to={`mailto: ${config.profile.helpdeskEmail}`} external>{config.profile.helpdeskEmail}</Link>, or <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community.</div>)
-          :
-          // public platform error message
-          (<div>Something went wrong. Please <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community ({config.profile.communityUrl})</div>)
-      
+      message = config.profile.isPartnerPreview ? (
+        // PPP error message
+        <div>
+          Something went wrong. Please contact Open Targets at{' '}
+          <Link to={`mailto: ${config.profile.helpdeskEmail}`} external>
+            {config.profile.helpdeskEmail}
+          </Link>
+          , or{' '}
+          <Link to={config.profile.communityTicketUrl} external>
+            submit a bug report
+          </Link>{' '}
+          on the Open Targets Community.
+        </div>
+      ) : (
+        // public platform error message
+        <div>
+          Something went wrong. Please{' '}
+          <Link to={config.profile.communityTicketUrl} external>
+            submit a bug report
+          </Link>{' '}
+          on the Open Targets Community ({config.profile.communityUrl})
+        </div>
+      ),
     } = this.props;
 
     return this.state.hasError ? (

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import { Typography } from '@material-ui/core';
 import config from '../config';
 import Link from './Link';
+import usePermissions from '../hooks/usePermissions';
 
 class ErrorBoundary extends Component {
   state = {
@@ -13,8 +14,9 @@ class ErrorBoundary extends Component {
   }
 
   render() {
+    const { isPartnerPreview } = usePermissions();
     const {
-      message = config.profile.isPartnerPreview ? (
+      message = isPartnerPreview ? (
         // PPP error message
         <div>
           Something went wrong. Please contact Open Targets at{' '}

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -14,7 +14,14 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = <div>Something went wrong. Please <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community ({config.profile.communityUrl})</div>
+      message = 
+        config.profile.isPartnerPreview ? 
+          // PPP error message
+          (<div>Something went wrong. Please contact Open Targets at <Link to={`mailto: ${config.profile.helpdeskEmail}`} external>{config.profile.helpdeskEmail}</Link>, or <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community.</div>)
+          :
+          // public platform error message
+          (<div>Something went wrong. Please <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community ({config.profile.communityUrl})</div>)
+      
     } = this.props;
 
     return this.state.hasError ? (

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -23,11 +23,6 @@ class ErrorBoundary extends Component {
           <Link to={`mailto: ${config.profile.helpdeskEmail}`} external>
             {config.profile.helpdeskEmail}
           </Link>
-          , or{' '}
-          <Link to={config.profile.communityTicketUrl} external>
-            submit a bug report
-          </Link>{' '}
-          on the Open Targets Community.
         </div>
       ) : (
         // public platform error message

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { Typography } from '@material-ui/core';
 import config from '../config';
+import Link from './Link';
 
 class ErrorBoundary extends Component {
   state = {
@@ -13,9 +14,7 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = `Something went wrong. Please see our Open Targets Community at ${
-        config.profile.communityUrl
-      }`,
+      message = <div>Something went wrong. Please <Link to={config.profile.communityTicketUrl} external>submit a bug report</Link> on the Open Targets Community ({config.profile.communityUrl})</div>
     } = this.props;
 
     return this.state.hasError ? (

--- a/apps/platform/src/components/ErrorBoundary.jsx
+++ b/apps/platform/src/components/ErrorBoundary.jsx
@@ -13,8 +13,8 @@ class ErrorBoundary extends Component {
 
   render() {
     const {
-      message = `Something went wrong. Please contact Open Targets at ${
-        config.profile.helpdeskEmail
+      message = `Something went wrong. Please see our Open Targets Community at ${
+        config.profile.communityUrl
       }`,
     } = this.props;
 


### PR DESCRIPTION
Short PR to update the error message seen when a widget fail in both platform and genetics, as per issue https://github.com/opentargets/issues/issues/2823
Public platform handles also the version for PPP.
