### PR TITLE
[Platform]: Fix display of empty results for Known Drugs widget filter

### DIFF
--- a/packages/sections/src/common/KnownDrugs/Body.jsx
+++ b/packages/sections/src/common/KnownDrugs/Body.jsx
@@ -293,6 +293,7 @@ function Body({
         data: { [entity]: { knownDrugs: { rows, count: rows.length } } },
       }}
       renderDescription={Description}
+      showEmptyBody
       renderBody={() => (
         <Table
           loading={loading}

--- a/packages/ui/src/components/Section/SectionItem.jsx
+++ b/packages/ui/src/components/Section/SectionItem.jsx
@@ -28,6 +28,7 @@ function SectionItem({
   entity,
   showEmptySection = false,
   showContentLoading = false,
+  showEmptyBody = false
 }) {
   const classes = sectionStyles();
   const { loading, error, data } = request;
@@ -38,7 +39,7 @@ function SectionItem({
     hasData = definition.hasData(data[entity]);
   }
 
-  if (!hasData && !showEmptySection && !loading) return null;
+  if (!hasData && !showEmptySection && !loading && !showEmptyBody) return null;
 
   return (
     <Grid item xs={12}>
@@ -105,7 +106,7 @@ function SectionItem({
                 <Box className={classes.loadingPlaceholder} />
               )}
               {error && <SectionError error={error} />}
-              {!loading && hasData && (
+              {!loading && (hasData || showEmptyBody) && (
                 <CardContent className={classes.cardContent}>
                   {renderBody(data)}
                 </CardContent>

--- a/packages/ui/src/components/Table/Table.jsx
+++ b/packages/ui/src/components/Table/Table.jsx
@@ -52,7 +52,7 @@ const Table = ({
   query,
   variables,
 }) => {
-  const emptyRows = pageSize - rows.length;
+  const emptyRows = pageSize - rows?.length;
   const [selectedRow, setSelectedRow] = useState(0);
   const defaultClasses = tableStyles();
 


### PR DESCRIPTION
## Description
Introduces a new property in the SectionItem component that allows rendering the body with empty data. When users enter in the search of the Known Drugs widget an input that generates empty results, they can still see the widget and try again with a new input.

**Issue:** https://github.com/opentargets/issues/issues/3084

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Testing instructions:
- run Platform app using this branch
- visit http://localhost:3000/target/ENSG00000073756
- in the Known Drugs widget, search for "asd"
- empty results should be displayed as below
- clearing search should return to previous, unfiltered results

![image](https://github.com/opentargets/ot-ui-apps/assets/22417165/93636155-01ae-4f8f-9191-c1ebdd254541)

## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
