### PR TITLE
[Platform]: PPP display correct app name on nav

### DIFF
--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -60,7 +60,8 @@
     </script>
 
     <!-- - Deployment Context -->
-    <script type="text/javascript" src="/profiles/default.js"></script>
+    <!-- <script type="text/javascript" src="/profiles/default.js"></script> -->
+    <script type="text/javascript" src="/profiles/profile-partners.js"></script>
     <script type="text/javascript" src="/config.js"></script>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -60,8 +60,7 @@
     </script>
 
     <!-- - Deployment Context -->
-    <!-- <script type="text/javascript" src="/profiles/default.js"></script> -->
-    <script type="text/javascript" src="/profiles/profile-partners.js"></script>
+    <script type="text/javascript" src="/profiles/default.js"></script>
     <script type="text/javascript" src="/config.js"></script>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/apps/platform/src/components/OpenTargetsTitle.jsx
+++ b/apps/platform/src/components/OpenTargetsTitle.jsx
@@ -3,8 +3,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core/styles';
 import classNames from 'classnames';
 
-import config from '../config';
-import PartnerLockIcon from './PartnerLockIcon';
+import usePermissions from '../hooks/usePermissions';
 
 const styles = () => ({
   root: {
@@ -22,16 +21,12 @@ const styles = () => ({
 
 const OpenTargetsTitle = ({ classes, className, name }) => {
   const titleClasses = classNames(classes.root, className);
+  const { isPartnerPreview } = usePermissions();
+  const displayedAppName = isPartnerPreview ? 'Partner Preview Platform' : name;
   return (
     <Typography className={titleClasses} variant="h6" color="inherit">
       <span className={classes.fat}>Open Targets </span>
-      <span className={classes.thin}>{name}</span>
-      {config.isPartnerPreview ? (
-        <>
-          <span className={classes.thin}> - Partner Preview </span>
-          <PartnerLockIcon />
-        </>
-      ) : null}
+      <span className={classes.thin}>{displayedAppName}</span>
     </Typography>
   );
 };

--- a/apps/platform/src/pages/DownloadsPage/DownloadsPage.jsx
+++ b/apps/platform/src/pages/DownloadsPage/DownloadsPage.jsx
@@ -90,7 +90,7 @@ const DATA_VERSION_QUERY = gql`
 function getVersion(data) {
   if (!data) return null;
   const { month, year } = data.meta.dataVersion;
-  return `${year}.${month < 10 ? '0' : ''}${month}`;
+  return `${year}.${month}`;
 }
 
 function DownloadsPage() {
@@ -106,10 +106,7 @@ function DownloadsPage() {
       .then(res => res.text())
       .then(lines => {
         if (isCurrent) {
-          const nodes = lines
-            .trim()
-            .split('\n')
-            .map(JSON.parse);
+          const nodes = lines.trim().split('\n').map(JSON.parse);
           setDownloadsData(nodes);
         }
       });


### PR DESCRIPTION
# [Platform]: PPP display correct app name on nav

## Description

In PPP the application name in the navbar should be: **Open Targets** Partner Preview Platform

**Issue:** https://github.com/opentargets/issues/issues/2889
**Deploy preview:** https://deploy-preview-100--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Open the application with PPP profile and navigate for different pages

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
