### PR TITLE
[Package]: Search dropdown bug

### DIFF
--- a/packages/ui/src/AutocompleteSearch.tsx
+++ b/packages/ui/src/AutocompleteSearch.tsx
@@ -185,6 +185,7 @@ export default function AutocompleteSearch({
           onClose={onClose}
           isHomePage={isHomePage}
           focus={open}
+          setOpen={setOpen}
         />
       )}
     />

--- a/packages/ui/src/Search/SearchInput.tsx
+++ b/packages/ui/src/Search/SearchInput.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useContext, useRef } from "react";
+import { useEffect, useContext, useRef } from "react";
 import { Search } from "@material-ui/icons";
 import {
   makeStyles,

--- a/packages/ui/src/Search/SearchInput.tsx
+++ b/packages/ui/src/Search/SearchInput.tsx
@@ -54,17 +54,19 @@ function SearchInput({
   onClose,
   isHomePage,
   focus,
+  setOpen,
 }: {
   params: TextFieldProps;
   debounceValue: (str: string) => void;
   onClose: () => void;
   isHomePage?: boolean;
   focus: boolean;
+  setOpen: (value: boolean) => void;
 }) {
   const classes = useStyles();
-  const [searchInputValue, setSearchInputValue] = useState("");
-  const debouncedInputValue = useDebounce(searchInputValue, 300);
-  const { searchPlaceholder, setInputValue } = useContext(SearchContext);
+  const { searchPlaceholder, setInputValue, inputValue } =
+    useContext(SearchContext);
+  const debouncedInputValue = useDebounce(inputValue, 300);
   const inputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
@@ -100,13 +102,18 @@ function SearchInput({
           className: classes.inputPadding,
         }}
         onChange={(e) => {
-          setSearchInputValue(e.target.value.trim() || "");
           setInputValue(e.target.value.trim() || "");
         }}
-        value={searchInputValue}
+        value={inputValue}
         placeholder={searchPlaceholder}
         onKeyDown={(e) => {
-          if(e.code === "Escape") onClose();
+          if (e.code === "Escape") onClose();
+        }}
+        onBlur={() => {
+          onClose();
+        }}
+        onFocus={() => {
+          setOpen(true);
         }}
       />
     </div>


### PR DESCRIPTION
# [Package]: Search dropdown bug

## Opens recent items as soon as search is focused. And hidden as soon as it is unfocused. Passed setopen function to input for onfocus event

**Issue:** # [issue-2947](https://github.com/opentargets/issues/issues/2947)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

* Test A: 
        Steps to reproduce the behaviour:
            1. Go to https://platform.opentargets.org/
            2. Click on Search
            3. See error (if you have any recent items)

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
