### PR TITLE
[Genetics]: update gene's L2G pipeline query with missing download fields

### DIFF
--- a/apps/genetics/src/components/AssociatedStudiesTable.jsx
+++ b/apps/genetics/src/components/AssociatedStudiesTable.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import { Fragment } from 'react';
 import {
   DataDownloader,
   OtTableRF,

--- a/apps/genetics/src/sections/gene/L2GPipeline/L2GPipelineQuery.gql
+++ b/apps/genetics/src/sections/gene/L2GPipeline/L2GPipelineQuery.gql
@@ -20,6 +20,7 @@ query GenePageL2GPipelineQuery($geneId: String!) {
       nInitial
       nReplication
       hasSumstats
+      nCases
     }
     variant {
       rsId


### PR DESCRIPTION
[Genetics]: update gene's L2G pipeline query with missing download fields

## Description

The PR adds the `study.nCases` field to the query for the gene's page "Associated studies: locus-to-gene pipeline" table. This fixes the corresponding column in the downloaded table, which was always empty.

**Issue:** [issue 2926](https://github.com/opentargets/issues/issues/2926)
**Deploy preview:** [link](https://deploy-preview-119--ot-genetics.netlify.app)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Simply go to the [gene page](https://deploy-preview-119--ot-genetics.netlify.app/gene/ENSG00000171522) and download the first table. Check in the downloaded file that the "Study N Cases" columns contains values (note: only certain rows have values)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
