### PR TITLE
# [Platform]: Update functional consequence to variant consequence with label-chip

### DIFF
--- a/apps/platform/src/components/LabelChip.jsx
+++ b/apps/platform/src/components/LabelChip.jsx
@@ -1,0 +1,46 @@
+import { Typography } from '@material-ui/core';
+import OTTooltip from './Tooltip';
+
+function LabelChip({ label, value, to, tooltip = null }) {
+  const containerStyle = {
+    display: 'flex',
+    borderRadius: '5px',
+    border: '1px solid #3489ca',
+    overflow: 'hidden',
+    color: '#3489ca',
+    margin: '3px 0',
+    textDecoration: 'none',
+  };
+  const commonStyle = {
+    padding: '0 5px',
+    '&:hover': {},
+  };
+  const labelStyle = {
+    ...commonStyle,
+    backgroundColor: '#3489ca',
+    color: 'white',
+  };
+  const valueStyle = {
+    ...commonStyle,
+    backgroundColor: 'white',
+    borderLeft: '1px solid #3489ca',
+  };
+  return (
+    <OTTooltip title={tooltip} interactive={false}>
+      <a href={to} style={containerStyle}>
+        {label && (
+          <div style={labelStyle}>
+            <Typography variant="caption">{label}</Typography>
+          </div>
+        )}
+        {value && (
+          <div style={valueStyle}>
+            <Typography variant="caption">{value}</Typography>
+          </div>
+        )}
+      </a>
+    </OTTooltip>
+  );
+}
+
+export default LabelChip;

--- a/apps/platform/src/constants.js
+++ b/apps/platform/src/constants.js
@@ -304,3 +304,16 @@ export const studySourceMap = {
   SAIGE: 'UK Biobank',
   NEALE: 'UK Biobank',
 };
+
+export const variantConsequenceSource = {
+  VEP: {
+    label: 'VEP',
+    tooltip: 'Ensembl variant effect predictor',
+  },
+  ProtVar: { label: 'ProtVar', tooltip: 'Variant effect on protein function' },
+  QTL: {
+    label: 'QTL',
+    tooltip:
+      'The direction is inferred from the strongest effect across all the co-localising QTLs',
+  },
+};

--- a/apps/platform/src/sections/evidence/EVA/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVA/Body.jsx
@@ -16,7 +16,7 @@ import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import Description from './Description';
 import Link from '../../../components/Link';
 import { epmcUrl } from '../../../utils/urls';
-import { sentenceCase } from '../../../utils/global';
+import { identifiersOrgLink, sentenceCase } from '../../../utils/global';
 import SectionItem from '../../../components/Section/SectionItem';
 import Tooltip from '../../../components/Tooltip';
 import usePlatformApi from '../../../hooks/usePlatformApi';

