### PR TITLE
[Platform]: Free search text condition added

### DIFF
--- a/packages/sections/src/common/KnownDrugs/Body.jsx
+++ b/packages/sections/src/common/KnownDrugs/Body.jsx
@@ -290,7 +290,15 @@ function Body({
       request={{
         loading: initialLoading,
         error: false,
-        data: { [entity]: { knownDrugs: { rows, count: rows.length } } },
+        data: {
+          [entity]: {
+            knownDrugs: {
+              rows,
+              count: rows.length,
+              freeTextQuery: globalFilter,
+            },
+          },
+        },
       }}
       renderDescription={Description}
       renderBody={() => (

--- a/packages/sections/src/disease/KnownDrugs/index.js
+++ b/packages/sections/src/disease/KnownDrugs/index.js
@@ -2,7 +2,8 @@ export const definition = {
   id: "knownDrugs",
   name: "Known Drugs",
   shortName: "KD",
-  hasData: (data) => data.knownDrugs?.count > 0 || false,
+  hasData: (data) =>
+    data.knownDrugs?.count > 0 || data.knownDrugs.freeTextQuery || false,
 };
 
 // export { default as Summary } from './Summary';

--- a/packages/sections/src/drug/KnownDrugs/index.js
+++ b/packages/sections/src/drug/KnownDrugs/index.js
@@ -1,6 +1,7 @@
 export const definition = {
-  id: 'knownDrugs',
-  name: 'Clinical Precedence',
-  shortName: 'CP',
-  hasData: data => data.knownDrugs?.count > 0 || false,
+  id: "knownDrugs",
+  name: "Clinical Precedence",
+  shortName: "CP",
+  hasData: (data) =>
+    data.knownDrugs?.count > 0 || data.knownDrugs.freeTextQuery || false,
 };

--- a/packages/sections/src/target/KnownDrugs/index.js
+++ b/packages/sections/src/target/KnownDrugs/index.js
@@ -1,6 +1,6 @@
 export const definition = {
-  id: 'knownDrugs',
-  name: 'Known Drugs',
-  shortName: 'KD',
-  hasData: data => data.knownDrugs?.count > 0 || false,
+  id: "knownDrugs",
+  name: "Known Drugs",
+  shortName: "KD",
+  hasData: (data) => data.knownDrugs?.count > 0 || data.knownDrugs.freeTextQuery || false,
 };


### PR DESCRIPTION
# [Platform]: Free search text condition added

## Added search term as a condition to validate `has data`  in known drugs sections.

**Issue:** # https://github.com/opentargets/issues/issues/3084
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: type anything in known drugs section search.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
