### PR TITLE
[Platform]: Drug page remove EBI_OLS url and Meddra

### DIFF
--- a/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
+++ b/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
@@ -3,7 +3,6 @@ import { useQuery } from '@apollo/client';
 import Link from '../../../components/Link';
 import SectionItem from '../../../components/Section/SectionItem';
 import { DataTable, TableDrawer } from '../../../components/Table';
-import { identifiersOrgLink } from '../../../utils/global';
 import Description from './Description';
 import { naLabel, defaultRowsPerPageOptions } from '../../../constants';
 
@@ -49,18 +48,6 @@ const columns = [
         );
       return toxicityClass || description || naLabel;
     },
-  },
-  {
-    id: 'meddraSocCode',
-    label: 'MedDRA SOC code',
-    renderCell: ({ meddraSocCode }) =>
-      meddraSocCode ? (
-        <Link external to={identifiersOrgLink('meddra', meddraSocCode)}>
-          {meddraSocCode}
-        </Link>
-      ) : (
-        naLabel
-      ),
   },
   {
     id: 'country',

--- a/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
+++ b/apps/platform/src/sections/drug/DrugWarnings/Body.jsx
@@ -12,8 +12,6 @@ import Tooltip from '../../../components/Tooltip';
 
 const replaceSemicolonWithUnderscore = id => id.replace(':', '_');
 
-const EBI_OLS_URL = `https://www.ebi.ac.uk/ols4/ontologies/efo/terms?short_form=`;
-
 const columns = [
   {
     id: 'warningType',
@@ -26,10 +24,7 @@ const columns = [
       if (efoId)
         return (
           <Tooltip title={`Description:${description}`} showHelpIcon>
-            <Link
-              external
-              to={EBI_OLS_URL + replaceSemicolonWithUnderscore(efoId)}
-            >
+            <Link to={`/disease/${replaceSemicolonWithUnderscore(efoId)}`}>
               {efoTerm || efoId}
             </Link>
           </Tooltip>
@@ -45,9 +40,9 @@ const columns = [
         return (
           <Link
             external
-            to={
-              EBI_OLS_URL + replaceSemicolonWithUnderscore(efoIdForWarningClass)
-            }
+            to={`/disease/${replaceSemicolonWithUnderscore(
+              efoIdForWarningClass
+            )}`}
           >
             {toxicityClass || efoIdForWarningClass}
           </Link>


### PR DESCRIPTION
# [Platform]: Drug page remove EBI_OLS url and Meddra

## Description

Change columns of Drug Warnings

**Issue:** # [(link)](https://github.com/opentargets/issues/issues/3002)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Check deploy preview in `/drug/CHEMBL122`

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
