### PR TITLE
[Platform] Add chip for gene essentiality to target description

### DIFF
--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,3 +1,2 @@
-# VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
-VITE_API_URL=https://api.platform.mbdev.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
 VITE_PROFILE=default

--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,2 +1,3 @@
-VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
+# VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://api.platform.mbdev.opentargets.xyz/api/v4/graphql
 VITE_PROFILE=default

--- a/apps/platform/src/pages/TargetPage/ProfileHeader.jsx
+++ b/apps/platform/src/pages/TargetPage/ProfileHeader.jsx
@@ -65,6 +65,11 @@ function ProfileHeader() {
     theme.palette.primary.main
   );
   const synonyms = parseSynonyms(data?.target.synonyms || []);
+  
+  const geneInfo = [{
+    label: 'Core essential gene',
+    tooltip: 'Source: Cancer DepMap',
+  }];
 
   return (
     <BaseProfileHeader>
@@ -72,6 +77,7 @@ function ProfileHeader() {
         loading={loading}
         descriptions={targetDescription}
         targetId={data?.target.id}
+        infoChips= {data?.target.isEssential ? geneInfo : null}
       />
       <ChipList title="Synonyms" loading={loading}>
         {synonyms}

--- a/apps/platform/src/pages/TargetPage/TargetDescription.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetDescription.jsx
@@ -2,6 +2,7 @@ import { useState, useLayoutEffect, useRef } from 'react';
 import { v1 } from 'uuid';
 import { Typography, withStyles } from '@material-ui/core';
 import { Skeleton } from '@material-ui/lab';
+import {ChipList} from '../../components/ProfileHeader';
 
 const styles = theme => ({
   textContainer: {
@@ -34,6 +35,7 @@ function LongText({
   variant = 'body2',
   descriptions,
   targetId,
+  hasGutterBottom=false,
 }) {
   const containerRef = useRef();
   const [showMore, setShowMore] = useState(false);
@@ -66,7 +68,7 @@ function LongText({
   }
 
   return (
-    <Typography variant={variant}>
+    <Typography variant={variant} gutterBottom={hasGutterBottom}>
       <span ref={containerRef} className={classes.textContainer}>
         {descriptions.map((desc, i) => (
           <span
@@ -99,6 +101,7 @@ function TargetDescription({
   showLabel = true,
   targetId,
   lineLimit = 3,
+  infoChips = [],
 }) {
   let content;
 
@@ -106,11 +109,15 @@ function TargetDescription({
     content = 'No description available';
   } else {
     content = (
-      <StyledLongText
-        lineLimit={lineLimit}
-        descriptions={descriptions}
-        targetId={targetId}
-      />
+      <>
+        <StyledLongText
+          lineLimit={lineLimit}
+          descriptions={descriptions}
+          targetId={targetId}
+          hasGutterBottom={infoChips?.length>0}
+        />
+        {infoChips?.length>0 ? (<ChipList>{infoChips}</ChipList>) : null}
+      </>
     );
   }
 


### PR DESCRIPTION
# [Platform] Add chip for gene essentiality to target description

## Description

Display a chip with "core essential gene" below the description section on the target profile page, based on the `target.isEssential` field. Note this field will be available in the API soon, however it's not there yet and it's therefore not possible to test this correctly at the moment.

**Issue:** https://github.com/opentargets/issues/issues/2917
**Deploy preview:** https://deploy-preview-151--ot-platform.netlify.app/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This has been tested locally by forcing a flag to display the chip. A screenshot is included in the ticket.
- [ ] see preview https://deploy-preview-151--ot-platform.netlify.app/target/ENSG00000105397 (Note the target page is currently broken - refer to screenshot in issue 2917 for reference).

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
