### PR TITLE
[Platform]: data downloader in middle 

### DIFF
--- a/packages/sections/src/components/Table/Table.jsx
+++ b/packages/sections/src/components/Table/Table.jsx
@@ -93,8 +93,6 @@ const Table = ({
             className={defaultClasses.downloader}
             item
             xs={12}
-            md={8}
-            lg={8}
           >
             <DataDownloader
               columns={dataDownloaderColumns || columns}

--- a/packages/sections/src/target/Expression/SummaryTab.jsx
+++ b/packages/sections/src/target/Expression/SummaryTab.jsx
@@ -32,12 +32,12 @@ const getDownloadRows = (expressions) =>
 function SummaryTab({ symbol, data }) {
   return (
     <Grid container justifyContent="center">
+      <DataDownloader
+        tableHeaders={headers}
+        rows={getDownloadRows(data.target.expressions)}
+        fileStem={`${symbol}-expression`}
+      />
       <Grid item xs={12} lg={8}>
-        <DataDownloader
-          tableHeaders={headers}
-          rows={getDownloadRows(data.target.expressions)}
-          fileStem={`${symbol}-expression`}
-        />
         <SummaryTable data={data.target.expressions} />
       </Grid>
     </Grid>

--- a/packages/ui/src/components/Search/SearchListItem.tsx
+++ b/packages/ui/src/components/Search/SearchListItem.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, styled } from "@mui/material/styles";
+import { makeStyles, styled } from "@mui/styles";
 import { Typography, Chip } from "@mui/material";
 import SearchRecentListItem from "./SearchRecentListItem";
 import { commaSeparate } from "./utils/searchUtils";

--- a/packages/ui/src/components/Search/SearchListItem.tsx
+++ b/packages/ui/src/components/Search/SearchListItem.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, styled } from "@mui/styles";
+import { makeStyles, styled } from "@mui/material/styles";
 import { Typography, Chip } from "@mui/material";
 import SearchRecentListItem from "./SearchRecentListItem";
 import { commaSeparate } from "./utils/searchUtils";


### PR DESCRIPTION
# [Platform]: data downloader in middle 

## Removed small device condition from downloader to occupy less space. Use xs grid 12 always for data downloader

**Issue:** # (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
