### PR TITLE
[Platform / PPP ] fix SysBio/Gene Signature evidence widget IDs variables

### DIFF
--- a/apps/platform/src/sections/evidence/Reactome/Body.jsx
+++ b/apps/platform/src/sections/evidence/Reactome/Body.jsx
@@ -166,10 +166,10 @@ export function Body({ definition, id, label }) {
 }
 
 export function BodyCore({ definition, id, label, count }) {
-  const { ensgId: ensemblId, efoId } = id;
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
     size: count,
   };

--- a/apps/platform/src/sections/evidence/SysBio/Body.jsx
+++ b/apps/platform/src/sections/evidence/SysBio/Body.jsx
@@ -64,12 +64,14 @@ export function Body({ definition, id, label }) {
     Summary.fragments.SysBioSummaryFragment
   );
   const count = summaryData.sysBio.count;
-  
-  if(!count || count < 1) {
-    return null
+
+  if (!count || count < 1) {
+    return null;
   }
 
-  return <BodyCore definition={definition} id={id} label={label} count={count} />
+  return (
+    <BodyCore definition={definition} id={id} label={label} count={count} />
+  );
 }
 
 export function BodyCore({ definition, id, label, count }) {
@@ -90,7 +92,9 @@ export function BodyCore({ definition, id, label, count }) {
       definition={definition}
       chipText={dataTypesMap.affected_pathway}
       request={request}
-      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
+      renderDescription={() => (
+        <Description symbol={label.symbol} name={label.name} />
+      )}
       renderBody={data => (
         <DataTable
           columns={columns}

--- a/apps/platform/src/sections/evidence/SysBio/Body.jsx
+++ b/apps/platform/src/sections/evidence/SysBio/Body.jsx
@@ -73,9 +73,10 @@ export function Body({ definition, id, label }) {
 }
 
 export function BodyCore({ definition, id, label, count }) {
-  const { ensgId: ensemblId, efoId } = id;
+  const { ensgId, efoId } = id;
+
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
     size: count,
   };

--- a/apps/platform/src/sections/evidence/UniProtLiterature/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtLiterature/Body.jsx
@@ -92,10 +92,10 @@ export function Body({ definition, id, label }) {
 }
 
 export function BodyCore({ definition, id, label, count }) {
-  const { ensgId: ensemblId, efoId } = id;
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
     size: count,
   };

--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -103,10 +103,10 @@ export function Body({ definition, id, label }) {
 }
 
 export function BodyCore({ definition, id, label, count }) {
-  const { ensgId: ensemblId, efoId } = id;
+  const { ensgId, efoId } = id;
 
   const variables = {
-    ensemblId,
+    ensemblId: ensgId,
     efoId,
     size: count,
   };


### PR DESCRIPTION
# [Platform / PPP ] fix SysBio/Gene Signature evidence widget IDs variables

Refactor vars deconstruct in SysBio widget to fix error: undefined `ensgId` triggers error in `dataDownloaderFileStem` prop which causes the widget and page to crash.

## Description
It was noted that the evidence page breaks on PPP

> Can anyone double check this page on PPP: https://partner-platform.opentargets.org/evidence/ENSG00000080815/MONDO_0004975
> (https://opentargets-dev.slack.com/archives/C02B9NT33AL/p1683632137597549)

The error is due to an undefined var in the SysBio widget: this was fixed and the same approach applied to other widgets for consistency.

.../SysBio/Body.js = fixes for the actual bug + some style formatting
other files in PR = updated for consistency

This **PR does not** update the `dataDownloaderFileStem`: incorrectly this says "otgenetics", but since most widgets are like that, we'll address this separately.

No dependencies.

**Issue:** no ticket available - issue was reported on Slack chat
**Deploy preview:** https://deploy-preview-131--ot-platform-partner.netlify.app/evidence/ENSG00000080815/MONDO_0004975

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] This page breaks: https://partner-platform.opentargets.org/evidence/ENSG00000080815/MONDO_0004975
- [ ] This works: https://deploy-preview-131--ot-platform-partner.netlify.app/evidence/ENSG00000080815/MONDO_0004975

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
