### PR TITLE
[Genetics]: Fix download table on study-comparison page

### DIFF
--- a/apps/genetics/src/components/ManhattansVariantsTable.jsx
+++ b/apps/genetics/src/components/ManhattansVariantsTable.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Link, OtTable } from '../ot-ui-components';
+import { Link, OtTableRF, DataDownloader } from '../ot-ui-components';
 
 import variantIdComparator from '../logic/variantIdComparator';
 import cytobandComparator from '../logic/cytobandComparator';
@@ -69,15 +69,29 @@ function ManhattansVariantsTable({
       cytoband: getCytoband(chromosome, position),
     };
   });
+  const downloadData = dataWithCytoband.map(row => {
+    console.log(row);
+    return {
+      ...row,
+      bestGenes: row.bestGenes.map(d => d.gene.symbol).join(', '),
+    }
+  });
+
   return (
-    <OtTable
+    <OtTableRF
+      right={
+        <DataDownloader
+        tableHeaders={tableColumns(studyIds)}
+        rows={downloadData}
+        fileStem={filenameStem}
+        />
+      }
       loading={loading}
       error={error}
       columns={tableColumns(studyIds)}
       data={dataWithCytoband}
       sortBy="indexVariantId"
       order="asc"
-      downloadFileStem={filenameStem}
       message="Loci in this table are shared across all selected studies."
     />
   );

--- a/apps/genetics/src/ot-ui-components/components/OtTableRF.jsx
+++ b/apps/genetics/src/ot-ui-components/components/OtTableRF.jsx
@@ -234,6 +234,7 @@ class OtTableRF extends Component {
       verticalHeaders,
       classes,
       left,
+      right,
       center,
       message,
       filters,
@@ -258,6 +259,7 @@ class OtTableRF extends Component {
         loading={loading}
         error={error}
         left={left}
+        right={right}
         center={center}
       >
         {message ? (


### PR DESCRIPTION
# [Genetics]: Fix download table on study-comparison page

## Description
The "Top Ranked Genes" in the `CSV` and `TSV` download files from the table on the study-comparison page (https://genetics.opentargets.org/study-comparison/GCST002222) show as `[object Object]`. 

This PR fixes this issue by using `OtTableRF` (instead of `OtTable`) in combination with the `DataDownloader`.
This minor change allowed to make a distinction between the data in the table (`dataWithCytoband`) and the data that is actually downloaded (`downloadData`). The "Top Ranked Genes" (or `bestGenes`) in `downloadData` contains a string of gene symbols instead of objects.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [ ] Download `CSV` or `TSV` from https://genetics.opentargets.org/study-comparison/GCST002222 to see the `[object Object]` in "Top Ranked Genes".
- [ ] Run `yarn dev:genetics` with the code in this PR and download the `CSV` or `TSV` table to confirm the issue is solved.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
