### PR TITLE
[Platform]: update clinicaltrials URL in config

### DIFF
--- a/apps/platform/src/utils/urls.js
+++ b/apps/platform/src/utils/urls.js
@@ -64,7 +64,7 @@ export function europePmcBiblioSearchPOSTQuery(ids, size = 25) {
 }
 
 function clinicalTrialsUrl(id) {
-  return `https://www.clinicaltrials.gov/ct2/show/${id}`;
+  return `https://www.clinicaltrials.gov/study/${id}`;
 }
 
 function fdaUrl(id) {

--- a/packages/sections/src/utils/urls.js
+++ b/packages/sections/src/utils/urls.js
@@ -64,7 +64,7 @@ export function europePmcBiblioSearchPOSTQuery(ids, size = 25) {
 }
 
 function clinicalTrialsUrl(id) {
-  return `https://www.clinicaltrials.gov/ct2/show/${id}`;
+  return `https://www.clinicaltrials.gov/study/${id}`;
 }
 
 function fdaUrl(id) {

--- a/packages/ui/src/utils/urls.js
+++ b/packages/ui/src/utils/urls.js
@@ -64,7 +64,7 @@ export function europePmcBiblioSearchPOSTQuery(ids, size = 25) {
 }
 
 function clinicalTrialsUrl(id) {
-  return `https://www.clinicaltrials.gov/ct2/show/${id}`;
+  return `https://www.clinicaltrials.gov/study/${id}`;
 }
 
 function fdaUrl(id) {


### PR DESCRIPTION
# [Platform]: update clinicaltrials URL in config

## Description

Update the clinicaltrials base URL in the platform config (urls.js file); this seems to only be used in the Indications widget on drug profile page. 
Hence it appears that only packages/sections/src/utils/urls.js is being used: might need to review the use of the other two files.

Note: ClinicalTrials now uses a correct redirect from the old URLs so this fix might no longer be strictly required.
Also, if the URL will come from the API, this fix will also need to be updated accordingly.

**Issue:** https://github.com/opentargets/issues/issues/3048
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Check the inications widget on any drug profile page and see the link in the last column:
- [ ] https://deploy-preview-281--ot-platform.netlify.app/drug/CHEMBL3353410

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
