### PR TITLE
[Platform]: Update EFO link in disease page header

### DIFF
--- a/apps/platform/src/pages/DiseasePage/Header.jsx
+++ b/apps/platform/src/pages/DiseasePage/Header.jsx
@@ -37,7 +37,7 @@ function processXRefs(dbXRefs) {
 }
 
 function Header({ loading, efoId, name, dbXRefs = [] }) {
-  const efoUrl = `https://www.ebi.ac.uk/ols/ontologies/efo/terms?short_form=${efoId}`;
+  const efoUrl = `https://www.ebi.ac.uk/ols4/ontologies/efo/terms?short_form=${efoId}`;
   const xrefs = processXRefs(dbXRefs);
 
   return (


### PR DESCRIPTION
# [Platform]: Update EFO link in disease page header

## Description

This PR updates the EFO link at the top of the disease page. This still needs to be reviewed to confirm it's the behaviour we want.
It simply updates the link to OLS v4. To my understanding it's not currently supported by identifiers.org - so we'll need to review this.

EDIT 25/10/2023: @DSuveges and @ireneisdoomed have reviewed the approach and so the proposed solution (updating the OLS URL) is accepted. We can review and merge

**Issue:** https://github.com/opentargets/issues/issues/3108
**Deploy preview:** https://deploy-preview-278--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] https://deploy-preview-278--ot-platform.netlify.app/disease/MONDO_0018997/associations then click on the "EFO: MONDO_0018997" link at the top of the page

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
