### PR TITLE
[Platform]: Update drugWarnings annotation in the Platform

### DIFF
--- a/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
+++ b/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
@@ -8,6 +8,7 @@ import Description from './Description';
 import { naLabel, defaultRowsPerPageOptions } from '../../../constants';
 
 import DRUG_WARNINGS_QUERY from './DrugWarningsQuery.gql';
+import Tooltip from '../../../components/Tooltip';
 
 const replaceSemicolonWithUnderscore = id => id.replace(':', '_');
 
@@ -19,31 +20,28 @@ const columns = [
     label: 'Warning type',
   },
   {
-    id: 'description',
-    label: 'Description',
-    renderCell: ({ description }) => description ?? naLabel,
-  },
-  {
     id: 'efoTerm',
     label: 'Adverse event',
-    renderCell: ({ efoTerm, efoId }) => {
-      if (efoTerm && efoId)
+    renderCell: ({ efoTerm, efoId, description }) => {
+      if (efoId)
         return (
-          <Link
-            external
-            to={EBI_OLS_URL + replaceSemicolonWithUnderscore(efoId)}
-          >
-            {efoTerm}
-          </Link>
+          <Tooltip title={`Description : ${description}`} showHelpIcon>
+            <Link
+              external
+              to={EBI_OLS_URL + replaceSemicolonWithUnderscore(efoId)}
+            >
+              {efoTerm || efoId}
+            </Link>
+          </Tooltip>
         );
-      return efoTerm || efoId || naLabel;
+      return efoTerm || description || naLabel;
     },
   },
   {
     id: 'toxicityClass',
     label: 'ChEMBL warning class',
-    renderCell: ({ toxicityClass, efoIdForWarningClass }) => {
-      if (toxicityClass && efoIdForWarningClass)
+    renderCell: ({ toxicityClass, efoIdForWarningClass, description }) => {
+      if (efoIdForWarningClass)
         return (
           <Link
             external
@@ -51,10 +49,10 @@ const columns = [
               EBI_OLS_URL + replaceSemicolonWithUnderscore(efoIdForWarningClass)
             }
           >
-            {toxicityClass}
+            {toxicityClass || efoIdForWarningClass}
           </Link>
         );
-      return toxicityClass || efoIdForWarningClass || naLabel;
+      return toxicityClass || description || naLabel;
     },
   },
   {


### PR DESCRIPTION
# [Platform]: Update drugWarnings annotation in the Platform

## Description: Update drugWarnings annotation by moving description as a column to tooltip in the Platform

**Issue:** # https://github.com/opentargets/issues/issues/2943
**Deploy preview:** https://deploy-preview-159--ot-platform.netlify.app/drug/CHEMBL1233

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

* Test A : New column and link to warning column added in drug warning table.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
