### PR TITLE
[Platform] Specify caching of ScoredComponents in AOTF table

### DIFF
--- a/apps/platform/src/client.js
+++ b/apps/platform/src/client.js
@@ -4,7 +4,14 @@ import config from './config';
 
 const client = new ApolloClient({
   uri: config.urlApi,
-  cache: new InMemoryCache({ possibleTypes }),
+  cache: new InMemoryCache({
+    possibleTypes,
+    typePolicies: {
+      ScoredComponent: {
+        keyFields: ['componentId', 'score'],
+      },
+    },
+  }),
   headers: { 'OT-Platform': true },
 });
 


### PR DESCRIPTION
# [Platform] Specify caching of ScoredComponents in AOTF table

## Description

In the association tables, sometimes a bug appears where the first value in a column is shown for all the subsequent rows. When this happens, the API returns the correct information, but the response (`data`) of the `TargetAssociationsQuery`/`DiseaseAssociationsQuery` by the `client` defined in `client.js` returns the score of the first `ScoredComponent` for each datatype for all rows, see below. By explicitly caching the `ScoredComponent`s on `componentId` and `score` this was solved.

![image](https://github.com/opentargets/ot-ui-apps/assets/62542407/c444d9d8-2cbc-492a-a370-047a55de070d)


## Type of change

Please delete options that are not relevant.

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A: used different versions of ot-ui-apps v0.3.8-latest using yarn in dev and prd mode and in different browsers.
- [ ] Test B: used different versions of ot-ui-apps v0.3.8-latest using docker in different browsers.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
