### PR TITLE
[Platform]: fix table pagination icons size

### DIFF
--- a/packages/ui/src/components/Table/TablePaginationActions.jsx
+++ b/packages/ui/src/components/Table/TablePaginationActions.jsx
@@ -40,22 +40,22 @@ export function PaginationActionsComplete({
   return (
     <div className={classes.root}>
       <IconButton onClick={handleFirstPageButtonClick} disabled={page === 0}>
-        <FontAwesomeIcon icon={faBackwardStep} />
+        <FontAwesomeIcon size="2xs" icon={faBackwardStep} />
       </IconButton>
       <IconButton onClick={handleBackButtonClick} disabled={page === 0}>
-        <FontAwesomeIcon icon={faChevronLeft} />
+        <FontAwesomeIcon size="2xs" icon={faChevronLeft} />
       </IconButton>
       <IconButton
         onClick={handleNextButtonClick}
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
       >
-        <FontAwesomeIcon icon={faChevronRight} />
+        <FontAwesomeIcon size="2xs" icon={faChevronRight} />
       </IconButton>
       <IconButton
         onClick={handleLastPageButtonClick}
         disabled={page >= Math.ceil(count / rowsPerPage) - 1}
       >
-        <FontAwesomeIcon icon={faForwardStep} />
+        <FontAwesomeIcon size="2xs" icon={faForwardStep} />
       </IconButton>
     </div>
   );


### PR DESCRIPTION
# [Platform]: fix table pagination icons size

**Issue:** # (link)
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Check body tables

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
