### PR TITLE
[Platform]: Update DepMap widget with correct data from API

### DIFF
--- a/apps/platform/src/pages/TargetPage/TargetProfileHeader.gql
+++ b/apps/platform/src/pages/TargetPage/TargetProfileHeader.gql
@@ -4,4 +4,5 @@ fragment TargetProfileHeaderFragment on Target {
     source
   }
   functionDescriptions
+  isEssential
 }

--- a/apps/platform/src/sections/target/DepMap/Body.jsx
+++ b/apps/platform/src/sections/target/DepMap/Body.jsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { useQuery } from '@apollo/client';
 import Description from './Description';
 import SectionItem from '../../../components/Section/SectionItem';
@@ -6,14 +5,10 @@ import DepmapPlot from './DepmapPlot';
 
 import DEPMAP_QUERY from './Depmap.gql';
 
-// TODO: temporary sample data
-import data0 from './data/data.json';
 
 function Section({ definition, id, label: symbol }) {
   const variables = { ensemblId: id };
   const request = useQuery(DEPMAP_QUERY, { variables });
-
-  const { depMapEssentiality } = data0;
 
   return (
     <SectionItem
@@ -21,10 +16,9 @@ function Section({ definition, id, label: symbol }) {
       request={request}
       renderDescription={() => <Description symbol={symbol} />}
       renderBody={data => {
-        // TODO: depMapEssentiality will come from data
         return (
           <>
-            <DepmapPlot data={depMapEssentiality} />
+            <DepmapPlot data={data.target.depMapEssentiality} />
           </>
         );
       }}

--- a/apps/platform/src/sections/target/DepMap/Depmap.gql
+++ b/apps/platform/src/sections/target/DepMap/Depmap.gql
@@ -1,18 +1,14 @@
-# TODO: update with correct query when ready
-query Hallmarks($ensemblId: String!) {
+query Depmap ($ensemblId: String!) {
   target(ensemblId: $ensemblId) {
     id
-    hallmarks {
-      attributes {
-        name
-        pmid
-        description
-      }
-      cancerHallmarks {
-        pmid
-        impact
-        description
-        label
+    depMapEssentiality {
+      tissueName
+      screens{
+        depmapId
+        cellLineName
+        diseaseFromSource
+        geneEffect
+        expression
       }
     }
   }

--- a/apps/platform/src/sections/target/DepMap/DepmapSummaryFragment.gql
+++ b/apps/platform/src/sections/target/DepMap/DepmapSummaryFragment.gql
@@ -1,9 +1,5 @@
-# TODO: update with correct query when ready
-fragment CancerHallmarksSummaryFragment on Target {
-  hallmarks {
-    cancerHallmarks {
-      impact
-      label
-    }
+fragment DepmapSummaryFragment on Target {
+  depMapEssentiality{
+    tissueName
   }
 }

--- a/apps/platform/src/sections/target/DepMap/Description.jsx
+++ b/apps/platform/src/sections/target/DepMap/Description.jsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import Link from '../../../components/Link';
 
 function Description({ symbol }) {

--- a/apps/platform/src/sections/target/DepMap/Summary.jsx
+++ b/apps/platform/src/sections/target/DepMap/Summary.jsx
@@ -1,17 +1,11 @@
-import React from 'react';
 import _ from 'lodash';
 
 import usePlatformApi from '../../../hooks/usePlatformApi';
 import SummaryItem from '../../../components/Summary/SummaryItem';
 
-// TODO: import correct fragment when available
 import DEPMAP_SUMMARY_FRAGMENT from './DepmapSummaryFragment.gql';
 
-// TODO: temporary sample data
-import data0 from './data/data.json';
-
 function Summary({ definition }) {
-  // TODO: replace this
   const request = usePlatformApi(DEPMAP_SUMMARY_FRAGMENT);
 
   return (
@@ -19,10 +13,9 @@ function Summary({ definition }) {
       definition={definition}
       request={request}
       renderSummary={data => {
-        // TODO: use correct data
         return (
           <>
-            {data0.depMapEssentiality?.length} tissues
+            {data.depMapEssentiality?.length} tissues
           </>
         );
       }}
@@ -31,7 +24,7 @@ function Summary({ definition }) {
 }
 
 Summary.fragments = {
-  CancerHallmarksSummaryFragment: DEPMAP_SUMMARY_FRAGMENT,
+  DepmapSummaryFragment: DEPMAP_SUMMARY_FRAGMENT,
 };
 
 export default Summary;

--- a/apps/platform/src/sections/target/DepMap/index.js
+++ b/apps/platform/src/sections/target/DepMap/index.js
@@ -2,7 +2,7 @@ export const definition = {
   id: 'depMapEssentiality',
   name: 'Cancer DepMap',
   shortName: 'DM',
-  hasData: data => true, //data => data.hallmarks?.cancerHallmarks?.length > 0,
+  hasData: data => data.depMapEssentiality?.length > 0,
 };
 
 export { default as Summary } from './Summary';


### PR DESCRIPTION
# [Platform]: Update DepMap widget with correct data from API

## Description

Pull DepMap / essentiality target data from API and update widget:

- update target profile header query to display the "core essential gene" chip in the target description
- update DepMap widget queries with correct API fields
- update widget with correct "data" object
- remove sample data from code

**Issue:** https://github.com/opentargets/issues/issues/2917
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I've checked the profile page for different genes, comparing the widget's plot to the one on the DepMap website

- [ ] H2AC15 has "core essential gene" chip: 
- [ ] BRAF does not: 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