--- a/apps/platform/src/sections/evidence/EVA/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVA/Body.jsx
@@ -204,9 +204,8 @@ function getColumns() {
         //     }
         //   </>
         // );
-      },
-      filterValue: ({ variantFunctionalConsequence }) =>
-        `${sentenceCase(variantFunctionalConsequence.label)}, ${sentenceCase(variantFunctionalConsequenceFromQtlId.label)}`,
+      filterValue: ({ variantFunctionalConsequence, variantFunctionalConsequenceFromQtlId }) =>
+        (`${sentenceCase(variantFunctionalConsequence.label)}, ${sentenceCase(variantFunctionalConsequenceFromQtlId.label)}`),
     },
     {
       id: 'clinicalSignificances',

--- a/apps/platform/src/sections/evidence/EVA/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVA/Body.jsx
@@ -1,11 +1,13 @@
 import { useState, useEffect } from 'react';
-import { Typography, makeStyles, Chip } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import client from '../../../client';
 import ClinvarStars from '../../../components/ClinvarStars';
+import LabelChip from '../../../components/LabelChip';
 import {
   clinvarStarMap,
   naLabel,
   defaultRowsPerPageOptions,
+  variantConsequenceSource,
 } from '../../../constants';
 import { getPage, Table } from '../../../components/Table';
 import { getComparator } from '../../../components/Table/sortingAndFiltering';
@@ -24,16 +26,7 @@ import { dataTypesMap } from '../../../dataTypes';
 
 import CLINVAR_QUERY from './ClinvarQuery.gql';
 
-const useStyles = makeStyles({
-  xsmall: {
-    fontSize: '0.7rem',
-  },
-  chipLink: {
-    marginLeft: '5px',
-  },
-});
-
-function getColumns(classes) {
+function getColumns() {
   return [
     {
       id: 'disease.name',
@@ -127,51 +120,93 @@ function getColumns(classes) {
         ),
     },
     {
-      label: 'Functional consequence',
-      renderCell: ({ variantFunctionalConsequence, variantId }) => {
+      id: 'variantConsequence',
+      label: 'Variant Consequence',
+      renderCell: ({
+        variantFunctionalConsequence,
+        variantFunctionalConsequenceFromQtlId,
+        variantId,
+      }) => {
         const pvparams = variantId?.split('_') || [];
         return (
-          <>
-            <Link
-              external
-              to={`http://www.sequenceontology.org/browser/current_svn/term/${variantFunctionalConsequence.id}`}
-            >
-              <Chip
-                label={sentenceCase(variantFunctionalConsequence.label)}
-                size="small"
-                color="primary"
-                clickable
-                variant="outlined"
-                className={classes.xsmall}
+          <div style={{ display: 'flex', gap: '5px' }}>
+            {variantFunctionalConsequence && (
+              <LabelChip
+                label={variantConsequenceSource.VEP.label}
+                value={sentenceCase(variantFunctionalConsequence.label)}
+                tooltip={variantConsequenceSource.VEP.tooltip}
+                to={identifiersOrgLink(
+                  'SO',
+                  variantFunctionalConsequence.id.slice(3)
+                )}
               />
-            </Link>
-            {
-              // add linkout to ProtVar for specific functional consequence values:
-              // "missense variant", "stop gained"
-              (variantFunctionalConsequence.id === 'SO:0001583' ||
-                variantFunctionalConsequence.id === 'SO:0001587') &&
-              pvparams.length == 4 ? (
-                <Link
-                  external
-                  to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
-                  className={classes.chipLink}
-                >
-                  <Chip
-                    label="ProtVar"
-                    size="small"
-                    color="primary"
-                    clickable
-                    variant="outlined"
-                    className={classes.xsmall}
-                  />
-                </Link>
-              ) : null
-            }
-          </>
+            )}
+            {variantFunctionalConsequenceFromQtlId && (
+              <LabelChip
+                label={variantConsequenceSource.QTL.label}
+                value={sentenceCase(
+                  variantFunctionalConsequenceFromQtlId.label
+                )}
+                to={identifiersOrgLink(
+                  'SO',
+                  variantFunctionalConsequenceFromQtlId.id.slice(3)
+                )}
+                tooltip={variantConsequenceSource.QTL.tooltip}
+              />
+            )}
+            {(variantFunctionalConsequence.id === 'SO:0001583' ||
+              variantFunctionalConsequence.id === 'SO:0001587') && (
+              <LabelChip
+                label={variantConsequenceSource.ProtVar.label}
+                to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+                tooltip={variantConsequenceSource.ProtVar.tooltip}
+              />
+            )}
+          </div>
         );
       },
+        // return (
+        //   <>
+        //     <Link
+        //       external
+        //       to={`http://www.sequenceontology.org/browser/current_svn/term/${variantFunctionalConsequence.id}`}
+        //     >
+        //       <Chip
+        //         label={sentenceCase(variantFunctionalConsequence.label)}
+        //         size="small"
+        //         color="primary"
+        //         clickable
+        //         variant="outlined"
+        //         className={classes.xsmall}
+        //       />
+        //     </Link>
+        //     {
+        //       // add linkout to ProtVar for specific functional consequence values:
+        //       // "missense variant", "stop gained"
+        //       (variantFunctionalConsequence.id === 'SO:0001583' ||
+        //         variantFunctionalConsequence.id === 'SO:0001587') &&
+        //       pvparams.length == 4 ? (
+        //         <Link
+        //           external
+        //           to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+        //           className={classes.chipLink}
+        //         >
+        //           <Chip
+        //             label="ProtVar"
+        //             size="small"
+        //             color="primary"
+        //             clickable
+        //             variant="outlined"
+        //             className={classes.xsmall}
+        //           />
+        //         </Link>
+        //       ) : null
+        //     }
+        //   </>
+        // );
+      },
       filterValue: ({ variantFunctionalConsequence }) =>
-        sentenceCase(variantFunctionalConsequence.label),
+        `${sentenceCase(variantFunctionalConsequence.label)}, ${sentenceCase(variantFunctionalConsequenceFromQtlId.label)}`,
     },
     {
       id: 'clinicalSignificances',
@@ -292,8 +327,7 @@ export function BodyCore({ definition, id, label }) {
   const [sortOrder, setSortOrder] = useState('asc');
   // const [globalFilter, setGlobalFilter] = useState('');
 
-  const classes = useStyles();
-  const columns = getColumns(classes);
+  const columns = getColumns();
 
   useEffect(() => {
     let isCurrent = true;

--- a/apps/platform/src/sections/evidence/EVA/Body.jsx
+++ b/apps/platform/src/sections/evidence/EVA/Body.jsx
@@ -165,45 +165,6 @@ function getColumns() {
           </div>
         );
       },
-        // return (
-        //   <>
-        //     <Link
-        //       external
-        //       to={`http://www.sequenceontology.org/browser/current_svn/term/${variantFunctionalConsequence.id}`}
-        //     >
-        //       <Chip
-        //         label={sentenceCase(variantFunctionalConsequence.label)}
-        //         size="small"
-        //         color="primary"
-        //         clickable
-        //         variant="outlined"
-        //         className={classes.xsmall}
-        //       />
-        //     </Link>
-        //     {
-        //       // add linkout to ProtVar for specific functional consequence values:
-        //       // "missense variant", "stop gained"
-        //       (variantFunctionalConsequence.id === 'SO:0001583' ||
-        //         variantFunctionalConsequence.id === 'SO:0001587') &&
-        //       pvparams.length == 4 ? (
-        //         <Link
-        //           external
-        //           to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
-        //           className={classes.chipLink}
-        //         >
-        //           <Chip
-        //             label="ProtVar"
-        //             size="small"
-        //             color="primary"
-        //             clickable
-        //             variant="outlined"
-        //             className={classes.xsmall}
-        //           />
-        //         </Link>
-        //       ) : null
-        //     }
-        //   </>
-        // );
       filterValue: ({ variantFunctionalConsequence, variantFunctionalConsequenceFromQtlId }) =>
         (`${sentenceCase(variantFunctionalConsequence.label)}, ${sentenceCase(variantFunctionalConsequenceFromQtlId.label)}`),
     },

--- a/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTGenetics/Body.jsx
@@ -1,12 +1,13 @@
 import { useQuery } from '@apollo/client';
-
-import { Typography, makeStyles, Chip } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import { DataTable } from '../../../components/Table';
 import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
+import LabelChip from '../../../components/LabelChip';
 import {
   defaultRowsPerPageOptions,
   naLabel,
   studySourceMap,
+  variantConsequenceSource,
 } from '../../../constants';
 import Description from './Description';
 import { otgStudyUrl, otgVariantUrl } from '../../../utils/urls';
@@ -20,16 +21,7 @@ import usePlatformApi from '../../../hooks/usePlatformApi';
 
 import OPEN_TARGETS_GENETICS_QUERY from './sectionQuery.gql';
 
-const useStyles = makeStyles({
-  xsmall: {
-    fontSize: '0.7rem',
-  },
-  chipLink: {
-    marginLeft: '5px',
-  },
-});
-
-function getColumns(classes) {
+function getColumns() {
   return [
     {
       id: 'disease',
@@ -106,93 +98,51 @@ function getColumns(classes) {
         `${variantId} ${variantRsId}`,
     },
     {
-      id: 'variantFunctionalConsequenceId',
-      label: 'Functional Consequence',
-      renderCell: ({ variantFunctionalConsequence, variantId }) => {
+      id: 'variantConsequence',
+      label: 'Variant Consequence',
+      renderCell: ({
+        variantFunctionalConsequence,
+        variantFunctionalConsequenceFromQtlId,
+        variantId,
+      }) => {
         const pvparams = variantId?.split('_') || [];
-        return variantFunctionalConsequence ? (
-          <>
-            <Link
-              external
-              to={identifiersOrgLink(
-                'SO',
-                variantFunctionalConsequence.id.slice(3)
-              )}
-            >
-              <Chip
-                label={sentenceCase(variantFunctionalConsequence.label)}
-                size="small"
-                color="primary"
-                clickable
-                variant="outlined"
-                className={classes.xsmall}
+        return (
+          <div style={{ display: 'flex', gap: '5px' }}>
+            {variantFunctionalConsequence && (
+              <LabelChip
+                label={variantConsequenceSource.VEP.label}
+                value={sentenceCase(variantFunctionalConsequence.label)}
+                tooltip={variantConsequenceSource.VEP.tooltip}
+                to={identifiersOrgLink(
+                  'SO',
+                  variantFunctionalConsequence.id.slice(3)
+                )}
               />
-            </Link>
-
-            {
-              // add linkout to ProtVar for specific functional consequence values:
-              // "missense variant", "stop gained"
-              (variantFunctionalConsequence.id === 'SO:0001583' ||
-                variantFunctionalConsequence.id === 'SO:0001587') &&
-              pvparams.length == 4 ? (
-                <Link
-                  external
-                  to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
-                  className={classes.chipLink}
-                >
-                  <Chip
-                    label="ProtVar"
-                    size="small"
-                    color="primary"
-                    clickable
-                    variant="outlined"
-                    className={classes.xsmall}
-                  />
-                </Link>
-              ) : null
-            }
-          </>
-        ) : (
-          naLabel
+            )}
+            {variantFunctionalConsequenceFromQtlId && (
+              <LabelChip
+                label={variantConsequenceSource.QTL.label}
+                value={sentenceCase(
+                  variantFunctionalConsequenceFromQtlId.label
+                )}
+                to={identifiersOrgLink(
+                  'SO',
+                  variantFunctionalConsequenceFromQtlId.id.slice(3)
+                )}
+                tooltip={variantConsequenceSource.QTL.tooltip}
+              />
+            )}
+            {(variantFunctionalConsequence.id === 'SO:0001583' ||
+              variantFunctionalConsequence.id === 'SO:0001587') && (
+              <LabelChip
+                label={variantConsequenceSource.ProtVar.label}
+                to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+                tooltip={variantConsequenceSource.ProtVar.tooltip}
+              />
+            )}
+          </div>
         );
       },
-      filterValue: ({ variantFunctionalConsequence }) =>
-        `${sentenceCase(variantFunctionalConsequence.label)} ${
-          variantFunctionalConsequence.id
-        }`,
-    },
-    {
-      id: 'variantFunctionalConsequenceFromQtlId',
-      label: 'QTL effect',
-      tooltip:
-        'The direction is inferred from the strongest effect across all the co-localising QTLs',
-      renderCell: ({ variantFunctionalConsequenceFromQtlId }) =>
-        variantFunctionalConsequenceFromQtlId ? (
-          <Link
-            external
-            to={identifiersOrgLink(
-              'SO',
-              variantFunctionalConsequenceFromQtlId.id.slice(3)
-            )}
-          >
-            <Chip
-                label={sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
-                size="small"
-                color="primary"
-                clickable
-                variant="outlined"
-                className={classes.xsmall}
-              />
-          </Link>
-        ) : (
-          ''
-        ),
-      filterValue: ({ variantFunctionalConsequenceFromQtlId }) =>
-        variantFunctionalConsequenceFromQtlId
-          ? `${sentenceCase(variantFunctionalConsequenceFromQtlId.label)} ${
-              variantFunctionalConsequenceFromQtlId.id
-            }`
-          : naLabel,
     },
     {
       id: 'pValueMantissa',
@@ -283,8 +233,7 @@ function getColumns(classes) {
 export function BodyCore({ definition, id, label, count }) {
   const { ensgId, efoId } = id;
   const variables = { ensemblId: ensgId, efoId, size: count };
-  const classes = useStyles();
-  const columns = getColumns(classes);
+  const columns = getColumns();
 
   const request = useQuery(OPEN_TARGETS_GENETICS_QUERY, {
     variables,

--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -74,26 +74,6 @@ function getColumns() {
           </div>
         );
       },
-      // id: 'variantFunctionalConsequenceId',
-      // label: 'Functional Consequence',
-      // renderCell: ({ variantRsId }) => {
-      //   return (
-      //     <Link
-      //       external
-      //       to={`https://www.ebi.ac.uk/ProtVar/query?search=${variantRsId}`}
-      //       className={classes.chipLink}
-      //     >
-      //       <Chip
-      //         label="ProtVar"
-      //         size="small"
-      //         color="primary"
-      //         clickable
-      //         variant="outlined"
-      //         className={classes.xsmall}
-      //       />
-      //     </Link>
-      //   );
-      // },
     },
     {
       id: 'confidence',

--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -128,8 +128,7 @@ export function BodyCore({ definition, id, label, count }) {
     efoId,
     size: count,
   };
-  const classes = useStyles();
-  const columns = getColumns(classes);
+  const columns = getColumns();
 
   const request = useQuery(UNIPROT_VARIANTS_QUERY, {
     variables,

--- a/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
+++ b/apps/platform/src/sections/evidence/UniProtVariants/Body.jsx
@@ -1,5 +1,5 @@
 import { useQuery } from '@apollo/client';
-import { Typography, makeStyles, Chip } from '@material-ui/core';
+import { Typography } from '@material-ui/core';
 import usePlatformApi from '../../../hooks/usePlatformApi';
 import { identifiersOrgLink } from '../../../utils/global';
 import Link from '../../../components/Link';
@@ -7,7 +7,8 @@ import Tooltip from '../../../components/Tooltip';
 import SectionItem from '../../../components/Section/SectionItem';
 import { PublicationsDrawer } from '../../../components/PublicationsDrawer';
 import { DataTable } from '../../../components/Table';
-import { defaultRowsPerPageOptions } from '../../../constants';
+import LabelChip from '../../../components/LabelChip';
+import { defaultRowsPerPageOptions, variantConsequenceSource } from '../../../constants';
 import { epmcUrl } from '../../../utils/urls';
 import Summary from './Summary';
 import Description from './Description';
@@ -15,16 +16,7 @@ import { dataTypesMap } from '../../../dataTypes';
 
 import UNIPROT_VARIANTS_QUERY from './UniprotVariantsQuery.gql';
 
-const useStyles = makeStyles({
-  xsmall: {
-    fontSize: '0.7rem',
-  },
-  chipLink: {
-    marginLeft: '5px',
-  },
-});
-
-function getColumns(classes) {
+function getColumns() {
   return [
     {
       id: 'disease.name',
@@ -69,26 +61,39 @@ function getColumns(classes) {
       ),
     },
     {
-      id: 'variantFunctionalConsequenceId',
-      label: 'Functional Consequence',
+      id: 'variantConsequence',
+      label: 'Variant Consequence',
       renderCell: ({ variantRsId }) => {
         return (
-          <Link
-            external
-            to={`https://www.ebi.ac.uk/ProtVar/query?search=${variantRsId}`}
-            className={classes.chipLink}
-          >
-            <Chip
-              label="ProtVar"
-              size="small"
-              color="primary"
-              clickable
-              variant="outlined"
-              className={classes.xsmall}
+          <div style={{ display: 'flex', gap: '5px' }}>
+            <LabelChip
+              label={variantConsequenceSource.ProtVar.label}
+              to={`https://www.ebi.ac.uk/ProtVar/query?search=${variantRsId}`}
+              tooltip={variantConsequenceSource.ProtVar.tooltip}
             />
-          </Link>
+          </div>
         );
       },
+      // id: 'variantFunctionalConsequenceId',
+      // label: 'Functional Consequence',
+      // renderCell: ({ variantRsId }) => {
+      //   return (
+      //     <Link
+      //       external
+      //       to={`https://www.ebi.ac.uk/ProtVar/query?search=${variantRsId}`}
+      //       className={classes.chipLink}
+      //     >
+      //       <Chip
+      //         label="ProtVar"
+      //         size="small"
+      //         color="primary"
+      //         clickable
+      //         variant="outlined"
+      //         className={classes.xsmall}
+      //       />
+      //     </Link>
+      //   );
+      // },
     },
     {
       id: 'confidence',


### PR DESCRIPTION
# [Platform]: Update functional consequence to variant consequence with label-chip

## Description

Update Open Targets Genetics, ClinVar and UniProt Variant evidence widgets: 

- functional consequence changes to variant consequence
- chip links change style and add tooltip and label

**Issue:** not available
**Deploy preview:** https://deploy-preview-178--ot-platform.netlify.app

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] https://deploy-preview-178--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
