### PR TITLE
[Genetics]: Search result page option disabled

### DIFF
--- a/apps/platform/src/components/BasePage.jsx
+++ b/apps/platform/src/components/BasePage.jsx
@@ -20,7 +20,7 @@ const BasePage = ({ title, children, description, location }) => {
       header={
         <NavBar
           name="Platform"
-          search={<GlobalSearch />}
+          search={<GlobalSearch showSearchResultPage/>}
           items={mainMenuItems}
         />
       }

--- a/apps/platform/src/pages/HomePage/HomePage.jsx
+++ b/apps/platform/src/pages/HomePage/HomePage.jsx
@@ -140,7 +140,7 @@ const HomePage = () => {
           placement="bottom-end"
         />
         <HomeBox>
-          <AutocompleteSearch isHomePage />
+          <AutocompleteSearch isHomePage showSearchResultPage/>
           {/* Search examples */}
           <Grid
             className={classes.links}

--- a/packages/ui/src/AutocompleteSearch.tsx
+++ b/packages/ui/src/AutocompleteSearch.tsx
@@ -54,9 +54,11 @@ const getTheme = (primaryColor: string) =>
 export default function AutocompleteSearch({
   closeModal = () => {},
   isHomePage,
+  showSearchResultPage
 }: {
-  closeModal: () => void;
-  isHomePage: boolean;
+  closeModal?: () => void;
+  isHomePage?: boolean;
+  showSearchResultPage?: boolean;
 }) {
   const [searchResult, setSearchResult] = useState<SearchResult[]>([]);
   const [openListItem] = useListOption();
@@ -97,7 +99,7 @@ export default function AutocompleteSearch({
     let searchForTermObject;
     setSearchResult(recentItems);
     setLoading(searchQueryLoading);
-    if (inputValue) {
+    if (inputValue && showSearchResultPage) {
       searchForTermObject = {
         symbol: "Search For: " + inputValue,
         name: inputValue,
@@ -108,7 +110,7 @@ export default function AutocompleteSearch({
     }
     if (!loading && inputValue && data.length) {
       const RESULT_DATA = JSON.parse(JSON.stringify(data));
-      RESULT_DATA.unshift(searchForTermObject);
+      showSearchResultPage && RESULT_DATA.unshift(searchForTermObject);
       setSearchResult(RESULT_DATA);
       setLoading(false);
     }

--- a/packages/ui/src/GlobalSearch.jsx
+++ b/packages/ui/src/GlobalSearch.jsx
@@ -128,7 +128,7 @@ function GlobalSearch({showSearchResultPage}) {
         className={classes.modal}
       >
         <DialogContent>
-          <AutocompleteSearch closeModal={handleClose} showSearchResultPage/>
+          <AutocompleteSearch closeModal={handleClose} showSearchResultPage={showSearchResultPage}/>
         </DialogContent>
       </Dialog>
     </>

--- a/packages/ui/src/GlobalSearch.jsx
+++ b/packages/ui/src/GlobalSearch.jsx
@@ -66,7 +66,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function GlobalSearch() {
+function GlobalSearch({showSearchResultPage}) {
   const classes = useStyles();
   const [open, setOpen] = useState(false);
   const handleClose = () => {
@@ -128,7 +128,7 @@ function GlobalSearch() {
         className={classes.modal}
       >
         <DialogContent>
-          <AutocompleteSearch closeModal={handleClose} />
+          <AutocompleteSearch closeModal={handleClose} showSearchResultPage/>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
# [Genetics]: Search result page option disabled

## Show search results page prop added on Search component to disable option

**Issue:** # (link)
**Deploy preview:** [genetics-preview](https://deploy-preview-123--ot-genetics.netlify.app)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test: 
  1. Open genetics.
  2. Click on search and type something.
  3. There should be **NO** option named "Search for < term you entered >".
  4. Clicking enter should open first result by default.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
