### PR TITLE
[Platform]: add tooltip for testtail to ot-crispr widget

### DIFF
--- a/apps/platform/src/sections/evidence/CRISPRScreen/Body.jsx
+++ b/apps/platform/src/sections/evidence/CRISPRScreen/Body.jsx
@@ -69,7 +69,7 @@ const getColumns = () => [
             showHelpIcon
             title={
               <TooltipStyledLabel
-                label={'SCREEN LIBRARY'}
+                label={'Screen library'}
                 description={row.crisprScreenLibrary}
               />
             }
@@ -113,7 +113,7 @@ const getColumns = () => [
             showHelpIcon
             title={
               <TooltipStyledLabel
-                label={'STATISTICAL TEST TAIL'}
+                label={'Statistical test tail'}
                 description={row.statisticalTestTail}
               />
             }

--- a/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
@@ -47,7 +47,7 @@ const getColumns = () => [
             showHelpIcon
             title={
               <TooltipStyledLabel
-                label="Study overview"
+                label={'Study overview'}
                 description={row.studyOverview}
               />
             }
@@ -76,7 +76,7 @@ const getColumns = () => [
           showHelpIcon
           title={
             <TooltipStyledLabel
-              label="Cell line background"
+              label={'Cell line background'}
               description={row.cellLineBackground}
             />
           }
@@ -105,7 +105,7 @@ const getColumns = () => [
             showHelpIcon
             title={
               <TooltipStyledLabel
-                label={'STATISTICAL TEST TAIL'}
+                label={'Statistical test tail'}
                 description={row.statisticalTestTail}
               />
             }

--- a/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
+++ b/apps/platform/src/sections/evidence/OTCRISPR/Body.jsx
@@ -9,7 +9,7 @@ import Description from './Description';
 import Tooltip from '../../../components/Tooltip';
 import TooltipStyledLabel from '../../../components/TooltipStyledLabel';
 import Link from '../../../components/Link';
-import { defaultRowsPerPageOptions } from '../../../constants';
+import { defaultRowsPerPageOptions, naLabel } from '../../../constants';
 
 import CRISPR_QUERY from './OTCrisprQuery.gql';
 
@@ -98,8 +98,27 @@ const getColumns = () => [
     id: 'resourceScore',
     label: 'Significance',
     filterValue: row => `${row.resourceScore}; ${row.statisticalTestTail}`,
-    renderCell: row =>
-      row.resourceScore ? parseFloat(row.resourceScore.toFixed(6)) : 'N/A',
+    renderCell: row => {
+      if (row.resourceScore && row.statisticalTestTail) {
+        return (
+          <Tooltip
+            showHelpIcon
+            title={
+              <TooltipStyledLabel
+                label={'STATISTICAL TEST TAIL'}
+                description={row.statisticalTestTail}
+              />
+            }
+          >
+            <span>{parseFloat(row.resourceScore.toFixed(6))}</span>
+          </Tooltip>
+        );
+      } else {
+        return row.resourceScore
+          ? parseFloat(row.resourceScore.toFixed(6))
+          : naLabel;
+      }
+    },
   },
   {
     id: 'releaseVersion',


### PR DESCRIPTION
# [Platform]: add tooltip for testtail to ot-crispr widget

## Description

Update the `Significance` column in PPP ot-crispt widget: add tooltip for the `statisticalTestTail` field (similarly to the cirspr-screen widget).

**Issue:** no issue available
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] see preview

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
