### PR TITLE
[Platform]: OT Projects Section query different from fragment 

### DIFF
--- a/packages/sections/src/disease/OTProjects/Body.jsx
+++ b/packages/sections/src/disease/OTProjects/Body.jsx
@@ -3,10 +3,12 @@ import { usePlatformApi, Link, SectionItem, DataTable } from "ui";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheckCircle } from "@fortawesome/free-solid-svg-icons";
 import { makeStyles } from "@mui/styles";
+import { useQuery } from "@apollo/client";
+
 import Description from "./Description";
 import { defaultRowsPerPageOptions } from "../../constants";
-import Summary from "./Summary";
 import { definition } from ".";
+import OT_PROJECTS_QUERY from "./OTProjectsQuery.gql";
 
 const useStyles = makeStyles((theme) => ({
   primaryColor: {
@@ -44,8 +46,10 @@ const getColumns = (classes) => [
 ];
 
 function Body({ label, id: efoId, entity }) {
-  const request = usePlatformApi(Summary.fragments.OTProjectsSummaryFragment);
   const classes = useStyles();
+  const request = useQuery(OT_PROJECTS_QUERY, {
+    variables: { efoId },
+  });
 
   return (
     <SectionItem
@@ -53,13 +57,13 @@ function Body({ label, id: efoId, entity }) {
       request={request}
       entity={entity}
       renderDescription={() => <Description name={label} />}
-      renderBody={({ otarProjects }) => (
+      renderBody={({ disease }) => (
         <DataTable
           showGlobalFilter
           dataDownloader
           dataDownloaderFileStem={`${efoId}-otprojects`}
           columns={getColumns(classes)}
-          rows={otarProjects}
+          rows={disease.otarProjects}
           rowsPerPageOptions={defaultRowsPerPageOptions}
           sortBy="status"
         />

--- a/packages/sections/src/disease/OTProjects/OTProjectsQuery.gql
+++ b/packages/sections/src/disease/OTProjects/OTProjectsQuery.gql
@@ -1,0 +1,11 @@
+query OTProjectsQuery($efoId: String!) {
+  disease(efoId: $efoId) {
+    otarProjects {
+      otarCode
+      status
+      projectName
+      reference
+      integratesInPPP
+    }
+  }
+}

--- a/packages/sections/src/disease/OTProjects/OTProjectsSummaryFragment.gql
+++ b/packages/sections/src/disease/OTProjects/OTProjectsSummaryFragment.gql
@@ -1,9 +1,5 @@
 fragment OTProjectsSummaryFragment on Disease {
   otarProjects {
     otarCode
-    status
-    projectName
-    reference
-    integratesInPPP
   }
 }


### PR DESCRIPTION
# [Platform]: OT Projects Section query different from fragment 

## Created a new query for section and removed fragment query use from section.

**Issue:** # (link)
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: go to disease page and check for ot projects section in ppp

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
