### PR TITLE
[Platform]: fix PPP release version

### DIFF
--- a/apps/platform/src/pages/HomePage/PPHomePage.jsx
+++ b/apps/platform/src/pages/HomePage/PPHomePage.jsx
@@ -169,7 +169,7 @@ const HomePage = () => {
               <Link to={`/drug/${drugs[1].id}`}>{drugs[1].label}</Link>
             </Hidden>
           </Grid>
-          <Version />
+          <Version releaseNotesURL="http://home.opentargets.org/ppp-release-notes" />
           <div className={classes.dataPolicy}>
             <Typography
               variant="body2"

--- a/apps/platform/src/pages/HomePage/Version.jsx
+++ b/apps/platform/src/pages/HomePage/Version.jsx
@@ -34,10 +34,10 @@ function VersionContainer({ children }) {
 }
 
 // LINK
-function VersionLink({ month, year, version }) {
+function VersionLink({ month, year, version, link }) {
   return (
     <Box ml={1}>
-      <Link external to="https://platform-docs.opentargets.org/release-notes">
+      <Link external to={link}>
         {month} 20{year} ({version})
       </Link>
     </Box>
@@ -45,7 +45,9 @@ function VersionLink({ month, year, version }) {
 }
 
 // MAIN COMPONENT
-function Version() {
+function Version({
+  releaseNotesURL = 'https://platform-docs.opentargets.org/release-notes',
+}) {
   const { data, loading, error } = useQuery(DATA_VERSION_QUERY);
   if (error) return null;
   if (loading)
@@ -61,7 +63,12 @@ function Version() {
   return (
     <VersionContainer>
       Last update:
-      <VersionLink month={fullMonth} year={year} version={version} />
+      <VersionLink
+        link={releaseNotesURL}
+        month={fullMonth}
+        year={year}
+        version={version}
+      />
     </VersionContainer>
   );
 }


### PR DESCRIPTION
# [Platform]: fix PPP release version

## Description

In the prod version the homepage link to release notes is pointing to public release notes

**Issue:** # (link)
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Check the home page in PPP mode

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
