### PR TITLE
Update constraint metrics label

### DIFF
--- a/apps/platform/src/sections/target/GeneticConstraint/GeneticConstraintTable.jsx
+++ b/apps/platform/src/sections/target/GeneticConstraint/GeneticConstraintTable.jsx
@@ -90,7 +90,7 @@ function getColumns(ensemblId, symbol) {
       renderCell: ({ score, oe, oeLower, oeUpper, upperBin6 }) => {
         return (
           <>
-            <div>Z = {score}</div>
+            <div>{upperBin6===null ? 'Z' : 'pLI'} = {score}</div>
             <div>
               o/e = {oe} ({oeLower} - {oeUpper})
             </div>


### PR DESCRIPTION
This PR addresses issue https://github.com/opentargets/issues/issues/2817. It updates the label in the Genetic Constraint widget (target profile page) based on the type of category:
so for the "pLoF" row, the last column reads "pLI=..." instead of "Z=..." like for the other rows.