### PR TITLE
[Platform]: add chip style to QTL column in OT Genetics evidence widget

### DIFF
--- a/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
@@ -175,10 +175,17 @@ function getColumns(classes) {
               variantFunctionalConsequenceFromQtlId.id.slice(3)
             )}
           >
-            {sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
+            <Chip
+                label={sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
+                size="small"
+                color="primary"
+                clickable
+                variant="outlined"
+                className={classes.xsmall}
+              />
           </Link>
         ) : (
-          naLabel
+          ''
         ),
       filterValue: ({ variantFunctionalConsequenceFromQtlId }) =>
         variantFunctionalConsequenceFromQtlId


### PR DESCRIPTION
# [Platform]: add chip style to QTL column in OT Genetics evidence widget

## Description

As per title, change the look of the link to a chip in the OT Genetics evidence widget "QTL effect" column. Also show empty cell instead of "N/A".

**Issue:** no issue
**Deploy preview:** https://deploy-preview-172--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] https://deploy-preview-172--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
