### PR TITLE
Update downloads-map with target essentiality and target priorisation datasets

### DIFF
--- a/apps/platform/src/pages/DownloadsPage/dataset-mappings.json
+++ b/apps/platform/src/pages/DownloadsPage/dataset-mappings.json
@@ -313,5 +313,23 @@
    "order": null,
    "include_in_fe": false,
    "include_in_bq": false
+ },
+ {
+   "id": "targetsPriorisation",
+   "category": "Target",
+   "nice_name": "n/a",
+   "description": "------- I have no idea how to describe this -------",
+   "order": null,
+   "include_in_fe": false,
+   "include_in_bq": true
+ },
+{
+   "id": "targetEssentiality",
+   "category": "Target",
+   "nice_name": "n/a",
+   "description": "------- I have no idea how to describe this -------",
+   "order": null,
+   "include_in_fe": false,
+   "include_in_bq": true
  }
 ]


### PR DESCRIPTION
# [Platform] Update downloads-map with target essentiality and target priorisation datasets
This PR updates the downloads mapping with the new _targets essentiality_ and _target priorisation_ outputs from the ETL.

## Description

I have updated the _dataset-mappings.json_ file to include two new entries, but they need to be finalised becuase I didn't knwo how to best describe them, e.g. 'nice_name' and 'description' attributes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
The format has been preserved but it's not been tested on the web frontend.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
