### PR TITLE
[Platform]: fix changing page size in pharmacovigilance widget

### DIFF
--- a/packages/sections/src/drug/AdverseEvents/Body.jsx
+++ b/packages/sections/src/drug/AdverseEvents/Body.jsx
@@ -144,7 +144,7 @@ function Body({ id: chemblId, label: name, entity }) {
             fixed
             pageSize={pageSize}
             rowsPerPageOptions={[10, 25, 50, 100]}
-            onRowsPerPageChange={() => handleRowsPerPageChange()}
+            onRowsPerPageChange={(newSize) => handleRowsPerPageChange(newSize)}
             query={ADVERSE_EVENTS_QUERY.loc.source.body}
             variables={variables}
           />


### PR DESCRIPTION
# [Platform]: fix changing page size in pharmacovigilance widget (drug profile page)

## Description

Pass the `pageSize`, as selected in dropdown menu, to the query.

**Issue:** N/A
**Deploy preview:** https://deploy-preview-240--ot-platform.netlify.app/drug/CHEMBL112

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] https://deploy-preview-240--ot-platform.netlify.app/drug/CHEMBL112

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
