### PR TITLE
[Platform]: add ProtVar chip link to Uniprot Variants widget

### DIFF
--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { Typography } from '@material-ui/core';
+import { Typography, makeStyles, Chip } from '@material-ui/core';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 import { identifiersOrgLink } from '../../../utils/global';
 import Link from '../../../components/Link';
@@ -15,72 +15,105 @@ import { dataTypesMap } from '../../../dataTypes';
 
 import UNIPROT_VARIANTS_QUERY from './UniprotVariantsQuery.gql';
 
-const columns = [
-  {
-    id: 'disease.name',
-    label: 'Disease/phenotype',
-    renderCell: ({ disease, diseaseFromSource }) => (
-      <Tooltip
-        title={
-          <>
-            <Typography variant="subtitle2" display="block" align="center">
-              Reported disease or phenotype:
-            </Typography>
-            <Typography variant="caption" display="block" align="center">
-              {diseaseFromSource}
-            </Typography>
-          </>
-        }
-        showHelpIcon
-      >
-        <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
-      </Tooltip>
-    ),
+const useStyles = makeStyles({
+  xsmall: {
+    fontSize: '0.7rem',
   },
-  {
-    id: 'targetFromSourceId',
-    label: 'Reported protein',
-    renderCell: ({ targetFromSourceId }) => (
-      <Link external to={identifiersOrgLink('uniprot', targetFromSourceId)}>
-        {targetFromSourceId}
-      </Link>
-    ),
+  chipLink: {
+    marginLeft: '5px',
   },
-  {
-    id: 'variantRsId',
-    label: 'Variant',
-    renderCell: ({ variantRsId }) => (
-      <Link
-        external
-        to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
-      >
-        {variantRsId}
-      </Link>
-    ),
-  },
-  {
-    id: 'confidence',
-    label: 'Confidence',
-  },
-  {
-    label: 'Literature',
-    renderCell: ({ literature }) => {
-      const literatureList =
-        literature?.reduce((acc, id) => {
-          if (id !== 'NA') {
-            acc.push({
-              name: id,
-              url: epmcUrl(id),
-              group: 'literature',
-            });
-          }
-          return acc;
-        }, []) || [];
+});
 
-      return <PublicationsDrawer entries={literatureList} />;
+function getColumns(classes) {
+  return [
+    {
+      id: 'disease.name',
+      label: 'Disease/phenotype',
+      renderCell: ({ disease, diseaseFromSource }) => (
+        <Tooltip
+          title={
+            <>
+              <Typography variant="subtitle2" display="block" align="center">
+                Reported disease or phenotype:
+              </Typography>
+              <Typography variant="caption" display="block" align="center">
+                {diseaseFromSource}
+              </Typography>
+            </>
+          }
+          showHelpIcon
+        >
+          <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+        </Tooltip>
+      ),
     },
-  },
-];
+    {
+      id: 'targetFromSourceId',
+      label: 'Reported protein',
+      renderCell: ({ targetFromSourceId }) => (
+        <Link external to={identifiersOrgLink('uniprot', targetFromSourceId)}>
+          {targetFromSourceId}
+        </Link>
+      ),
+    },
+    {
+      id: 'variantRsId',
+      label: 'Variant',
+      renderCell: ({ variantRsId }) => (
+        <Link
+          external
+          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+        >
+          {variantRsId}
+        </Link>
+      ),
+    },
+    {
+      id: 'variantFunctionalConsequenceId',
+      label: 'Functional Consequence',
+      renderCell: ({ variantRsId }) => {
+        return (
+          <Link
+            external
+            to={`https://www.ebi.ac.uk/ProtVar/query?search=${variantRsId}`}
+            className={classes.chipLink}
+          >
+            <Chip
+              label="ProtVar"
+              size="small"
+              color="primary"
+              clickable
+              variant="outlined"
+              className={classes.xsmall}
+            />
+          </Link>
+        );
+      },
+    },
+    {
+      id: 'confidence',
+      label: 'Confidence',
+    },
+    {
+      label: 'Literature',
+      renderCell: ({ literature }) => {
+        const literatureList =
+          literature?.reduce((acc, id) => {
+            if (id !== 'NA') {
+              acc.push({
+                name: id,
+                url: epmcUrl(id),
+                group: 'literature',
+              });
+            }
+            return acc;
+          }, []) || [];
+
+        return <PublicationsDrawer entries={literatureList} />;
+      },
+    },
+  ];
+}
 
 export function BodyCore({ definition, id, label, count }) {
   const { ensgId, efoId } = id;
@@ -90,6 +123,8 @@ export function BodyCore({ definition, id, label, count }) {
     efoId,
     size: count,
   };
+  const classes = useStyles();
+  const columns = getColumns(classes);
 
   const request = useQuery(UNIPROT_VARIANTS_QUERY, {
     variables,


### PR DESCRIPTION
# [Platform]: add ProtVar chip link to Uniprot Variants widget

## Description

Update UniProt Variants evidence widget: add column with chip linkout to ProtVar website.

**Issue:** no issue available
**Deploy preview:** https://deploy-preview-175--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [ ] See UniProt Variants widget on https://deploy-preview-175--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
