### PR TITLE
[Platform]: add chip+link (ProtVar) to OTGenetics and ClinVar widgets

### DIFF
--- a/apps/platform/src/sections/evidence/EVA/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVA/Body.jsx
@@ -28,215 +28,232 @@ const useStyles = makeStyles({
   },
   chipLink: {
     marginLeft: '5px',
-  }
+  },
 });
 
 function getColumns(classes) {
   return [
-  {
-    id: 'disease.name',
-    label: 'Disease/phenotype',
-    renderCell: ({ disease, diseaseFromSource, cohortPhenotypes }) => (
-      <Tooltip
-        title={
-          <>
-            <Typography variant="subtitle2" display="block" align="center">
-              Reported disease or phenotype:
-            </Typography>
-            <Typography
-              variant="caption"
-              display="block"
-              align="center"
-              gutterBottom
-            >
-              {diseaseFromSource}
-            </Typography>
+    {
+      id: 'disease.name',
+      label: 'Disease/phenotype',
+      renderCell: ({ disease, diseaseFromSource, cohortPhenotypes }) => (
+        <Tooltip
+          title={
+            <>
+              <Typography variant="subtitle2" display="block" align="center">
+                Reported disease or phenotype:
+              </Typography>
+              <Typography
+                variant="caption"
+                display="block"
+                align="center"
+                gutterBottom
+              >
+                {diseaseFromSource}
+              </Typography>
 
-            {cohortPhenotypes?.length > 1 ? (
-              <>
-                <Typography variant="subtitle2" display="block" align="center">
-                  All reported phenotypes:
-                </Typography>
-                <Typography variant="caption" display="block">
-                  {cohortPhenotypes.map(cp => (
-                    <div key={cp}>{cp}</div>
-                  ))}
-                </Typography>
-              </>
-            ) : (
-              ''
-            )}
+              {cohortPhenotypes?.length > 1 ? (
+                <>
+                  <Typography
+                    variant="subtitle2"
+                    display="block"
+                    align="center"
+                  >
+                    All reported phenotypes:
+                  </Typography>
+                  <Typography variant="caption" display="block">
+                    {cohortPhenotypes.map(cp => (
+                      <div key={cp}>{cp}</div>
+                    ))}
+                  </Typography>
+                </>
+              ) : (
+                ''
+              )}
+            </>
+          }
+          showHelpIcon
+        >
+          <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+        </Tooltip>
+      ),
+    },
+    {
+      id: 'variantId',
+      label: 'Variant ID',
+      renderCell: ({ variantId }) =>
+        // trim long IDs and append '...'
+        variantId ? (
+          <>
+            {variantId.substring(0, 20)}
+            {variantId.length > 20 ? '\u2026' : ''}
           </>
-        }
-        showHelpIcon
-      >
-        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
-      </Tooltip>
-    ),
-  },
-  {
-    id: 'variantId',
-    label: 'Variant ID',
-    renderCell: ({ variantId }) =>
-      // trim long IDs and append '...'
-      variantId ? (
-        <>
-          {variantId.substring(0, 20)}
-          {variantId.length > 20 ? '\u2026' : ''}
-        </>
-      ) : (
-        naLabel
-      ),
-  },
-  {
-    id: 'variantRsId',
-    label: 'rsID',
-    renderCell: ({ variantRsId }) =>
-      variantRsId ? (
-        <Link
-          external
-          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
-        >
-          {variantRsId}
-        </Link>
-      ) : (
-        naLabel
-      ),
-  },
-  {
-    id: 'variantHgvsId',
-    label: 'HGVS ID',
-    renderCell: ({ variantHgvsId }) => variantHgvsId || naLabel,
-  },
-  {
-    id: 'studyId',
-    label: 'ClinVar ID',
-    renderCell: ({ studyId }) =>
-      studyId ? (
-        <Link external to={`https://www.ncbi.nlm.nih.gov/clinvar/${studyId}`}>
-          {studyId}
-        </Link>
-      ) : (
-        naLabel
-      ),
-  },
-  {
-    label: 'Functional consequence',
-    renderCell: ({ variantFunctionalConsequence, variantId }) => {
-      const pvparams = variantId?.split('_') || [];
-      return (
-      <>
-        <Link
-          external
-          to={`http://www.sequenceontology.org/browser/current_svn/term/${variantFunctionalConsequence.id}`}
-        >
-          {sentenceCase(variantFunctionalConsequence.label)}
-        </Link>
-        { 
-          // could also check agains functional consequence ID, 
-          // but the "missense_variant" label is also reliable
-          (variantFunctionalConsequence.label === 'missense_variant' && pvparams.length==4) ? (
+        ) : (
+          naLabel
+        ),
+    },
+    {
+      id: 'variantRsId',
+      label: 'rsID',
+      renderCell: ({ variantRsId }) =>
+        variantRsId ? (
+          <Link
+            external
+            to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+          >
+            {variantRsId}
+          </Link>
+        ) : (
+          naLabel
+        ),
+    },
+    {
+      id: 'variantHgvsId',
+      label: 'HGVS ID',
+      renderCell: ({ variantHgvsId }) => variantHgvsId || naLabel,
+    },
+    {
+      id: 'studyId',
+      label: 'ClinVar ID',
+      renderCell: ({ studyId }) =>
+        studyId ? (
+          <Link external to={`https://www.ncbi.nlm.nih.gov/clinvar/${studyId}`}>
+            {studyId}
+          </Link>
+        ) : (
+          naLabel
+        ),
+    },
+    {
+      label: 'Functional consequence',
+      renderCell: ({ variantFunctionalConsequence, variantId }) => {
+        const pvparams = variantId?.split('_') || [];
+        return (
+          <>
             <Link
               external
-              to = {`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
-              className={classes.chipLink}
+              to={`http://www.sequenceontology.org/browser/current_svn/term/${variantFunctionalConsequence.id}`}
             >
-              <Chip label="ProtVar" size="small" color="primary" clickable variant="outlined" className={classes.xsmall}/>
+              {sentenceCase(variantFunctionalConsequence.label)}
             </Link>
-          ) : null
-        }
-      </>
-    )},
-    filterValue: ({ variantFunctionalConsequence }) =>
-      sentenceCase(variantFunctionalConsequence.label),
-  },
-  {
-    id: 'clinicalSignificances',
-    filterValue: ({ clinicalSignificances }) => clinicalSignificances.join(),
-    label: 'Clinical significance',
-    renderCell: ({ clinicalSignificances }) => {
-      if (!clinicalSignificances) return naLabel;
-      if (clinicalSignificances.length === 1)
-        return sentenceCase(clinicalSignificances[0]);
-      return (
-        <ul
-          style={{
-            margin: 0,
-            padding: 0,
-            listStyle: 'none',
-          }}
-        >
-          {clinicalSignificances.map(clinicalSignificance => (
-            <li key={clinicalSignificance}>
-              {sentenceCase(clinicalSignificance)}
-            </li>
-          ))}
-        </ul>
-      );
-    },
-  },
-  {
-    id: 'allelicRequirements',
-    label: 'Allele origin',
-    renderCell: ({ alleleOrigins, allelicRequirements }) => {
-      if (!alleleOrigins || alleleOrigins.length === 0) return naLabel;
-
-      if (allelicRequirements)
-        return (
-          <Tooltip
-            title={
-              <>
-                <Typography variant="subtitle2" display="block" align="center">
-                  Allelic requirements:
-                </Typography>
-                {allelicRequirements.map(r => (
-                  <Typography variant="caption" key={r}>
-                    {r}
-                  </Typography>
-                ))}
-              </>
+            {
+              // could also check agains functional consequence ID,
+              // but the "missense_variant" label is also reliable
+              variantFunctionalConsequence.label === 'missense_variant' &&
+              pvparams.length == 4 ? (
+                <Link
+                  external
+                  to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+                  className={classes.chipLink}
+                >
+                  <Chip
+                    label="ProtVar"
+                    size="small"
+                    color="primary"
+                    clickable
+                    variant="outlined"
+                    className={classes.xsmall}
+                  />
+                </Link>
+              ) : null
             }
-            showHelpIcon
-          >
-            {alleleOrigins.map(a => sentenceCase(a)).join('; ')}
-          </Tooltip>
+          </>
         );
-
-      return alleleOrigins.map(a => sentenceCase(a)).join('; ');
+      },
+      filterValue: ({ variantFunctionalConsequence }) =>
+        sentenceCase(variantFunctionalConsequence.label),
     },
-    filterValue: ({ alleleOrigins }) =>
-      alleleOrigins ? alleleOrigins.join() : '',
-  },
-  {
-    id: 'confidence',
-    label: 'Review status',
-    renderCell: ({ confidence }) => (
-      <Tooltip title={confidence}>
-        <span>
-          <ClinvarStars num={clinvarStarMap[confidence]} />
-        </span>
-      </Tooltip>
-    ),
-  },
-  {
-    label: 'Literature',
-    renderCell: ({ literature }) => {
-      const literatureList =
-        literature?.reduce((acc, id) => {
-          if (id !== 'NA') {
-            acc.push({
-              name: id,
-              url: epmcUrl(id),
-              group: 'literature',
-            });
-          }
-          return acc;
-        }, []) || [];
-
-      return <PublicationsDrawer entries={literatureList} />;
+    {
+      id: 'clinicalSignificances',
+      filterValue: ({ clinicalSignificances }) => clinicalSignificances.join(),
+      label: 'Clinical significance',
+      renderCell: ({ clinicalSignificances }) => {
+        if (!clinicalSignificances) return naLabel;
+        if (clinicalSignificances.length === 1)
+          return sentenceCase(clinicalSignificances[0]);
+        return (
+          <ul
+            style={{
+              margin: 0,
+              padding: 0,
+              listStyle: 'none',
+            }}
+          >
+            {clinicalSignificances.map(clinicalSignificance => (
+              <li key={clinicalSignificance}>
+                {sentenceCase(clinicalSignificance)}
+              </li>
+            ))}
+          </ul>
+        );
+      },
     },
-  },
-];
+    {
+      id: 'allelicRequirements',
+      label: 'Allele origin',
+      renderCell: ({ alleleOrigins, allelicRequirements }) => {
+        if (!alleleOrigins || alleleOrigins.length === 0) return naLabel;
+
+        if (allelicRequirements)
+          return (
+            <Tooltip
+              title={
+                <>
+                  <Typography
+                    variant="subtitle2"
+                    display="block"
+                    align="center"
+                  >
+                    Allelic requirements:
+                  </Typography>
+                  {allelicRequirements.map(r => (
+                    <Typography variant="caption" key={r}>
+                      {r}
+                    </Typography>
+                  ))}
+                </>
+              }
+              showHelpIcon
+            >
+              {alleleOrigins.map(a => sentenceCase(a)).join('; ')}
+            </Tooltip>
+          );
+
+        return alleleOrigins.map(a => sentenceCase(a)).join('; ');
+      },
+      filterValue: ({ alleleOrigins }) =>
+        alleleOrigins ? alleleOrigins.join() : '',
+    },
+    {
+      id: 'confidence',
+      label: 'Review status',
+      renderCell: ({ confidence }) => (
+        <Tooltip title={confidence}>
+          <span>
+            <ClinvarStars num={clinvarStarMap[confidence]} />
+          </span>
+        </Tooltip>
+      ),
+    },
+    {
+      label: 'Literature',
+      renderCell: ({ literature }) => {
+        const literatureList =
+          literature?.reduce((acc, id) => {
+            if (id !== 'NA') {
+              acc.push({
+                name: id,
+                url: epmcUrl(id),
+                group: 'literature',
+              });
+            }
+            return acc;
+          }, []) || [];
+
+        return <PublicationsDrawer entries={literatureList} />;
+      },
+    },
+  ];
 }
 
 function fetchClinvar(ensemblId, efoId, cursor, size) {

--- a/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
@@ -26,231 +26,243 @@ const useStyles = makeStyles({
   },
   chipLink: {
     marginLeft: '5px',
-  }
+  },
 });
 
 function getColumns(classes) {
   return [
-  {
-    id: 'disease',
-    label: 'Disease/phenotype',
-    renderCell: ({ disease }) => (
-      <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
-    ),
-    filterValue: ({ disease }) => disease.name,
-  },
-  {
-    id: 'diseaseFromSource',
-    label: 'Reported disease/phenotype',
-    renderCell: ({ diseaseFromSource, studyId }) => {
-      const parsedDiseaseFromSource = diseaseFromSource.replace(/['"]+/g, '');
-      return (
-        <Link external to={otgStudyUrl(studyId)}>
-          {diseaseFromSource ? parsedDiseaseFromSource : studyId}
-        </Link>
-      );
+    {
+      id: 'disease',
+      label: 'Disease/phenotype',
+      renderCell: ({ disease }) => (
+        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      ),
+      filterValue: ({ disease }) => disease.name,
     },
-  },
-  {
-    id: 'literature',
-    label: 'Publication',
-    renderCell: ({ literature, publicationYear, publicationFirstAuthor }) => {
-      if (!literature) return naLabel;
-      return (
-        <PublicationsDrawer
-          entries={[{ name: literature[0] }]}
-          customLabel={`${publicationFirstAuthor} et al, ${publicationYear}`}
-        />
-      );
+    {
+      id: 'diseaseFromSource',
+      label: 'Reported disease/phenotype',
+      renderCell: ({ diseaseFromSource, studyId }) => {
+        const parsedDiseaseFromSource = diseaseFromSource.replace(/['"]+/g, '');
+        return (
+          <Link external to={otgStudyUrl(studyId)}>
+            {diseaseFromSource ? parsedDiseaseFromSource : studyId}
+          </Link>
+        );
+      },
     },
-    filterValue: ({ literature, publicationYear, publicationFirstAuthor }) =>
-      `${literature} ${publicationYear} ${publicationFirstAuthor}`,
-  },
-  {
-    id: 'studySource',
-    label: 'Study source',
-    renderCell: ({ projectId }) => {
-      if (!projectId) return naLabel;
-      if (Object.keys(studySourceMap).indexOf(projectId) < 0) return naLabel;
-      return studySourceMap[projectId];
+    {
+      id: 'literature',
+      label: 'Publication',
+      renderCell: ({ literature, publicationYear, publicationFirstAuthor }) => {
+        if (!literature) return naLabel;
+        return (
+          <PublicationsDrawer
+            entries={[{ name: literature[0] }]}
+            customLabel={`${publicationFirstAuthor} et al, ${publicationYear}`}
+          />
+        );
+      },
+      filterValue: ({ literature, publicationYear, publicationFirstAuthor }) =>
+        `${literature} ${publicationYear} ${publicationFirstAuthor}`,
     },
-  },
-  {
-    id: 'variantId',
-    label: 'Variant ID (RSID)',
-    renderCell: ({ variantId, variantRsId }) => (
-      <>
-        {variantId ? (
-          <Link external to={otgVariantUrl(variantId)}>
-            {variantId}
+    {
+      id: 'studySource',
+      label: 'Study source',
+      renderCell: ({ projectId }) => {
+        if (!projectId) return naLabel;
+        if (Object.keys(studySourceMap).indexOf(projectId) < 0) return naLabel;
+        return studySourceMap[projectId];
+      },
+    },
+    {
+      id: 'variantId',
+      label: 'Variant ID (RSID)',
+      renderCell: ({ variantId, variantRsId }) => (
+        <>
+          {variantId ? (
+            <Link external to={otgVariantUrl(variantId)}>
+              {variantId}
+            </Link>
+          ) : (
+            naLabel
+          )}
+          {variantRsId ? (
+            <Typography variant="caption">
+              {' '}
+              (
+              <Link
+                external
+                to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+              >
+                {variantRsId}
+              </Link>
+              )
+            </Typography>
+          ) : null}
+        </>
+      ),
+      filterValue: ({ variantId, variantRsId }) =>
+        `${variantId} ${variantRsId}`,
+    },
+    {
+      id: 'variantFunctionalConsequenceId',
+      label: 'Functional Consequence',
+      renderCell: ({ variantFunctionalConsequence, variantId }) => {
+        const pvparams = variantId?.split('_') || [];
+        return variantFunctionalConsequence ? (
+          <>
+            <Link
+              external
+              to={identifiersOrgLink(
+                'SO',
+                variantFunctionalConsequence.id.slice(3)
+              )}
+            >
+              {sentenceCase(variantFunctionalConsequence.label)}
+            </Link>
+
+            {
+              // could also check agains functional consequence ID,
+              // but the "missense_variant" label is also reliable
+              variantFunctionalConsequence.label === 'missense_variant' &&
+              pvparams.length == 4 ? (
+                <Link
+                  external
+                  to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+                  className={classes.chipLink}
+                >
+                  <Chip
+                    label="ProtVar"
+                    size="small"
+                    color="primary"
+                    clickable
+                    variant="outlined"
+                    className={classes.xsmall}
+                  />
+                </Link>
+              ) : null
+            }
+          </>
+        ) : (
+          naLabel
+        );
+      },
+      filterValue: ({ variantFunctionalConsequence }) =>
+        `${sentenceCase(variantFunctionalConsequence.label)} ${
+          variantFunctionalConsequence.id
+        }`,
+    },
+    {
+      id: 'variantFunctionalConsequenceFromQtlId',
+      label: 'QTL effect',
+      tooltip:
+        'The direction is inferred from the strongest effect across all the co-localising QTLs',
+      renderCell: ({ variantFunctionalConsequenceFromQtlId }) =>
+        variantFunctionalConsequenceFromQtlId ? (
+          <Link
+            external
+            to={identifiersOrgLink(
+              'SO',
+              variantFunctionalConsequenceFromQtlId.id.slice(3)
+            )}
+          >
+            {sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
           </Link>
         ) : (
           naLabel
-        )}
-        {variantRsId ? (
-          <Typography variant="caption">
-            {' '}
-            (
-            <Link
-              external
-              to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
-            >
-              {variantRsId}
-            </Link>
-            )
-          </Typography>
-        ) : null}
-      </>
-    ),
-    filterValue: ({ variantId, variantRsId }) => `${variantId} ${variantRsId}`,
-  },
-  {
-    id: 'variantFunctionalConsequenceId',
-    label: 'Functional Consequence',
-    renderCell: ({ variantFunctionalConsequence, variantId }) =>
-      { 
-        const pvparams = variantId?.split('_') || [];
-        return (
-        variantFunctionalConsequence ? (
-          <>
-        <Link
-          external
-          to={identifiersOrgLink(
-            'SO',
-            variantFunctionalConsequence.id.slice(3)
-          )}
-        >
-          {sentenceCase(variantFunctionalConsequence.label)}
-        </Link>
-
-        { 
-          // could also check agains functional consequence ID, 
-          // but the "missense_variant" label is also reliable
-          (variantFunctionalConsequence.label === 'missense_variant' && pvparams.length==4) ? (
-            <Link
-              external
-              to = {`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
-              className={classes.chipLink}
-            >
-              <Chip label="ProtVar" size="small" color="primary" clickable variant="outlined" className={classes.xsmall}/>
-            </Link>
-          ) : null
-        }
-</>
-      ) : (
-        naLabel
-      ))},
-    filterValue: ({ variantFunctionalConsequence }) =>
-      `${sentenceCase(variantFunctionalConsequence.label)} ${
-        variantFunctionalConsequence.id
-      }`,
-  },
-  {
-    id: 'variantFunctionalConsequenceFromQtlId',
-    label: 'QTL effect',
-    tooltip:
-      'The direction is inferred from the strongest effect across all the co-localising QTLs',
-    renderCell: ({ variantFunctionalConsequenceFromQtlId }) =>
-      variantFunctionalConsequenceFromQtlId ? (
-        <Link
-          external
-          to={identifiersOrgLink(
-            'SO',
-            variantFunctionalConsequenceFromQtlId.id.slice(3)
-          )}
-        >
-          {sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
-        </Link>
-      ) : (
-        naLabel
+        ),
+      filterValue: ({ variantFunctionalConsequenceFromQtlId }) =>
+        variantFunctionalConsequenceFromQtlId
+          ? `${sentenceCase(variantFunctionalConsequenceFromQtlId.label)} ${
+              variantFunctionalConsequenceFromQtlId.id
+            }`
+          : naLabel,
+    },
+    {
+      id: 'pValueMantissa',
+      label: (
+        <>
+          Association <i>p</i>-value
+        </>
       ),
-    filterValue: ({ variantFunctionalConsequenceFromQtlId }) =>
-      variantFunctionalConsequenceFromQtlId
-        ? `${sentenceCase(variantFunctionalConsequenceFromQtlId.label)} ${
-            variantFunctionalConsequenceFromQtlId.id
-          }`
-        : naLabel,
-  },
-  {
-    id: 'pValueMantissa',
-    label: (
-      <>
-        Association <i>p</i>-value
-      </>
-    ),
-    numeric: true,
-    sortable: true,
-    renderCell: ({ pValueMantissa, pValueExponent }) => (
-      <ScientificNotation number={[pValueMantissa, pValueExponent]} />
-    ),
-    comparator: (a, b) =>
-      a.pValueMantissa * 10 ** a.pValueExponent -
-      b.pValueMantissa * 10 ** b.pValueExponent,
-  },
-  {
-    id: 'studySampleSize',
-    label: 'Sample size',
-    numeric: true,
-    sortable: true,
-    renderCell: ({ studySampleSize }) =>
-      studySampleSize ? parseInt(studySampleSize, 10).toLocaleString() : naLabel,
-  },
-  {
-    id: 'oddsRatio',
-    label: 'Odds Ratio (CI 95%)',
-    numeric: true,
-    renderCell: ({
-      oddsRatio,
-      oddsRatioConfidenceIntervalLower,
-      oddsRatioConfidenceIntervalUpper,
-    }) => {
-      const ci =
-        oddsRatioConfidenceIntervalLower && oddsRatioConfidenceIntervalUpper
-          ? `(${parseFloat(
-              oddsRatioConfidenceIntervalLower.toFixed(3)
-            )}, ${parseFloat(oddsRatioConfidenceIntervalUpper.toFixed(3))})`
-          : '';
-      return oddsRatio ? `${parseFloat(oddsRatio.toFixed(3))} ${ci}` : naLabel;
+      numeric: true,
+      sortable: true,
+      renderCell: ({ pValueMantissa, pValueExponent }) => (
+        <ScientificNotation number={[pValueMantissa, pValueExponent]} />
+      ),
+      comparator: (a, b) =>
+        a.pValueMantissa * 10 ** a.pValueExponent -
+        b.pValueMantissa * 10 ** b.pValueExponent,
     },
-  },
-  {
-    id: 'betaConfidenceInterval',
-    label: 'Beta (CI 95%)',
-    numeric: true,
-    renderCell: ({
-      beta,
-      betaConfidenceIntervalLower,
-      betaConfidenceIntervalUpper,
-    }) => {
-      const ci =
-        betaConfidenceIntervalLower && betaConfidenceIntervalUpper
-          ? `(${parseFloat(
-              betaConfidenceIntervalLower.toFixed(3)
-            )}, ${parseFloat(betaConfidenceIntervalUpper.toFixed(3))})`
-          : '';
-      return beta ? `${parseFloat(beta.toFixed(3))} ${ci}` : naLabel;
+    {
+      id: 'studySampleSize',
+      label: 'Sample size',
+      numeric: true,
+      sortable: true,
+      renderCell: ({ studySampleSize }) =>
+        studySampleSize
+          ? parseInt(studySampleSize, 10).toLocaleString()
+          : naLabel,
     },
-  },
-  {
-    id: 'resourceScore',
-    label: 'L2G score',
-    tooltip: (
-      <>
-        Causal inference score - see{' '}
-        <Link
-          external
-          to="https://platform-docs.opentargets.org/evidence#open-targets-genetics-portal"
-        >
-          our documentation
-        </Link>{' '}
-        for more information.
-      </>
-    ),
-    numeric: true,
-    sortable: true,
-    renderCell: ({ resourceScore }) => parseFloat(resourceScore.toFixed(5)),
-  },
-];
+    {
+      id: 'oddsRatio',
+      label: 'Odds Ratio (CI 95%)',
+      numeric: true,
+      renderCell: ({
+        oddsRatio,
+        oddsRatioConfidenceIntervalLower,
+        oddsRatioConfidenceIntervalUpper,
+      }) => {
+        const ci =
+          oddsRatioConfidenceIntervalLower && oddsRatioConfidenceIntervalUpper
+            ? `(${parseFloat(
+                oddsRatioConfidenceIntervalLower.toFixed(3)
+              )}, ${parseFloat(oddsRatioConfidenceIntervalUpper.toFixed(3))})`
+            : '';
+        return oddsRatio
+          ? `${parseFloat(oddsRatio.toFixed(3))} ${ci}`
+          : naLabel;
+      },
+    },
+    {
+      id: 'betaConfidenceInterval',
+      label: 'Beta (CI 95%)',
+      numeric: true,
+      renderCell: ({
+        beta,
+        betaConfidenceIntervalLower,
+        betaConfidenceIntervalUpper,
+      }) => {
+        const ci =
+          betaConfidenceIntervalLower && betaConfidenceIntervalUpper
+            ? `(${parseFloat(
+                betaConfidenceIntervalLower.toFixed(3)
+              )}, ${parseFloat(betaConfidenceIntervalUpper.toFixed(3))})`
+            : '';
+        return beta ? `${parseFloat(beta.toFixed(3))} ${ci}` : naLabel;
+      },
+    },
+    {
+      id: 'resourceScore',
+      label: 'L2G score',
+      tooltip: (
+        <>
+          Causal inference score - see{' '}
+          <Link
+            external
+            to="https://platform-docs.opentargets.org/evidence#open-targets-genetics-portal"
+          >
+            our documentation
+          </Link>{' '}
+          for more information.
+        </>
+      ),
+      numeric: true,
+      sortable: true,
+      renderCell: ({ resourceScore }) => parseFloat(resourceScore.toFixed(5)),
+    },
+  ];
 }
 
 export function BodyCore({ definition, id, label, count }) {
@@ -258,7 +270,7 @@ export function BodyCore({ definition, id, label, count }) {
   const variables = { ensemblId: ensgId, efoId, size: count };
   const classes = useStyles();
   const columns = getColumns(classes);
-  
+
   const request = useQuery(OPEN_TARGETS_GENETICS_QUERY, {
     variables,
   });


### PR DESCRIPTION
# [Platform]: add chip+link (ProtVar) to OTGenetics and ClinVar widgets

## Description

Add a chip to link out to ProtVar from the Functional consequence field, when this is "missense variant".
Both widgets display the same chip/logic and this could be refactored in a separate component, but in the interest of time I'll leave that for after the release.

**Issue:** https://github.com/opentargets/issues/issues/2948
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] /evidence/ENSG00000167207/EFO_0000384 shows both widgets

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
