### PR TITLE
[Platform]: Data download table format multiplier

### DIFF
--- a/apps/platform/src/pages/DownloadsPage/DownloadsPage.jsx
+++ b/apps/platform/src/pages/DownloadsPage/DownloadsPage.jsx
@@ -55,9 +55,9 @@ function getColumns(date) {
       id: 'formats',
       label: 'Format(s)',
       renderCell: ({ niceName, formats }) => {
-        return formats.map(format => {
+        return formats.map((format, index) => {
           return (
-            <Fragment key={format.format}>
+            <Fragment key={index}>
               <DownloadsDrawer
                 title={niceName}
                 format={format.format}


### PR DESCRIPTION
# [Platform]: Data download table format multiplier.

## Searching 'evidence' every time adding additional format chips to first row of "format" column. Key updated for looping on formats.

**Issue:** # [Issue-2899](https://github.com/opentargets/issues/issues/2899)
**Deploy preview:** [Preview](https://deploy-preview-106--ot-platform.netlify.app)

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

* Test A: Searching 'evidence' in data downloads table search was adding additional chips to first row every time search was done.
* Test B: Search 'evidence' in data downloads table.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
