### PR TITLE
[Platform]: PPP Project table header and icon changes

### DIFF
--- a/apps/platform/index.html
+++ b/apps/platform/index.html
@@ -60,7 +60,8 @@
     </script>
 
     <!-- - Deployment Context -->
-    <script type="text/javascript" src="/profiles/default.js"></script>
+    <!-- <script type="text/javascript" src="/profiles/default.js"></script> -->
+    <script type="text/javascript" src="/profiles/profile-partners.js"></script>
     <script type="text/javascript" src="/config.js"></script>
     <script type="module" src="/src/index.jsx"></script>
   </body>

--- a/apps/platform/src/config.js
+++ b/apps/platform/src/config.js
@@ -2,7 +2,8 @@
 const config = {
   urlApi:
     window.configUrlApi ??
-    'https://api.platform.dev.opentargets.xyz/api/v4/graphql',
+    // 'https://api.platform.dev.opentargets.xyz/api/v4/graphql',
+    'https://api.partner-platform.dev.opentargets.xyz/api/v4/graphql',
   googleTagManagerID: window.configGoogleTagManagerID ?? null,
   efoURL: window.configEFOURL ?? '/data/ontology/efo_json/diseases_efo.jsonl',
 

--- a/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
+++ b/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
@@ -1,14 +1,31 @@
 import React, { Fragment } from 'react';
-import { Paper, Box, Typography, makeStyles } from '@material-ui/core';
+import {
+  Paper,
+  Box,
+  Typography,
+  makeStyles,
+  Avatar,
+  Chip,
+} from '@material-ui/core';
 import projectsData from './projects-data.json';
 import { DataTable } from '../../components/Table';
 import Link from '../../components/Link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleCheck, faCircleNotch } from '@fortawesome/free-solid-svg-icons';
+import {
+  faCircleCheck,
+  faCircleNotch,
+} from '@fortawesome/free-solid-svg-icons';
+import ChipList from '../../components/ChipList';
 
 const useStyles = makeStyles(theme => ({
   icon: {
     color: theme.palette.primary.main,
+  },
+  diseaseContainer: {
+    display: 'flex',
+  },
+  disease: {
+    marginRight: '0.2rem',
   },
 }));
 
@@ -30,10 +47,11 @@ function ProjectPage() {
     { id: 'project_lead', label: 'Project Lead' },
     { id: 'generates_data', label: 'Generates Data' },
     {
-      id: 'integrates_in_PPP',
+      id: 'currently_integrates_in_PPP',
       label: 'Currently integrates into PPP',
-      renderCell: ({ integrates_in_PPP }) => {
-        const icon = integrates_in_PPP === 'Y' ? faCircleCheck : faCircleNotch;
+      renderCell: ({ currently_integrates_in_PPP }) => {
+        const icon =
+          currently_integrates_in_PPP === 'Y' ? faCircleCheck : faCircleNotch;
         return (
           <FontAwesomeIcon size="lg" icon={icon} className={classes.icon} />
         );
@@ -41,6 +59,32 @@ function ProjectPage() {
     },
     { id: 'project_status', label: 'Project Status' },
     { id: 'open_targets_therapeutic_area', label: 'Therapeutic Area' },
+    {
+      id: 'disease_mapping',
+      label: 'Diseases Mapped',
+      renderCell: ({ disease_mapping }) => {
+        let ALL_AVATARS = [];
+        disease_mapping.map((disease, index) => {
+          disease &&
+            disease.label &&
+            ALL_AVATARS.push(
+              <Link
+                to={'disease/' + disease.disease_id}
+                key={index}
+              >
+                <Chip
+                  size="small"
+                  label={disease.label}
+                  clickable
+                  color="primary"
+                  className={classes.disease}
+                />
+              </Link>
+            );
+        });
+        return <div className={classes.diseaseContainer}>{ALL_AVATARS}</div>;
+      },
+    },
   ];
   return (
     <Fragment>

--- a/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
+++ b/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
@@ -1,42 +1,48 @@
 import React, { Fragment } from 'react';
-import { Paper, Box, Typography } from '@material-ui/core';
+import { Paper, Box, Typography, makeStyles } from '@material-ui/core';
 import projectsData from './projects-data.json';
 import { DataTable } from '../../components/Table';
 import Link from '../../components/Link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import {
-  faCheck,
-  faXmark,
-} from '@fortawesome/free-solid-svg-icons';
+import { faCircleCheck, faMinus } from '@fortawesome/free-solid-svg-icons';
+import { faCircleDot, faCircle  } from '@fortawesome/free-regular-svg-icons';
 
-const columns = [
-  {
-    id: 'otar_code',
-    label: 'Project Code',
-    renderCell: ({ otar_code }) => {
-      return otar_code ? (
-        <Link to={`http://home.opentargets.org/${otar_code}`} external newTab>
-          {otar_code}
-        </Link>
-      ) : null;
-    },
+const useStyles = makeStyles(theme => ({
+  icon: {
+    color: theme.palette.primary.main,
   },
-  { id: 'project_name', label: 'Project Name' },
-  { id: 'project_lead', label: 'Project Lead' },
-  { id: 'generates_data', label: 'Generates Data' },
-  {
-    id: 'integrates_in_PPP',
-    label: 'Integrates into PPP',
-    renderCell: ({ integrates_in_PPP }) => {
-      const icon = integrates_in_PPP === 'Y' ? faCheck : faXmark;
-      return <FontAwesomeIcon size="lg" icon={icon} />;
-    },
-  },
-  { id: 'project_status', label: 'Project Status' },
-  { id: 'open_targets_therapeutic_area', label: 'Therapeutic Area' },
-];
+}));
 
 function ProjectPage() {
+  const classes = useStyles();
+  const columns = [
+    {
+      id: 'otar_code',
+      label: 'Project Code',
+      renderCell: ({ otar_code }) => {
+        return otar_code ? (
+          <Link to={`http://home.opentargets.org/${otar_code}`} external newTab>
+            {otar_code}
+          </Link>
+        ) : null;
+      },
+    },
+    { id: 'project_name', label: 'Project Name' },
+    { id: 'project_lead', label: 'Project Lead' },
+    { id: 'generates_data', label: 'Generates Data' },
+    {
+      id: 'integrates_in_PPP',
+      label: 'Currently integrates into PPP',
+      renderCell: ({ integrates_in_PPP }) => {
+        const icon = integrates_in_PPP === 'Y' ? faCircleCheck : faCircle;
+        return (
+          <FontAwesomeIcon size="lg" icon={icon} className={classes.icon} />
+        );
+      },
+    },
+    { id: 'project_status', label: 'Project Status' },
+    { id: 'open_targets_therapeutic_area', label: 'Therapeutic Area' },
+  ];
   return (
     <Fragment>
       <Typography variant="h4" component="h1" paragraph>
@@ -59,7 +65,11 @@ function ProjectPage() {
       </Typography>
       <Typography paragraph>
         PPP specific documentation can be found{' '}
-        <Link to="https://platform-docs.opentargets.org/partner-preview-platform" external newTab>
+        <Link
+          to="http://home.opentargets.org/ppp-documentation"
+          external
+          newTab
+        >
           here
         </Link>
       </Typography>

--- a/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
+++ b/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
@@ -4,8 +4,7 @@ import projectsData from './projects-data.json';
 import { DataTable } from '../../components/Table';
 import Link from '../../components/Link';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCircleCheck, faMinus } from '@fortawesome/free-solid-svg-icons';
-import { faCircleDot, faCircle  } from '@fortawesome/free-regular-svg-icons';
+import { faCircleCheck, faCircleNotch } from '@fortawesome/free-solid-svg-icons';
 
 const useStyles = makeStyles(theme => ({
   icon: {
@@ -34,7 +33,7 @@ function ProjectPage() {
       id: 'integrates_in_PPP',
       label: 'Currently integrates into PPP',
       renderCell: ({ integrates_in_PPP }) => {
-        const icon = integrates_in_PPP === 'Y' ? faCircleCheck : faCircle;
+        const icon = integrates_in_PPP === 'Y' ? faCircleCheck : faCircleNotch;
         return (
           <FontAwesomeIcon size="lg" icon={icon} className={classes.icon} />
         );

--- a/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
+++ b/apps/platform/src/pages/ProjectsPage/ProjectsPage.jsx
@@ -15,7 +15,6 @@ import {
   faCircleCheck,
   faCircleNotch,
 } from '@fortawesome/free-solid-svg-icons';
-import ChipList from '../../components/ChipList';
 
 const useStyles = makeStyles(theme => ({
   icon: {
@@ -61,7 +60,7 @@ function ProjectPage() {
     { id: 'open_targets_therapeutic_area', label: 'Therapeutic Area' },
     {
       id: 'disease_mapping',
-      label: 'Diseases Mapped',
+      label: 'Disease Mapped in the PPP',
       renderCell: ({ disease_mapping }) => {
         let ALL_AVATARS = [];
         disease_mapping.map((disease, index) => {

--- a/apps/platform/src/pages/ProjectsPage/projects-data.json
+++ b/apps/platform/src/pages/ProjectsPage/projects-data.json
@@ -4,692 +4,816 @@
     "project_name": "Keratinocytes",
     "project_lead": "Phil Jones",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": [
+      {
+        "label": "Psoriasis",
+        "disease_id": "EFO_0000676"
+      },
+      {
+        "label": "Atopic Eczema",
+        "disease_id": "EFO_0000274"
+      }
+    ]
   },
   {
     "otar_code": "OTAR2072",
     "project_name": "DNA Damage",
     "project_lead": "Gabriel Balmus",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": [
+      {
+        "label": "amyotrophic lateral sclerosis",
+        "disease_id": "MONDO_0004976"
+      }
+    ]
   },
   {
     "otar_code": "OTAR036",
     "project_name": "iPSC neuron CRISPR",
     "project_lead": "Rick Livesey",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": [
+      {
+        "label": "Alzheimer disease",
+        "disease_id": "MONDO_0004975"
+      },
+      {
+        "label": "Parkinson disease",
+        "disease_id": "MONDO_0005180"
+      },
+      {
+        "label": "frontotemporal dementia ",
+        "disease_id": "MONDO_0017276"
+      }
+    ]
   },
   {
     "otar_code": "OTAR2054",
     "project_name": "Stress Response Modulators in iNeurons",
     "project_lead": "Manos Metzakopian / Andrew Bassett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": [
+      {
+        "label": "Alzheimer disease",
+        "disease_id": "MONDO_0004975"
+      }
+    ]
   },
   {
     "otar_code": "OTAR2059",
     "project_name": "Open Targets Validation Lab (Experimental Platform Pilot)",
     "project_lead": "Panos Zalmas/ Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": [
+      {
+        "label": "colorectal carcinoma",
+        "disease_id": "EFO_1001951"
+      }
+    ]
   },
   {
     "otar_code": "OTAR2062",
     "project_name": "ENCORE",
     "project_lead": "Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": [
+      {
+        "label": "colorectal carcinoma",
+        "disease_id": "EFO_1001951"
+      }
+    ]
   },
   {
     "otar_code": "OTAR035",
     "project_name": "PD CRISPR",
     "project_lead": "Manos Metzakopian",
     "generates_data": "Yes",
-    "integrates_in_PPP": "Y",
+    "currently_integrates_in_PPP": "Y",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": [
+      {
+        "label": "Parkinson disease",
+        "disease_id": "EFO_1001951"
+      }
+    ]
   },
   {
     "otar_code": "OTAR031",
     "project_name": "NK Cell Receptors",
     "project_lead": "Dave Adams",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR034",
     "project_name": "Genetics Core",
     "project_lead": "Maya Ghoussaini/ Ian Dunham",
     "generates_data": "Genetics/ Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR042",
     "project_name": "Tractability",
     "project_lead": "Andrew Leach",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2045",
     "project_name": "GWAS Catalog",
     "project_lead": "Laura Harris / Helen Parkinson",
     "generates_data": "Genetics evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2047",
     "project_name": "Enhanced Molecular and Clinical Data",
     "project_lead": "Andrew Leach",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2048",
     "project_name": "Protein Function",
     "project_lead": "Maria Martin",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2049",
     "project_name": "T Cell Survival and Function",
     "project_lead": "Dave Adams",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2051",
     "project_name": "NASH",
     "project_lead": "Ludovic Vallier",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2052",
     "project_name": "Identification and Validation of Novel Pain Targets",
     "project_lead": "Manos Metzakopian / Andrew Bassett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2053",
     "project_name": "100 Chromatin-Related Disorders",
     "project_lead": "Matt Hurles",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2055",
     "project_name": "Prediction of Oncology Targets and in Silico Drug Prescriptions",
     "project_lead": "Francesco Iorio",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2056",
     "project_name": "Literature",
     "project_lead": "Jo McIntyre",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2057",
     "project_name": "IBD eQTL Mapping and Database",
     "project_lead": "Carl Anderson",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2058",
     "project_name": "IBD Functional Characterisation",
     "project_lead": "Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2060",
     "project_name": "NSCLC (Deciphering myeloid landscape of non-small cell lung cancer)",
     "project_lead": "Ana Cvejic",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2061",
     "project_name": "iFuncOnc",
     "project_lead": "Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2063",
     "project_name": "Immune Variants and T-Cell Function",
     "project_lead": "Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2064",
     "project_name": "SLE eQTL Map",
     "project_lead": "Emma Davenport",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2065",
     "project_name": "Neuroinflammation",
     "project_lead": "Andrew Bassett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2066",
     "project_name": "Context Specific Networks",
     "project_lead": "Pedro Beltrao",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2067",
     "project_name": "Cell Type Deconvolution",
     "project_lead": "Irene Papatheodorou",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2068",
     "project_name": "Target Safety",
     "project_lead": "Andrew Leach",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2069",
     "project_name": "Genetic Dose-Response Modelling",
     "project_lead": "Gosia Trynka",
     "generates_data": "Platform / GP evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2070",
     "project_name": "IO Target ID",
     "project_lead": "Moritz Gerstung",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2071",
     "project_name": "NeuroID",
     "project_lead": "Andrew Bassett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2073",
     "project_name": "NeuroFlux",
     "project_lead": "Rick Livesey",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2075",
     "project_name": "Integration of Loss-of-Function variants into Open Targets Genetics",
     "project_lead": "Maya Ghoussaini/ Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2076",
     "project_name": "Phenotypic mapping of gene functions in immune cells",
     "project_lead": "Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2077",
     "project_name": "Expanding the eQTL Catalogue: new single-cell datasets and improved interpretation of splicing QTLs",
     "project_lead": "Kaur Alasoo",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2078",
     "project_name": "Target Engine",
     "project_lead": "Ian Dunham",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2079",
     "project_name": "Saturation Genome Editing in Immune Genes",
     "project_lead": "Gosia Trynka/ Dave Adams",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2080",
     "project_name": "Natural Killer cell evasion and exhaustion mediators",
     "project_lead": "Annie Speak",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2081",
     "project_name": "Sequence Variation, Protein Structure and Function",
     "project_lead": "Pedro Beltrao",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR3083",
     "project_name": "Project Symphony",
     "project_lead": "Dave Adams / Wolfgang Huber",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR3084",
     "project_name": "Project BOND",
     "project_lead": "Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR3086",
     "project_name": "IMMERSE",
     "project_lead": "Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR3087",
     "project_name": "Splicing Target Prioritisation",
     "project_lead": "Kaur Alasoo / Ben Lehner",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Active",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR005",
     "project_name": "Rare and Common Diseases",
     "project_lead": "Helen Parkinson",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR006",
     "project_name": "Pathways (Reactome)",
     "project_lead": "Henning Hermjakob",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR007",
     "project_name": "Cancer Mutations (COSMIC)",
     "project_lead": "Simon Forbes",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR008",
     "project_name": "Known Drug Targets (ChEMBL)",
     "project_lead": "Andrew Leach",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR009",
     "project_name": "GWAS Database",
     "project_lead": "Helen Parkinson",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR010",
     "project_name": "Expression (Atlas)",
     "project_lead": "Irene Papatheodorou",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR011",
     "project_name": "Protein Knowledge (UniProt)",
     "project_lead": "Maria Martin / Sandra Orchard",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR012",
     "project_name": "Variation Database (EVA)",
     "project_lead": "Thomas Keane",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR013",
     "project_name": "Melanoma NGS",
     "project_lead": "Moritz Gerstung",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR014",
     "project_name": "1000 cell line RNA-seq",
     "project_lead": "Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR015",
     "project_name": "CRISPR Cas9 Target ID",
     "project_lead": "Mathew Garnett",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR016",
     "project_name": "Cancer Functional Genomics",
     "project_lead": "Julio Saez-Rodriguez",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR017",
     "project_name": "IBD Ontology",
     "project_lead": "Helen Parkinson",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR020",
     "project_name": "Epigenomics of GSK Cell Lines",
     "project_lead": "Bill Cairns",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR021",
     "project_name": "Influential Variants",
     "project_lead": "Ewan Birney",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR022",
     "project_name": "Metabolite GWAS",
     "project_lead": "Nicole Soranzo",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR023",
     "project_name": "Statistical Integration",
     "project_lead": "Oli Stegle",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR024",
     "project_name": "Regulatory Elements (POSTGAP)",
     "project_lead": "Daniel Zerbino",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR025",
     "project_name": "Literature",
     "project_lead": "Jo McEntyre",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR026",
     "project_name": "MacroScreen",
     "project_lead": "Dan Gaffney",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR027",
     "project_name": "TargetID Asthma",
     "project_lead": "Sarah Teichmann",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR028",
     "project_name": "Bronchiectasis",
     "project_lead": "David Michalovich",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Other Therapy Area"
+    "open_targets_therapeutic_area": "Other Therapy Area",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR032",
     "project_name": "Dendritic Cell Screen",
     "project_lead": "Dan Gaffney",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR037",
     "project_name": "AD PD GWAS fine map",
     "project_lead": "Andrew Bassett / Jeremy Schwartzentruber",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR038",
     "project_name": "AD mutations single cell profiles",
     "project_lead": "Martin Hemberg",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR039",
     "project_name": "Profiling iPSC neurons",
     "project_lead": "Dan Gaffney",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR040",
     "project_name": "Cyto Immunogenomics",
     "project_lead": "Gosia Trynka",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Immunology and Inflammation"
+    "open_targets_therapeutic_area": "Immunology and Inflammation",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR041",
     "project_name": "CELLector",
     "project_lead": "Francesco Iorio",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Oncology"
+    "open_targets_therapeutic_area": "Oncology",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR043",
     "project_name": "Expression Atlas",
     "project_lead": "Irene Papatheodorou",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR044",
     "project_name": "Networks",
     "project_lead": "Pedro B, Pablo P & Sandra O",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR050",
     "project_name": "Enteric Neurons",
     "project_lead": "Manos Metzakopian",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Neurodegenerative Disease"
+    "open_targets_therapeutic_area": "Neurodegenerative Disease",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2046",
     "project_name": "eQTL Resources",
     "project_lead": "Daniel Zerbino",
     "generates_data": "Platform evidence",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   },
   {
     "otar_code": "OTAR2074",
     "project_name": "Genome Screen Database",
     "project_lead": "Peter Harrison",
     "generates_data": "Yes",
-    "integrates_in_PPP": "N",
+    "currently_integrates_in_PPP": "N",
     "project_status": "Closed",
-    "open_targets_therapeutic_area": "Informatics"
+    "open_targets_therapeutic_area": "Informatics",
+    "disease_mapping": []
   }
 ]


### PR DESCRIPTION
# [Platform]: PPP Project table header and icon changes

## PPP Project table header text changes from "Integrates into PPP" to "Currently integrates into PPP", changed icons


**Issue:** # [Issue-2900](https://github.com/opentargets/issues/issues/2900)
**Deploy preview:** [PPP Preview](https://deploy-preview-107--ot-platform.netlify.app/projects)

## Type of change

* Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

* Test A: Text on table header is "Integrates into PPP", ppp documentation link on projects page redirects to [platform-docs](https://platform-docs.opentargets.org/partner-preview-platform).
* Test B: Text on table header is "Currently integrates into PPP", ppp documentation link on projects page redirects to [ot-home/ppp-doc](http://home.opentargets.org/ppp-documentation).

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
