### PR TITLE
[Platform]: resize depmap link help icon on target page

### DIFF
--- a/apps/platform/src/components/ExternalLink/CrisprDepmapLink.jsx
+++ b/apps/platform/src/components/ExternalLink/CrisprDepmapLink.jsx
@@ -6,7 +6,7 @@ import Link from '../Link';
 
 const useStyles = makeStyles(theme => ({
   helpIcon: {
-    fontSize: '10px',
+    fontSize: '1.0rem !important',
   },
   tooltip: {
     backgroundColor: theme.palette.background.paper,

--- a/apps/platform/src/components/ExternalLink/CrisprDepmapLink.jsx
+++ b/apps/platform/src/components/ExternalLink/CrisprDepmapLink.jsx
@@ -6,7 +6,7 @@ import Link from '../Link';
 
 const useStyles = makeStyles(theme => ({
   helpIcon: {
-    fontSize: '1.0rem !important',
+    fontSize: '0.875rem !important',
   },
   tooltip: {
     backgroundColor: theme.palette.background.paper,


### PR DESCRIPTION
# [Platform]: resize depmap link help icon on target page
Adjust the size of the depmap link help icon on target page

## Description

MUI5 caused the help icon for "Project Score" (DepMap) on target page to display too big. However the one in production looks very small. 
Resetting the size to be the same as the label text (then the `<sup>` tag element makes it a little smaller)

**Issue:** N/A
**Deploy preview:** https://deploy-preview-209--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] https://deploy-preview-209--ot-platform.netlify.app/target/ENSG00000171862
- [ ] compare to production: https://platform.opentargets.org/target/ENSG00000171862

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
