### PR TITLE
[Platform]: Next view of the associations page crashing

### DIFF
--- a/apps/platform/src/pages/DiseasePage/ClassicAssociationsTable.jsx
+++ b/apps/platform/src/pages/DiseasePage/ClassicAssociationsTable.jsx
@@ -277,7 +277,7 @@ function ClassicAssociationsTable({ efoId, aggregationFilters }) {
     'data.disease.associatedTargets'
   );
 
-  function handlePageChange(pageChanged) {
+  const handlePageChange = pageChanged => {
     setLoading(true);
     client
       .query({
@@ -296,21 +296,22 @@ function ClassicAssociationsTable({ efoId, aggregationFilters }) {
         setPage(pageChanged);
         setLoading(false);
       });
-  }
+  };
 
-  function handleRowsPerPageChange(pageSizeChanged) {
-    setPageSize(pageSizeChanged);
-  }
+  const handleRowsPerPageChange = pageSizeChanged => {
+    const newPageSize = Number(pageSizeChanged);
+    setPageSize(newPageSize);
+  };
 
-  function handleSort(sortChanged) {
+  const handleSort = sortChanged => {
     setSortBy(sortChanged);
-  }
+  };
 
-  function handleGlobalFilterChange(newFilter) {
+  const handleGlobalFilterChange = newFilter => {
     if (newFilter !== filter) {
       setFilter(newFilter);
     }
-  }
+  };
 
   const columns = getColumns(efoId, classes, isPartnerPreview);
   const processedRows = getRows(rows);
@@ -335,10 +336,10 @@ function ClassicAssociationsTable({ efoId, aggregationFilters }) {
         pageSize={pageSize}
         rowCount={count}
         rowsPerPageOptions={[10, 50, 200, 500]}
-        onGlobalFilterChange={()=>handleGlobalFilterChange()}
-        onSortBy={()=>handleSort()}
-        onPageChange={()=>handlePageChange()}
-        onRowsPerPageChange={()=>handleRowsPerPageChange()}
+        onGlobalFilterChange={handleGlobalFilterChange}
+        onSortBy={handleSort}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
       />
       <Legend />
     </>

--- a/apps/platform/src/pages/TargetPage/ClassicAssociationsTable.jsx
+++ b/apps/platform/src/pages/TargetPage/ClassicAssociationsTable.jsx
@@ -243,7 +243,7 @@ function ClassicAssociationsTable({ ensgId, aggregationFilters }) {
     'data.target.associatedDiseases'
   );
 
-  function handlePageChange(pageChanged) {
+  const handlePageChange = pageChanged => {
     setLoading(true);
     client
       .query({
@@ -262,21 +262,22 @@ function ClassicAssociationsTable({ ensgId, aggregationFilters }) {
         setPage(pageChanged);
         setLoading(false);
       });
-  }
+  };
 
-  function handleRowsPerPageChange(pageSizeChanged) {
-    setPageSize(pageSizeChanged);
-  }
+  const handleRowsPerPageChange = pageSizeChanged => {
+    const newPageSize = Number(pageSizeChanged);
+    setPageSize(newPageSize);
+  };
 
-  function handleSort(sortChanged) {
+  const handleSort = sortChanged => {
     setSortBy(sortChanged);
-  }
+  };
 
-  function handleGlobalFilterChange(newFilter) {
+  const handleGlobalFilterChange = newFilter => {
     if (newFilter !== filter) {
       setFilter(newFilter);
     }
-  }
+  };
 
   if (initialLoading) return <Skeleton variant="rect" height="40vh" />;
 
@@ -301,10 +302,10 @@ function ClassicAssociationsTable({ ensgId, aggregationFilters }) {
         pageSize={pageSize}
         rowCount={count}
         rowsPerPageOptions={[10, 50, 200, 500]}
-        onGlobalFilterChange={() => handleGlobalFilterChange()}
-        onSortBy={() => handleSort()}
-        onPageChange={() => handlePageChange()}
-        onRowsPerPageChange={() => handleRowsPerPageChange()}
+        onGlobalFilterChange={handleGlobalFilterChange}
+        onSortBy={handleSort}
+        onPageChange={handlePageChange}
+        onRowsPerPageChange={handleRowsPerPageChange}
       />
       <Legend />
     </>


### PR DESCRIPTION
# [Platform]: Next view of the associations page crashing


## Description

Please include a summary of the change and which issue is fixed. List any dependencies that are required for this change.

**Issue:** https://github.com/opentargets/issues/issues/2996
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Check classic assoc page

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
