### PR TITLE
[Platform]: add custom sorting to the chemical probes table

### DIFF
--- a/packages/sections/src/target/ChemicalProbes/Body.jsx
+++ b/packages/sections/src/target/ChemicalProbes/Body.jsx
@@ -6,6 +6,7 @@ import { definition } from ".";
 import Description from "./Description";
 import CHEMICAL_PROBES_QUERY from "./ChemicalProbes.gql";
 import { naLabel, defaultRowsPerPageOptions } from "../../constants";
+import _ from "lodash";
 
 /**
  * Style the tooltips as "label: value" with a bold label
@@ -96,17 +97,24 @@ function Body({ id, label: symbol, entity }) {
       request={request}
       entity={entity}
       renderDescription={() => <Description symbol={symbol} />}
-      renderBody={(data) =>
-        data.target.chemicalProbes?.length > 0 ? (
+      renderBody={(data) => {
+        // sort probes manually as we need a custom sort based score, quality and origin
+        const sortedProbes = _.orderBy(data.target.chemicalProbes, [
+          'probesDrugsScore',
+          'isHighQuality',
+          p => p.origin?.map(o => o.toLowerCase()).includes('experimental'),
+        ], ['desc', 'desc', 'desc']);
+
+        return data.target.chemicalProbes?.length > 0 ? (
           <DataTable
             columns={columns}
-            rows={data.target.chemicalProbes}
+            rows={sortedProbes}
             showGlobalFilter
             dataDownloader
             dataDownloaderFileStem={`${symbol}-chemical-probes`}
             fixed
-            sortBy="probesDrugsScore"
-            order="desc"
+            // sortBy="probesDrugsScore"
+            // order="desc"
             rowsPerPageOptions={defaultRowsPerPageOptions}
             noWrap={false}
             noWrapHeader={false}
@@ -114,6 +122,7 @@ function Body({ id, label: symbol, entity }) {
             variables={variables}
           />
         ) : null
+      }
       }
     />
   );


### PR DESCRIPTION
# [Platform]: add custom sorting to the chemical probes table

## Description

The Chemical Probes widget table, on the target profile page, used to have a "custom" sorting. This PR adds back more accurate sorting based on score, quality and origin. @ireneisdoomed can confirm if this approach is suitable and the results are OK.

Note: this is an old ticket, so not high priority. Need to confirm expected functionality before code review.

**Issue:** # https://github.com/opentargets/issues/issues/2742
**Deploy preview:** https://deploy-preview-279--ot-platform.netlify.app/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

See Chemical Probes widget at below link; probes with the same score should be prioritised by quality and origin:

- [x] https://deploy-preview-279--ot-platform.netlify.app/target/ENSG00000091831

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
