### PR TITLE
[Platform]: add more detailed "full text available" description to publications

### DIFF
--- a/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
+++ b/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
@@ -170,42 +170,6 @@ function PublicationWrapper({
             {
               isOpenAccess ? "Full text free to use/read" : "Full text free to read"
             }
-
-            {/* <Tooltip
-              title={isOpenAccess ? "Free to read and use" : "Free to read"}
-              showHelpIcon
-            >
-              <FontAwesomeIcon
-                icon={faFileAlt}
-                style={{ marginRight: "8px" }}
-                size="lg"
-              />
-              Full text available
-            </Tooltip> */}
-
-            {/* <Tooltip
-              title={isOpenAccess ? "Free to read and use" : "Free to read"}
-            >
-            <FontAwesomeIcon
-                icon={faFileAlt}
-                style={{ marginRight: "8px" }}
-                size="lg"
-              />
-              Full text available
-              <FontAwesomeIcon
-                icon={faGlasses}
-                style={{ marginLeft: "8px" }}
-                size="md"
-              />
-              { isOpenAccess ? 
-               <FontAwesomeIcon
-                icon={faQuoteLeft}
-                style={{ marginLeft: "8px" }}
-                size="md"
-              /> : null}
-            </Tooltip> */}
-
-
           </span>
         )}
       </Box>

--- a/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
+++ b/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
@@ -3,8 +3,6 @@ import {
   faPlusCircle,
   faMinusCircle,
   faFileAlt,
-  faGlasses,
-  faQuoteLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Box, Button, Typography } from "@mui/material";
@@ -12,7 +10,6 @@ import { makeStyles } from "@mui/styles";
 
 import LongText from "../LongText";
 import Link from "../Link";
-import Tooltip from "../Tooltip";
 
 import PublicationSummary from "./PublicationSummary";
 import config from "../../config";

--- a/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
+++ b/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
@@ -3,6 +3,8 @@ import {
   faPlusCircle,
   faMinusCircle,
   faFileAlt,
+  faGlasses,
+  faQuoteLeft,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Box, Button, Typography } from "@mui/material";
@@ -10,6 +12,7 @@ import { makeStyles } from "@mui/styles";
 
 import LongText from "../LongText";
 import Link from "../Link";
+import Tooltip from "../Tooltip";
 
 import PublicationSummary from "./PublicationSummary";
 import config from "../../config";
@@ -164,9 +167,45 @@ function PublicationWrapper({
               style={{ marginRight: "8px" }}
               size="lg"
             />
-            Full text available: {
-              isOpenAccess ? "free to read and use" : "free to read"
+            {
+              isOpenAccess ? "Full text free to use/read" : "Full text free to read"
             }
+
+            {/* <Tooltip
+              title={isOpenAccess ? "Free to read and use" : "Free to read"}
+              showHelpIcon
+            >
+              <FontAwesomeIcon
+                icon={faFileAlt}
+                style={{ marginRight: "8px" }}
+                size="lg"
+              />
+              Full text available
+            </Tooltip> */}
+
+            {/* <Tooltip
+              title={isOpenAccess ? "Free to read and use" : "Free to read"}
+            >
+            <FontAwesomeIcon
+                icon={faFileAlt}
+                style={{ marginRight: "8px" }}
+                size="lg"
+              />
+              Full text available
+              <FontAwesomeIcon
+                icon={faGlasses}
+                style={{ marginLeft: "8px" }}
+                size="md"
+              />
+              { isOpenAccess ? 
+               <FontAwesomeIcon
+                icon={faQuoteLeft}
+                style={{ marginLeft: "8px" }}
+                size="md"
+              /> : null}
+            </Tooltip> */}
+
+
           </span>
         )}
       </Box>

--- a/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
+++ b/packages/ui/src/components/PublicationsDrawer/PublicationWrapper.jsx
@@ -164,7 +164,9 @@ function PublicationWrapper({
               style={{ marginRight: "8px" }}
               size="lg"
             />
-            Full text available
+            Full text available: {
+              isOpenAccess ? "free to read and use" : "free to read"
+            }
           </span>
         )}
       </Box>


### PR DESCRIPTION
# [Platform]: add more detailed "full text available" description to publications

## Description

Update the text for "Full text available" chip in the publications drawer.
Still in progress - @buniello will check if the proposed solution works.

**Issue:** https://github.com/opentargets/issues/issues/3008
**Deploy preview:** https://deploy-preview-250--ot-platform.netlify.app

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] See publications on GEL Panel App widget: https://deploy-preview-250--ot-platform.netlify.app/evidence/ENSG00000167207/EFO_0000384

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
