### PR TITLE
[Genetics]: Error Boundary added to CredibleSetsGwasQtlList 

### DIFF
--- a/apps/genetics/src/sections/studyLocus/CredibleSetsGroup/CredibleSetsGroup.jsx
+++ b/apps/genetics/src/sections/studyLocus/CredibleSetsGroup/CredibleSetsGroup.jsx
@@ -30,6 +30,7 @@ import {
   PlotContainerSection,
   significantFigures,
 } from '../../../ot-ui-components';
+import ErrorBoundary from '../../../components/ErrorBoundary';
 
 const CredibleSetsGroup = ({ variantId, studyId, start, end, chromosome }) => {
   const PAGE_CREDIBLE_SET_KEY = `gwasCredibleSet__${studyId}__${variantId}`;
@@ -66,14 +67,11 @@ const CredibleSetsGroup = ({ variantId, studyId, start, end, chromosome }) => {
     }
   };
 
-  useEffect(
-    () => {
-      setCredibleSetIntersectionKeys([
-        `gwasCredibleSet__${studyId}__${variantId}`,
-      ]);
-    },
-    [studyId, variantId]
-  );
+  useEffect(() => {
+    setCredibleSetIntersectionKeys([
+      `gwasCredibleSet__${studyId}__${variantId}`,
+    ]);
+  }, [studyId, variantId]);
 
   const {
     loading: credibleSetsGroupLoading,
@@ -87,12 +85,8 @@ const CredibleSetsGroup = ({ variantId, studyId, start, end, chromosome }) => {
     return <Skeleton height="20vh" width="80vw" />;
   }
 
-  ({
-    pageCredibleSet,
-    studyInfo,
-    gwasColocalisation,
-    qtlColocalisation,
-  } = credibleSetsGroupQueryResult);
+  ({ pageCredibleSet, studyInfo, gwasColocalisation, qtlColocalisation } =
+    credibleSetsGroupQueryResult);
 
   pageCredibleSetAdjusted = filterPageCredibleSet(
     pageCredibleSet,
@@ -108,9 +102,10 @@ const CredibleSetsGroup = ({ variantId, studyId, start, end, chromosome }) => {
     isGreaterThanZero(gwasColocalisation.length) ||
     isGreaterThanZero(qtlColocalisation.length);
 
-  const colocalisationCredibleSetQuery = shouldMakeColocalisationCredibleSetQuery
-    ? createCredibleSetsQuery({ gwasColocalisation, qtlColocalisation })
-    : null;
+  const colocalisationCredibleSetQuery =
+    shouldMakeColocalisationCredibleSetQuery
+      ? createCredibleSetsQuery({ gwasColocalisation, qtlColocalisation })
+      : null;
 
   return (
     <>
@@ -212,24 +207,26 @@ const CredibleSetsGroup = ({ variantId, studyId, start, end, chromosome }) => {
 
       {shouldMakeColocalisationCredibleSetQuery &&
       colocalisationCredibleSetQuery ? (
-        <CredibleSetsGwasQtlList
-          query={colocalisationCredibleSetQuery}
-          gwasColocalisation={gwasColocalisation}
-          qtlColocalisation={qtlColocalisation}
-          log2h4h3SliderValue={log2h4h3SliderValue}
-          h4SliderValue={h4SliderValue}
-          credSet95Value={credSet95Value}
-          variantId={variantId}
-          studyId={studyId}
-          pageCredibleSetAdjusted={pageCredibleSetAdjusted}
-          credibleSetIntersectionKeys={credibleSetIntersectionKeys}
-          start={start}
-          end={end}
-          chromosome={chromosome}
-          handleCredibleSetIntersectionKeysCheckboxClick={
-            handleCredibleSetIntersectionKeysCheckboxClick
-          }
-        />
+        <ErrorBoundary>
+          <CredibleSetsGwasQtlList
+            query={colocalisationCredibleSetQuery}
+            gwasColocalisation={gwasColocalisation}
+            qtlColocalisation={qtlColocalisation}
+            log2h4h3SliderValue={log2h4h3SliderValue}
+            h4SliderValue={h4SliderValue}
+            credSet95Value={credSet95Value}
+            variantId={variantId}
+            studyId={studyId}
+            pageCredibleSetAdjusted={pageCredibleSetAdjusted}
+            credibleSetIntersectionKeys={credibleSetIntersectionKeys}
+            start={start}
+            end={end}
+            chromosome={chromosome}
+            handleCredibleSetIntersectionKeysCheckboxClick={
+              handleCredibleSetIntersectionKeysCheckboxClick
+            }
+          />
+        </ErrorBoundary>
       ) : null}
     </>
   );


### PR DESCRIPTION
# [Genetics]: Error Boundary added to CredibleSetsGwasQtlList 

## Description
Error Boundary added to CredibleSetsGwasQtlList in study locus page to hide a section that causes error.


**Issue:** # [issue-2910](https://github.com/opentargets/issues/issues/2910)
**Deploy preview:** (link)

## Type of change

* Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

* Test A: 
   1. Go to [Genetics](https://genetics.opentargets.org/study-locus/FINNGEN_R6_L12_DERMATITISECZEMA/20_63697100_T_C)
   2. The results will appear for a few seconds.
   3. An error message appears and everything on the page disappears.

* Test B:
   1. Go to [Genetics](https://genetics.opentargets.org/study-locus/FINNGEN_R6_L12_DERMATITISECZEMA/20_63697100_T_C)
   2. The results will appear for a few seconds.
   3. An error message appears only for `CredibleSetsGwasQtlList` section.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
