### PR TITLE
Fix EuropePmc data download

### DIFF
--- a/apps/platform/src/sections/evidence/EuropePmc/Body.jsx
+++ b/apps/platform/src/sections/evidence/EuropePmc/Body.jsx
@@ -202,6 +202,30 @@ export function BodyCore({ definition, id, label }) {
   }, [newIds]);
 
   const columns = getColumns(label);
+  const downloadColumns = [
+    {
+      id: 'disease',
+      label: 'Disease/phenotype',
+    },
+    {
+      id: 'title',
+      label: 'Publication',
+    },
+    {
+      id: 'europePmcId',
+    },
+    {
+      id: 'pmcId',
+    },
+    {
+      id: 'year',
+    },
+    {
+      id: 'resourceScore',
+      label: 'Score',
+      numeric: true,
+    },
+  ];
 
   return (
     <SectionItem
@@ -216,7 +240,12 @@ export function BodyCore({ definition, id, label }) {
           getPage(res.disease.evidences.rows, page, pageSize),
           literatureData
         );
-
+        const downloadData = rows.map(row => {
+          return {
+            ...row,
+            disease: row.disease.name,
+          }
+        });
         return (
           <Table
             loading={loading}
@@ -228,6 +257,8 @@ export function BodyCore({ definition, id, label }) {
             page={page}
             pageSize={pageSize}
             rows={rows}
+            dataDownloaderRows={downloadData}
+            dataDownloaderColumns={downloadColumns}
             rowCount={data.disease.evidences.count}
             rowsPerPageOptions={[5, 10, 15, 20, 25]}
             query={EUROPE_PMC_QUERY.loc.source.body}


### PR DESCRIPTION
# Platform: fix download of EuropePmc data

## Description

EuropePmc data download buttons did not work because no `dataDownloaderRows` were provided to the `<Table>` component.

In this PR, `dataDownloaderRows` are provided. Additionally, the `europePmcId` and `pmcId` columns are added to the download data for reference.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Download EuropePmc data before and after fix by using `yarn dev: platform` and pointing to `"https://api.platform.opentargets.org/api/v4/graphql"` in the `config.js`

Downloading of data was tested on: /evidence/ENSG00000157764/MONDO_0015280

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
