### PR TITLE
[Platform]: Create configuration provider - migrate version requests to hook

### DIFF
--- a/apps/platform/src/App.tsx
+++ b/apps/platform/src/App.tsx
@@ -1,6 +1,6 @@
 import { BrowserRouter as Router, Route, Switch } from "react-router-dom";
 import { ApolloProvider } from "@apollo/client";
-import { ThemeProvider, SearchProvider, PrivateRoute } from "ui";
+import { ThemeProvider, SearchProvider, PrivateRoute, ConfigurationProvider } from "ui";
 
 import SEARCH_QUERY from "./components/Search/SearchQuery.gql";
 import ShouldAccessPPP from "./components/ShouldAccessPPP";
@@ -23,54 +23,56 @@ function App() {
   const suggestions = getSuggestedSearch();
   return (
     <ApolloProvider client={client}>
-      <ThemeProvider theme={theme}>
-        <SearchProvider
-          searchSuggestions={suggestions}
-          searchQuery={SEARCH_QUERY}
-          searchPlaceholder="Search for a target, drug, disease, or phenotype..."
-        >
-          <Router>
-            <Switch>
-              <Route exact path="/">
-                <HomePage suggestions={suggestions} />
-              </Route>
-              <Route path="/search">
-                <SearchPage />
-              </Route>
-              <Route path="/downloads">
-                <DownloadsPage />
-              </Route>
-              <Route path="/disease/:efoId">
-                <DiseasePage />
-              </Route>
-              <Route path="/target/:ensgId">
-                <TargetPage />
-              </Route>
-              <Route path="/drug/:chemblId">
-                <DrugPage />
-              </Route>
-              <Route path="/evidence/:ensgId/:efoId">
-                <EvidencePage />
-              </Route>
-              <Route path="/variants">
-                <VariantsPage />
-              </Route>
-              <Route path="/api">
-                <APIPage />
-              </Route>
-              <Route path="/projects">
-                <PrivateRoute>
-                  <ProjectsPage />
-                </PrivateRoute>
-              </Route>
-              <Route>
-                <NotFoundPage />
-              </Route>
-            </Switch>
-            <ShouldAccessPPP />
-          </Router>
-        </SearchProvider>
-      </ThemeProvider>
+      <ConfigurationProvider client={client}>
+        <ThemeProvider theme={theme}>
+          <SearchProvider
+            searchSuggestions={suggestions}
+            searchQuery={SEARCH_QUERY}
+            searchPlaceholder="Search for a target, drug, disease, or phenotype..."
+          >
+            <Router>
+              <Switch>
+                <Route exact path="/">
+                  <HomePage suggestions={suggestions} />
+                </Route>
+                <Route path="/search">
+                  <SearchPage />
+                </Route>
+                <Route path="/downloads">
+                  <DownloadsPage />
+                </Route>
+                <Route path="/disease/:efoId">
+                  <DiseasePage />
+                </Route>
+                <Route path="/target/:ensgId">
+                  <TargetPage />
+                </Route>
+                <Route path="/drug/:chemblId">
+                  <DrugPage />
+                </Route>
+                <Route path="/evidence/:ensgId/:efoId">
+                  <EvidencePage />
+                </Route>
+                <Route path="/variants">
+                  <VariantsPage />
+                </Route>
+                <Route path="/api">
+                  <APIPage />
+                </Route>
+                <Route path="/projects">
+                  <PrivateRoute>
+                    <ProjectsPage />
+                  </PrivateRoute>
+                </Route>
+                <Route>
+                  <NotFoundPage />
+                </Route>
+              </Switch>
+              <ShouldAccessPPP />
+            </Router>
+          </SearchProvider>
+        </ThemeProvider>
+      </ConfigurationProvider>
     </ApolloProvider>
   );
 }

--- a/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
@@ -29,7 +29,7 @@ import { styled } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
 import { faCloudArrowDown, faCaretDown } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tooltip } from "ui";
+import { Tooltip, useConfigContext } from "ui";
 import useBatchDownloader from "./hooks/useBatchDownloader";
 import useAotfContext from "./hooks/useAotfContext";
 import OriginalDataSources from "./static_datasets/dataSourcesAssoc";
