### PR TITLE
[Platform]: Migrate Chembl, IMPC and ClinVar Somatic to server side pagination

### DIFF
--- a/packages/sections/src/evidence/Chembl/ChemblQuery.gql
+++ b/packages/sections/src/evidence/Chembl/ChemblQuery.gql
@@ -1,11 +1,14 @@
-query ChemblQuery($ensemblId: String!, $efoId: String!) {
+query ChemblQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    chemblSummary: evidences(
+    evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["chembl"]
+      size: $size
+      cursor: $cursor
     ) {
+      cursor
       count
       rows {
         disease {

--- a/packages/sections/src/evidence/Chembl/index.js
+++ b/packages/sections/src/evidence/Chembl/index.js
@@ -5,7 +5,7 @@ export const definition = {
   id,
   name: "ChEMBL",
   shortName: "CE",
-  hasData: (data) => data.chemblSummary.count > 0,
+  hasData: data => data.chembl.count > 0,
   isPrivate: isPrivateEvidenceSection(id),
 };
 

--- a/packages/sections/src/evidence/EVASomatic/Body.jsx
+++ b/packages/sections/src/evidence/EVASomatic/Body.jsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@apollo/client";
+import { useState, useEffect } from "react";
 import { Box, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import {
@@ -7,24 +7,24 @@ import {
   Tooltip,
   Link,
   PublicationsDrawer,
-  DataTable,
   ClinvarStars,
+  Table,
+  useCursorBatchDownloader,
+  getComparator,
+  getPage,
 } from "ui";
+import client from "../../client";
 
 import { sentenceCase } from "../../utils/global";
 
 import { epmcUrl } from "../../utils/urls";
-import {
-  clinvarStarMap,
-  naLabel,
-  defaultRowsPerPageOptions,
-} from "../../constants";
+import { clinvarStarMap, naLabel, defaultRowsPerPageOptions } from "../../constants";
 import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
 import EVA_SOMATIC_QUERY from "./EvaSomaticQuery.gql";
 import { definition } from ".";
 
-const getColumns = (label) => [
+const getColumns = label => [
   {
     id: "disease.name",
     label: "Disease/phenotype",
@@ -35,12 +35,7 @@ const getColumns = (label) => [
             <Typography variant="subtitle2" display="block" align="center">
               Reported disease or phenotype:
             </Typography>
-            <Typography
-              variant="caption"
-              display="block"
-              align="center"
-              gutterBottom
-            >
+            <Typography variant="caption" display="block" align="center" gutterBottom>
               {diseaseFromSource}
             </Typography>
 
@@ -50,7 +45,7 @@ const getColumns = (label) => [
                   All reported phenotypes:
                 </Typography>
                 <Typography variant="caption" display="block">
-                  {cohortPhenotypes.map((cp) => (
+                  {cohortPhenotypes.map(cp => (
                     <div key={cp}>{cp}</div>
                   ))}
                 </Typography>
@@ -117,8 +112,7 @@ const getColumns = (label) => [
     renderCell: ({ clinicalSignificances }) => {
       if (!clinicalSignificances) return naLabel;
 
-      if (clinicalSignificances.length === 1)
-        return sentenceCase(clinicalSignificances[0]);
+      if (clinicalSignificances.length === 1) return sentenceCase(clinicalSignificances[0]);
 
       if (clinicalSignificances.length > 1)
         return (
@@ -129,10 +123,8 @@ const getColumns = (label) => [
               listStyle: "none",
             }}
           >
-            {clinicalSignificances.map((clinicalSignificance) => (
-              <li key={clinicalSignificance}>
-                {sentenceCase(clinicalSignificance)}
-              </li>
+            {clinicalSignificances.map(clinicalSignificance => (
+              <li key={clinicalSignificance}>{sentenceCase(clinicalSignificance)}</li>
             ))}
           </ul>
         );
@@ -155,7 +147,7 @@ const getColumns = (label) => [
                 <Typography variant="subtitle2" display="block" align="center">
                   Allelic requirements:
                 </Typography>
-                {allelicRequirements.map((r) => (
+                {allelicRequirements.map(r => (
                   <Typography variant="caption" key={r}>
                     {r}
                   </Typography>
@@ -164,14 +156,13 @@ const getColumns = (label) => [
             }
             showHelpIcon
           >
-            {alleleOrigins.map((a) => sentenceCase(a)).join("; ")}
+            {alleleOrigins.map(a => sentenceCase(a)).join("; ")}
           </Tooltip>
         );
 
-      return alleleOrigins.map((a) => sentenceCase(a)).join("; ");
+      return alleleOrigins.map(a => sentenceCase(a)).join("; ");
     },
-    filterValue: ({ alleleOrigins }) =>
-      alleleOrigins ? alleleOrigins.join() : "",
+    filterValue: ({ alleleOrigins }) => (alleleOrigins ? alleleOrigins.join() : ""),
   },
   {
     label: "Review status",
@@ -199,15 +190,23 @@ const getColumns = (label) => [
         }, []) || [];
 
       return (
-        <PublicationsDrawer
-          entries={literatureList}
-          symbol={label.symbol}
-          name={label.name}
-        />
+        <PublicationsDrawer entries={literatureList} symbol={label.symbol} name={label.name} />
       );
     },
   },
 ];
+
+function fetchData({ ensemblId, efoId, cursor, size }) {
+  return client.query({
+    query: EVA_SOMATIC_QUERY,
+    variables: {
+      ensemblId,
+      efoId,
+      cursor,
+      size,
+    },
+  });
+}
 
 const useStyles = makeStyles({
   roleInCancerBox: {
@@ -220,35 +219,115 @@ const useStyles = makeStyles({
 
 function Body({ id, label, entity }) {
   const classes = useStyles();
-  const { ensgId, efoId } = id;
-  const variables = {
-    ensemblId: ensgId,
-    efoId,
-  };
 
-  const request = useQuery(EVA_SOMATIC_QUERY, {
-    variables,
-  });
+  const { ensgId: ensemblId, efoId } = id;
+
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [count, setCount] = useState(0);
+  const [cursor, setCursor] = useState("");
+  const [rows, setRows] = useState([]);
+  const [page, setPage] = useState(0);
+  const [size, setPageSize] = useState(10);
+  const [sortColumn, setSortColumn] = useState(null);
+  const [sortOrder, setSortOrder] = useState("asc");
+  const [target, setTarget] = useState({});
 
   const columns = getColumns(label);
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    fetchData({ ensemblId, efoId, cursor: "", size }).then(res => {
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.evidences;
+      if (isCurrent) {
+        setInitialLoading(false);
+        setCursor(newCursor);
+        setCount(newCount);
+        setRows(newRows);
+        setTarget(res.data.target);
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  const getWholeDataset = useCursorBatchDownloader(
+    EVA_SOMATIC_QUERY,
+    {
+      ensemblId,
+      efoId,
+    },
+    `data.disease.impc`
+  );
+
+  const handlePageChange = newPage => {
+    const newPageInt = Number(newPage);
+    if (size * newPageInt + size > rows.length && cursor !== null) {
+      setLoading(true);
+      fetchData({ ensemblId, efoId, cursor, size }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        setRows([...rows, ...newRows]);
+        setLoading(false);
+        setCursor(newCursor);
+        setPage(newPageInt);
+      });
+    } else {
+      setPage(newPageInt);
+    }
+  };
+
+  const handleRowsPerPageChange = newPageSize => {
+    const newPageSizeInt = Number(newPageSize);
+    if (newPageSizeInt > rows.length && cursor !== null) {
+      setLoading(true);
+      fetchData({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        setRows([...rows, ...newRows]);
+        setLoading(false);
+        setCursor(newCursor);
+        setPage(0);
+        setPageSize(newPageSizeInt);
+      });
+    } else {
+      setPage(0);
+      setPageSize(newPageSizeInt);
+    }
+  };
+
+  const handleSortBy = sortBy => {
+    setSortColumn(sortBy);
+    setSortOrder(
+      // eslint-disable-next-line
+      sortColumn === sortBy ? (sortOrder === "asc" ? "desc" : "asc") : "asc"
+    );
+  };
+
+  const processedRows = [...rows];
+
+  if (sortColumn) {
+    processedRows.sort(getComparator(columns, sortOrder, sortColumn));
+  }
 
   return (
     <SectionItem
       definition={definition}
       chipText={dataTypesMap.somatic_mutation}
-      request={request}
+      request={{
+        loading: initialLoading,
+        data: { [entity]: { eva_somatic: { rows, count: rows.length } } },
+      }}
       entity={entity}
-      renderDescription={() => (
-        <Description symbol={label.symbol} name={label.name} />
-      )}
-      renderBody={({ disease, target: { hallmarks } }) => {
-        const { rows } = disease.evaSomaticSummary;
-
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
+      renderBody={() => {
+        const { hallmarks } = target;
         const roleInCancerItems =
           hallmarks && hallmarks.attributes.length > 0
             ? hallmarks.attributes
-                .filter((attribute) => attribute.name === "role in cancer")
-                .map((attribute) => ({
+                .filter(attribute => attribute.name === "role in cancer")
+                .map(attribute => ({
                   label: attribute.description,
                   url: epmcUrl(attribute.pmid),
                 }))
@@ -261,16 +340,27 @@ function Body({ id, label, entity }) {
               </Typography>
               <ChipList items={roleInCancerItems} />
             </Box>
-            <DataTable
+            <Table
+              loading={loading}
               columns={columns}
-              rows={rows}
-              dataDownloader
-              showGlobalFilter
-              sortBy="score"
-              order="desc"
+              rows={getPage(processedRows, page, size)}
+              rowCount={count}
               rowsPerPageOptions={defaultRowsPerPageOptions}
+              page={page}
+              pageSize={size}
+              onPageChange={handlePageChange}
+              onRowsPerPageChange={handleRowsPerPageChange}
+              onSortBy={handleSortBy}
               query={EVA_SOMATIC_QUERY.loc.source.body}
-              variables={variables}
+              dataDownloader
+              dataDownloaderRows={getWholeDataset}
+              dataDownloaderFileStem="impc-evidence"
+              variables={{
+                ensemblId,
+                efoId,
+                cursor,
+                size,
+              }}
             />
           </>
         );

--- a/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
+++ b/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
@@ -1,11 +1,14 @@
-query EvaSomaticQuery($ensemblId: String!, $efoId: String!) {
+query EvaSomaticQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    evaSomaticSummary: evidences(
+    evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["eva_somatic"]
+      size: $size
+      cursor: $cursor
     ) {
+      cursor
       count
       rows {
         disease {

--- a/packages/sections/src/evidence/EVASomatic/index.js
+++ b/packages/sections/src/evidence/EVASomatic/index.js
@@ -1,10 +1,10 @@
-import { isPrivateEvidenceSection } from '../../utils/partnerPreviewUtils';
+import { isPrivateEvidenceSection } from "../../utils/partnerPreviewUtils";
 
-const id = 'eva_somatic';
+const id = "eva_somatic";
 export const definition = {
   id,
-  name: 'ClinVar (somatic)',
-  shortName: 'CS',
-  hasData: ({ evaSomaticSummary }) => evaSomaticSummary.count > 0,
+  name: "ClinVar (somatic)",
+  shortName: "CS",
+  hasData: data => data.eva_somatic.count > 0,
   isPrivate: isPrivateEvidenceSection(id),
 };

--- a/packages/sections/src/evidence/Impc/Body.jsx
+++ b/packages/sections/src/evidence/Impc/Body.jsx
@@ -1,14 +1,19 @@
 import { Typography } from "@mui/material";
-import { useQuery } from "@apollo/client";
+import { useState, useEffect } from "react";
+
 import {
   Link,
   SectionItem,
   Tooltip,
-  DataTable,
+  Table,
   TableDrawer,
   MouseModelAllelicComposition,
+  useCursorBatchDownloader,
+  getComparator,
+  getPage,
 } from "ui";
 
+import client from "../../client";
 import { definition } from ".";
 import Description from "./Description";
 import INTOGEN_QUERY from "./sectionQuery.gql";
@@ -37,17 +42,14 @@ const columns = [
         <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
       </Tooltip>
     ),
-    filterValue: ({ disease, diseaseFromSource }) =>
-      [disease.name, diseaseFromSource].join(),
+    filterValue: ({ disease, diseaseFromSource }) => [disease.name, diseaseFromSource].join(),
   },
   {
     id: "diseaseModelAssociatedHumanPhenotypes",
     label: "Human phenotypes",
-    renderCell: ({
-      diseaseModelAssociatedHumanPhenotypes: humanPhenotypes,
-    }) => {
+    renderCell: ({ diseaseModelAssociatedHumanPhenotypes: humanPhenotypes }) => {
       const entries = humanPhenotypes
-        ? humanPhenotypes.map((entry) => ({
+        ? humanPhenotypes.map(entry => ({
             name: entry.label,
             group: "Human phenotypes",
           }))
@@ -63,28 +65,24 @@ const columns = [
       );
     },
     filterValue: ({ diseaseModelAssociatedHumanPhenotypes = [] }) =>
-      diseaseModelAssociatedHumanPhenotypes?.map((dmahp) => dmahp.label).join(),
+      diseaseModelAssociatedHumanPhenotypes?.map(dmahp => dmahp.label).join(),
   },
   {
     id: "diseaseModelAssociatedModelPhenotypes",
     label: "Mouse phenotypes",
 
-    renderCell: ({
-      diseaseModelAssociatedModelPhenotypes: mousePhenotypes,
-    }) => (
+    renderCell: ({ diseaseModelAssociatedModelPhenotypes: mousePhenotypes }) => (
       <TableDrawer
-        entries={mousePhenotypes.map((entry) => ({
+        entries={mousePhenotypes.map(entry => ({
           name: entry.label,
           group: "Mouse phenotypes",
         }))}
         showSingle={false}
-        message={`${mousePhenotypes.length} phenotype${
-          mousePhenotypes.length !== 1 ? "s" : ""
-        }`}
+        message={`${mousePhenotypes.length} phenotype${mousePhenotypes.length !== 1 ? "s" : ""}`}
       />
     ),
     filterValue: ({ diseaseModelAssociatedModelPhenotypes = [] }) =>
-      diseaseModelAssociatedModelPhenotypes.map((dmamp) => dmamp.label).join(),
+      diseaseModelAssociatedModelPhenotypes.map(dmamp => dmamp.label).join(),
   },
   {
     id: "literature",
@@ -108,10 +106,7 @@ const columns = [
           </Link>
         );
       }
-      if (
-        biologicalModelAllelicComposition &&
-        biologicalModelGeneticBackground
-      ) {
+      if (biologicalModelAllelicComposition && biologicalModelGeneticBackground) {
         return (
           <MouseModelAllelicComposition
             allelicComposition={biologicalModelAllelicComposition}
@@ -125,36 +120,137 @@ const columns = [
   },
 ];
 
-function Body({ id, label, entity }) {
-  const { ensgId, efoId } = id;
-  const variables = {
-    ensemblId: ensgId,
-    efoId,
-  };
-  const request = useQuery(INTOGEN_QUERY, {
-    variables,
+function fetchData({ ensemblId, efoId, cursor, size }) {
+  return client.query({
+    query: INTOGEN_QUERY,
+    variables: {
+      ensemblId,
+      efoId,
+      cursor,
+      size,
+    },
   });
+}
+
+function Body({ id, label, entity }) {
+  const { ensgId: ensemblId, efoId } = id;
+  const [initialLoading, setInitialLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [count, setCount] = useState(0);
+  const [cursor, setCursor] = useState("");
+  const [rows, setRows] = useState([]);
+  const [page, setPage] = useState(0);
+  const [size, setPageSize] = useState(10);
+  const [sortColumn, setSortColumn] = useState(null);
+  const [sortOrder, setSortOrder] = useState("asc");
+
+  useEffect(() => {
+    let isCurrent = true;
+
+    fetchData({ ensemblId, efoId, cursor: "", size }).then(res => {
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.evidences;
+      if (isCurrent) {
+        setInitialLoading(false);
+        setCursor(newCursor);
+        setCount(newCount);
+        setRows(newRows);
+      }
+    });
+
+    return () => {
+      isCurrent = false;
+    };
+  }, []);
+
+  const getWholeDataset = useCursorBatchDownloader(
+    INTOGEN_QUERY,
+    {
+      ensemblId,
+      efoId,
+    },
+    `data.disease.impc`
+  );
+
+  const handlePageChange = newPage => {
+    const newPageInt = Number(newPage);
+    if (size * newPageInt + size > rows.length && cursor !== null) {
+      setLoading(true);
+      fetchData({ ensemblId, efoId, cursor, size }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        setRows([...rows, ...newRows]);
+        setLoading(false);
+        setCursor(newCursor);
+        setPage(newPageInt);
+      });
+    } else {
+      setPage(newPageInt);
+    }
+  };
+
+  const handleRowsPerPageChange = newPageSize => {
+    const newPageSizeInt = Number(newPageSize);
+    if (newPageSizeInt > rows.length && cursor !== null) {
+      setLoading(true);
+      fetchData({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        setRows([...rows, ...newRows]);
+        setLoading(false);
+        setCursor(newCursor);
+        setPage(0);
+        setPageSize(newPageSizeInt);
+      });
+    } else {
+      setPage(0);
+      setPageSize(newPageSizeInt);
+    }
+  };
+
+  const handleSortBy = sortBy => {
+    setSortColumn(sortBy);
+    setSortOrder(
+      // eslint-disable-next-line
+      sortColumn === sortBy ? (sortOrder === "asc" ? "desc" : "asc") : "asc"
+    );
+  };
+
+  const processedRows = [...rows];
+
+  if (sortColumn) {
+    processedRows.sort(getComparator(columns, sortOrder, sortColumn));
+  }
 
   return (
     <SectionItem
       definition={definition}
       chipText={dataTypesMap.animal_model}
-      request={request}
+      request={{
+        loading: initialLoading,
+        data: { [entity]: { impc: { rows, count: rows.length } } },
+      }}
       entity={entity}
-      renderDescription={() => (
-        <Description symbol={label.symbol} name={label.name} />
-      )}
-      renderBody={(data) => (
-        <DataTable
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
+      renderBody={() => (
+        <Table
+          loading={loading}
           columns={columns}
-          dataDownloader
-          dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
-          rows={data.disease.impc.rows}
-          pageSize={5}
-          rowsPerPageOptions={[5].concat(defaultRowsPerPageOptions)} // custom page size of 5 is not included in defaultRowsPerPageOptions
-          showGlobalFilter
+          rows={getPage(processedRows, page, size)}
+          rowCount={count}
+          rowsPerPageOptions={defaultRowsPerPageOptions}
+          page={page}
+          pageSize={size}
+          onPageChange={handlePageChange}
+          onRowsPerPageChange={handleRowsPerPageChange}
+          onSortBy={handleSortBy}
           query={INTOGEN_QUERY.loc.source.body}
-          variables={variables}
+          dataDownloader
+          dataDownloaderRows={getWholeDataset}
+          dataDownloaderFileStem="impc-evidence"
+          variables={{
+            ensemblId,
+            efoId,
+            cursor,
+            size,
+          }}
         />
       )}
     />

--- a/packages/sections/src/evidence/Impc/sectionQuery.gql
+++ b/packages/sections/src/evidence/Impc/sectionQuery.gql
@@ -1,11 +1,14 @@
-query impcQuery($ensemblId: String!, $efoId: String!) {
+query impcQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    impc: evidences(
+    evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["impc"]
+      size: $size
+      cursor: $cursor
     ) {
+      cursor
       count
       rows {
         disease {


### PR DESCRIPTION
# [Platform]: Migrate Chembl, IMPC and ClinVar Somatic to server-side pagination

## Description

**Issue:** https://github.com/opentargets/issues/issues/3147
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Check Chembl section on AotF
- Check IMPC section on AotF
- Check ClinVar section on AotF

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
