### PR TITLE
[Platform]: Adjust spacing and alignment in bibliography and literature widgets

### DIFF
--- a/packages/sections/src/common/Literature/Entities.jsx
+++ b/packages/sections/src/common/Literature/Entities.jsx
@@ -15,7 +15,7 @@ const useStyles = makeStyles((theme) => ({
     display: "flex",
     flexWrap: "wrap",
     "& > *": {
-      margin: theme.spacing(0.5),
+      margin: `${theme.spacing(0.5)} !important`,
     },
   },
   loadingContainer: {

--- a/packages/sections/src/components/PublicationsDrawer/PublicationWrapper.jsx
+++ b/packages/sections/src/components/PublicationsDrawer/PublicationWrapper.jsx
@@ -20,8 +20,10 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "normal",
   },
   detailsButton: {
-    margin: "1rem",
-    marginLeft: "0",
+    margin: "1rem !important",
+    marginLeft: "0 !important",
+    color: '#5a5f5f !important',
+    borderColor: '#c4c4c4 !important',
   },
   detailPanel: {
     background: `${theme.palette.grey[100]}`,

--- a/packages/sections/src/evidence/EuropePmc/Publication.jsx
+++ b/packages/sections/src/evidence/EuropePmc/Publication.jsx
@@ -16,7 +16,9 @@ const useStyles = makeStyles((theme) => ({
     whiteSpace: "normal",
   },
   detailsButton: {
-    margin: "1rem",
+    margin: "1rem !important",
+    color: '#5a5f5f !important',
+    borderColor: '#c4c4c4 !important',
   },
   detailPanel: {
     background: `${theme.palette.grey[100]}`,


### PR DESCRIPTION
# [Platform]: Adjust spacing and alignment in bibliography and literature widgets

## Description

Adjust alignment of buttons and spacing between chips. Also sets the color for the "show abstract" button.
Note: this does not address the incorrect alignment of the download buttons in the evidence literature widget.

**Issue:** N/A
**Deploy preview:** https://deploy-preview-218--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] EPMC widget on evidence page: https://deploy-preview-218--ot-platform.netlify.app/evidence/ENSG00000232810/EFO_0003778
- [ ] Bibliography widget on profile page (target and disease): e.g. https://deploy-preview-218--ot-platform.netlify.app/target/ENSG00000232810

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