@@ -149,7 +149,7 @@ const actions = {
 
 function DataDownloader({ fileStem }) {
   const [state, dispatch] = useReducer(reducer, initialState);
-
+  const { version } = useConfigContext();
   const classes = styles();
   const {
     id,
@@ -243,7 +243,7 @@ function DataDownloader({ fileStem }) {
     }
     const blob = createBlob(format)(dataColumns, allRows);
     const d = new Date().toLocaleDateString();
-    FileSaver.saveAs(blob, `${dataFileStem}-${d}.${format}`, {
+    FileSaver.saveAs(blob, `${dataFileStem}-${d}-v${version.year}.${version.month}.${format}`, {
       autoBOM: false,
     });
   };

--- a/apps/platform/src/pages/HomePage/Version.jsx
+++ b/apps/platform/src/pages/HomePage/Version.jsx
@@ -1,6 +1,5 @@
-import { gql, useQuery } from '@apollo/client';
-import { Box, Typography } from '@mui/material';
-import { Link } from 'ui';
+import { Box, Typography } from "@mui/material";
+import { Link, useConfigContext } from "ui";
 
 // HELPERS
 function getVersion({ month, year }) {
@@ -9,20 +8,8 @@ function getVersion({ month, year }) {
 
 function getFullMonth({ month, year }) {
   const date = new Date(year + 2000, month - 1);
-  return date.toLocaleString('default', { month: 'long' });
+  return date.toLocaleString("default", { month: "long" });
 }
-
-// QUERY
-const DATA_VERSION_QUERY = gql`
-  query DataVersion {
-    meta {
-      dataVersion {
-        month
-        year
-      }
-    }
-  }
-`;
 
 // CONTAINER
 function VersionContainer({ children }) {
@@ -43,35 +30,25 @@ function VersionLink({ month, year, version, link }) {
 }
 
 // MAIN COMPONENT
-function Version({
-  releaseNotesURL = 'https://platform-docs.opentargets.org/release-notes',
-}) {
-  const { data, loading, error } = useQuery(DATA_VERSION_QUERY);
-  if (error) return null;
-  if (loading)
+function Version({ releaseNotesURL = "https://platform-docs.opentargets.org/release-notes" }) {
+  const { version } = useConfigContext();
+  if (version.error) return null;
+  if (version.loading)
     return (
       <VersionContainer>
         <Typography variant="body2">Loading data version ...</Typography>
       </VersionContainer>
     );
-  const {
-    meta: {
-      dataVersion: { month, year },
-    },
-  } = data;
-  const version = getVersion({ month, year });
+  const { month, year } = version;
+
+  const parsedVersion = getVersion({ month, year });
   const fullMonth = getFullMonth({ month, year });
 
   return (
     <VersionContainer>
       <Typography variant="body2">
-        Last update:{' '}
-        <VersionLink
-          link={releaseNotesURL}
-          month={fullMonth}
-          year={year}
-          version={version}
-        />
+        Last update:{" "}
+        <VersionLink link={releaseNotesURL} month={fullMonth} year={year} version={parsedVersion} />
       </Typography>
     </VersionContainer>
   );

--- a/packages/ui/src/contexts/ConfigurationProvider.tsx
+++ b/packages/ui/src/contexts/ConfigurationProvider.tsx
@@ -1,0 +1,87 @@
+import { PropsWithChildren, createContext, useContext, useEffect, useState } from "react";
+import { gql, useQuery, ApolloError, NormalizedCacheObject, ApolloClient } from "@apollo/client";
+
+// QUERY
+const DATA_VERSION_QUERY = gql`
+  query DataVersion {
+    meta {
+      dataVersion {
+        month
+        year
+      }
+    }
+  }
+`;
+
+type Version = {
+  month: string;
+  year: string;
+  loading: boolean;
+  error: ApolloError | null;
+};
+
+type ContextType = {
+  version: Version;
+  client: ApolloClient<NormalizedCacheObject> | null;
+};
+
+interface ProviderProps extends PropsWithChildren {
+  client: ApolloClient<NormalizedCacheObject>;
+}
+
+const initialState: ContextType = {
+  version: {
+    loading: false,
+    error: null,
+    month: "0",
+    year: "0",
+  },
+  client: null,
+};
+export const ConfigurationContext = createContext<ContextType | undefined>(undefined);
+
+export const ConfigurationProvider = ({ children, client }: ProviderProps): JSX.Element => {
+  const [version, setVersion] = useState<ContextType["version"]>(initialState.version);
+
+  const { data, loading, error } = useQuery(DATA_VERSION_QUERY);
+
+  useEffect(() => {
+    if (loading) {
+      setVersion(v => ({ ...v, loading }));
+      return;
+    }
+
+    if (error) {
+      setVersion(v => ({ ...v, error }));
+      return;
+    }
+    const {
+      meta: {
+        dataVersion: { month, year },
+      },
+    } = data;
+
+    setVersion({
+      loading: false,
+      error: null,
+      month: month,
+      year: year,
+    });
+  }, [data, loading, error]);
+
+  return (
+    <ConfigurationContext.Provider value={{ version, client }}>
+      {children}
+    </ConfigurationContext.Provider>
+  );
+};
+
+export const useConfigContext = (): ContextType => {
+  const context = useContext(ConfigurationContext);
+
+  if (!context) {
+    throw new Error("useConfigContext must be used inside the ConfigurationProvider");
+  }
+
+  return context;
+};

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -36,6 +36,7 @@ export { default as NotFoundPage } from "./pages/NotFoundPage";
 export { default as Page } from "./pages/Page";
 
 export { default as PlatformApiProvider } from "./contexts/PlatformApiProvider";
+export * from "./contexts/ConfigurationProvider";
 
 export * as summaryUtils from "./components/Summary/utils";
 export * from "./components/Section";


### PR DESCRIPTION
# [Platform]: Create configuration provider - migrate version requests to hook

## Description

To enforce development experience and code quality, we should unify the data version and client import from one source of truth. This PR creates a new ConfigurationProvider with a hook (useConfigContext) that exposes a data version and ApolloClient instance.

**Issue:** https://github.com/opentargets/issues/issues/3165
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Check home page data version
- Check AotF exported file name with version

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
