### PR TITLE
[Platform]: fix known drugs table missing data when change page size

### DIFF
--- a/packages/sections/src/drug/KnownDrugs/KnownDrugsQuery.gql
+++ b/packages/sections/src/drug/KnownDrugs/KnownDrugsQuery.gql
@@ -2,10 +2,11 @@ query KnownDrugsQuery(
   $chemblId: String!
   $cursor: String
   $freeTextQuery: String
+  $size: Int = 10
 ) {
   drug(chemblId: $chemblId) {
     id
-    knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery) {
+    knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery, size: $size) {
       count
       cursor
       rows {

--- a/packages/sections/src/target/KnownDrugs/KnownDrugsQuery.gql
+++ b/packages/sections/src/target/KnownDrugs/KnownDrugsQuery.gql
@@ -2,10 +2,11 @@ query KnownDrugsQuery(
   $ensgId: String!
   $cursor: String
   $freeTextQuery: String
+  $size: Int = 10
 ) {
   target(ensemblId: $ensgId) {
     id
-    knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery) {
+    knownDrugs(cursor: $cursor, freeTextQuery: $freeTextQuery, size: $size) {
       count
       cursor
       rows {


### PR DESCRIPTION
# [Platform]: fix known drugs table missing data when change page size

## Description

Changing the table page size causes the table to show no data when paginating. Adding `size` parameter to query fixes it.
Setting the default to 10 as on disease profile page.

**Issue:**
**Deploy preview:**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
