### PR TITLE
[Platform]: SSP data download fix - gql query variable and reference change

### DIFF
--- a/packages/sections/src/evidence/Chembl/Body.jsx
+++ b/packages/sections/src/evidence/Chembl/Body.jsx
@@ -224,7 +224,7 @@ function Body({ id, label, entity }) {
     let isCurrent = true;
 
     fetchData({ ensemblId, efoId, cursor: "", size }).then(res => {
-      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.evidences;
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.chembl;
       if (isCurrent) {
         setInitialLoading(false);
         setCursor(newCursor);
@@ -244,7 +244,7 @@ function Body({ id, label, entity }) {
       ensemblId,
       efoId,
     },
-    `data.disease.evidence`
+    `data.disease.chembl`
   );
 
   const handlePageChange = newPage => {
@@ -252,7 +252,7 @@ function Body({ id, label, entity }) {
     if (size * newPageInt + size > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.chembl;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);
@@ -268,7 +268,7 @@ function Body({ id, label, entity }) {
     if (newPageSizeInt > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.chembl;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);

--- a/packages/sections/src/evidence/Chembl/ChemblQuery.gql
+++ b/packages/sections/src/evidence/Chembl/ChemblQuery.gql
@@ -1,7 +1,7 @@
 query ChemblQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    evidences(
+    chembl: evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["chembl"]

--- a/packages/sections/src/evidence/EVA/Body.jsx
+++ b/packages/sections/src/evidence/EVA/Body.jsx
@@ -40,26 +40,17 @@ function getColumns(label) {
               <Typography variant="subtitle2" display="block" align="center">
                 Reported disease or phenotype:
               </Typography>
-              <Typography
-                variant="caption"
-                display="block"
-                align="center"
-                gutterBottom
-              >
+              <Typography variant="caption" display="block" align="center" gutterBottom>
                 {diseaseFromSource}
               </Typography>
 
               {cohortPhenotypes?.length > 1 ? (
                 <>
-                  <Typography
-                    variant="subtitle2"
-                    display="block"
-                    align="center"
-                  >
+                  <Typography variant="subtitle2" display="block" align="center">
                     All reported phenotypes:
                   </Typography>
                   <Typography variant="caption" display="block">
-                    {cohortPhenotypes.map((cp) => (
+                    {cohortPhenotypes.map(cp => (
                       <div key={cp}>{cp}</div>
                     ))}
                   </Typography>
@@ -137,22 +128,14 @@ function getColumns(label) {
                 label={variantConsequenceSource.VEP.label}
                 value={sentenceCase(variantFunctionalConsequence.label)}
                 tooltip={variantConsequenceSource.VEP.tooltip}
-                to={identifiersOrgLink(
-                  "SO",
-                  variantFunctionalConsequence.id.slice(3)
-                )}
+                to={identifiersOrgLink("SO", variantFunctionalConsequence.id.slice(3))}
               />
             )}
             {variantFunctionalConsequenceFromQtlId && (
               <LabelChip
                 label={variantConsequenceSource.QTL.label}
-                value={sentenceCase(
-                  variantFunctionalConsequenceFromQtlId.label
-                )}
-                to={identifiersOrgLink(
-                  "SO",
-                  variantFunctionalConsequenceFromQtlId.id.slice(3)
-                )}
+                value={sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
+                to={identifiersOrgLink("SO", variantFunctionalConsequenceFromQtlId.id.slice(3))}
                 tooltip={variantConsequenceSource.QTL.tooltip}
               />
             )}
@@ -167,10 +150,7 @@ function getColumns(label) {
           </div>
         );
       },
-      filterValue: ({
-        variantFunctionalConsequence,
-        variantFunctionalConsequenceFromQtlId,
-      }) =>
+      filterValue: ({ variantFunctionalConsequence, variantFunctionalConsequenceFromQtlId }) =>
         `${sentenceCase(variantFunctionalConsequence.label)}, ${sentenceCase(
           variantFunctionalConsequenceFromQtlId.label
         )}`,
@@ -181,8 +161,7 @@ function getColumns(label) {
       label: "Clinical significance",
       renderCell: ({ clinicalSignificances }) => {
         if (!clinicalSignificances) return naLabel;
-        if (clinicalSignificances.length === 1)
-          return sentenceCase(clinicalSignificances[0]);
+        if (clinicalSignificances.length === 1) return sentenceCase(clinicalSignificances[0]);
         return (
           <ul
             style={{
@@ -191,10 +170,8 @@ function getColumns(label) {
               listStyle: "none",
             }}
           >
-            {clinicalSignificances.map((clinicalSignificance) => (
-              <li key={clinicalSignificance}>
-                {sentenceCase(clinicalSignificance)}
-              </li>
+            {clinicalSignificances.map(clinicalSignificance => (
+              <li key={clinicalSignificance}>{sentenceCase(clinicalSignificance)}</li>
             ))}
           </ul>
         );
@@ -211,14 +188,10 @@ function getColumns(label) {
             <Tooltip
               title={
                 <>
-                  <Typography
-                    variant="subtitle2"
-                    display="block"
-                    align="center"
-                  >
+                  <Typography variant="subtitle2" display="block" align="center">
                     Allelic requirements:
                   </Typography>
-                  {allelicRequirements.map((r) => (
+                  {allelicRequirements.map(r => (
                     <Typography variant="caption" key={r}>
                       {r}
                     </Typography>
@@ -227,14 +200,13 @@ function getColumns(label) {
               }
               showHelpIcon
             >
-              {alleleOrigins.map((a) => sentenceCase(a)).join("; ")}
+              {alleleOrigins.map(a => sentenceCase(a)).join("; ")}
             </Tooltip>
           );
 
-        return alleleOrigins.map((a) => sentenceCase(a)).join("; ");
+        return alleleOrigins.map(a => sentenceCase(a)).join("; ");
       },
-      filterValue: ({ alleleOrigins }) =>
-        alleleOrigins ? alleleOrigins.join() : "",
+      filterValue: ({ alleleOrigins }) => (alleleOrigins ? alleleOrigins.join() : ""),
     },
     {
       id: "confidence",
@@ -263,11 +235,7 @@ function getColumns(label) {
           }, []) || [];
 
         return (
-          <PublicationsDrawer
-            entries={literatureList}
-            symbol={label.symbol}
-            name={label.name}
-          />
+          <PublicationsDrawer entries={literatureList} symbol={label.symbol} name={label.name} />
         );
       },
     },
@@ -305,12 +273,8 @@ function Body({ id, label, entity }) {
   useEffect(() => {
     let isCurrent = true;
 
-    fetchClinvar({ ensemblId, efoId, cursor: "", size }).then((res) => {
-      const {
-        cursor: newCursor,
-        rows: newRows,
-        count: newCount,
-      } = res.data.disease.evidences;
+    fetchClinvar({ ensemblId, efoId, cursor: "", size }).then(res => {
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.eva;
       if (isCurrent) {
         setInitialLoading(false);
         setCursor(newCursor);
@@ -330,15 +294,15 @@ function Body({ id, label, entity }) {
       ensemblId,
       efoId,
     },
-    `data.disease.evaSummary`
+    `data.disease.eva`
   );
 
-  const handlePageChange = (newPage) => {
+  const handlePageChange = newPage => {
     const newPageInt = Number(newPage);
     if (size * newPageInt + size > rows.length && cursor !== null) {
       setLoading(true);
-      fetchClinvar({ ensemblId, efoId, cursor, size }).then((res) => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+      fetchClinvar({ ensemblId, efoId, cursor, size }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.eva;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);
@@ -349,28 +313,25 @@ function Body({ id, label, entity }) {
     }
   };
 
-  const handleRowsPerPageChange = (newPageSize) => {
+  const handleRowsPerPageChange = newPageSize => {
     const newPageSizeInt = Number(newPageSize);
     if (newPageSizeInt > rows.length && cursor !== null) {
       setLoading(true);
-      fetchClinvar({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(
-        (res) => {
-          const { cursor: newCursor, rows: newRows } =
-            res.data.disease.evidences;
-          setRows([...rows, ...newRows]);
-          setLoading(false);
-          setCursor(newCursor);
-          setPage(0);
-          setPageSize(newPageSizeInt);
-        }
-      );
+      fetchClinvar({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
+        const { cursor: newCursor, rows: newRows } = res.data.disease.eva;
+        setRows([...rows, ...newRows]);
+        setLoading(false);
+        setCursor(newCursor);
+        setPage(0);
+        setPageSize(newPageSizeInt);
+      });
     } else {
       setPage(0);
       setPageSize(newPageSizeInt);
     }
   };
 
-  const handleSortBy = (sortBy) => {
+  const handleSortBy = sortBy => {
     setSortColumn(sortBy);
     setSortOrder(
       // eslint-disable-next-line
@@ -391,11 +352,9 @@ function Body({ id, label, entity }) {
       entity={entity}
       request={{
         loading: initialLoading,
-        data: { [entity]: { evaSummary: { rows, count: rows.length } } },
+        data: { [entity]: { eva: { rows, count: rows.length } } },
       }}
-      renderDescription={() => (
-        <Description symbol={label.symbol} name={label.name} />
-      )}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
       renderBody={() => (
         <Table
           // showGlobalFilter

--- a/packages/sections/src/evidence/EVA/ClinvarQuery.gql
+++ b/packages/sections/src/evidence/EVA/ClinvarQuery.gql
@@ -1,16 +1,11 @@
-query ClinvarQuery(
-  $ensemblId: String!
-  $efoId: String!
-  $size: Int!
-  $cursor: String
-) {
+query ClinvarQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   target(ensemblId: $ensemblId) {
     approvedSymbol
   }
   disease(efoId: $efoId) {
     id
     name
-    evidences(
+    eva: evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["eva"]

--- a/packages/sections/src/evidence/EVA/EVASummaryQuery.gql
+++ b/packages/sections/src/evidence/EVA/EVASummaryQuery.gql
@@ -1,10 +1,5 @@
 fragment evaSummary on Disease {
-  evaSummary: evidences(
-    ensemblIds: [$ensgId]
-    enableIndirect: true
-    datasourceIds: ["eva"]
-    size: 0
-  ) {
+  eva: evidences(ensemblIds: [$ensgId], enableIndirect: true, datasourceIds: ["eva"], size: 0) {
     count
   }
 }

--- a/packages/sections/src/evidence/EVA/index.js
+++ b/packages/sections/src/evidence/EVA/index.js
@@ -1,10 +1,10 @@
-import { isPrivateEvidenceSection } from '../../utils/partnerPreviewUtils';
+import { isPrivateEvidenceSection } from "../../utils/partnerPreviewUtils";
 
-const id = 'eva';
+const id = "eva";
 export const definition = {
   id,
-  name: 'ClinVar',
-  shortName: 'CV',
-  hasData: ({ evaSummary }) => evaSummary.count > 0,
+  name: "ClinVar",
+  shortName: "CV",
+  hasData: ({ eva }) => eva.count > 0,
   isPrivate: isPrivateEvidenceSection(id),
 };

--- a/packages/sections/src/evidence/EVASomatic/Body.jsx
+++ b/packages/sections/src/evidence/EVASomatic/Body.jsx
@@ -239,7 +239,7 @@ function Body({ id, label, entity }) {
     let isCurrent = true;
 
     fetchData({ ensemblId, efoId, cursor: "", size }).then(res => {
-      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.evidences;
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.eva_somatic;
       if (isCurrent) {
         setInitialLoading(false);
         setCursor(newCursor);
@@ -260,7 +260,7 @@ function Body({ id, label, entity }) {
       ensemblId,
       efoId,
     },
-    `data.disease.impc`
+    `data.disease.eva_somatic`
   );
 
   const handlePageChange = newPage => {
@@ -268,7 +268,7 @@ function Body({ id, label, entity }) {
     if (size * newPageInt + size > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.eva_somatic;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);
@@ -284,7 +284,7 @@ function Body({ id, label, entity }) {
     if (newPageSizeInt > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.eva_somatic;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);

--- a/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
+++ b/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
@@ -1,7 +1,7 @@
 query EvaSomaticQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    evidences(
+    eva_somatic: evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["eva_somatic"]

--- a/packages/sections/src/evidence/Impc/Body.jsx
+++ b/packages/sections/src/evidence/Impc/Body.jsx
@@ -148,7 +148,7 @@ function Body({ id, label, entity }) {
     let isCurrent = true;
 
     fetchData({ ensemblId, efoId, cursor: "", size }).then(res => {
-      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.evidences;
+      const { cursor: newCursor, rows: newRows, count: newCount } = res.data.disease.impc;
       if (isCurrent) {
         setInitialLoading(false);
         setCursor(newCursor);
@@ -176,7 +176,7 @@ function Body({ id, label, entity }) {
     if (size * newPageInt + size > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.impc;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);
@@ -192,7 +192,7 @@ function Body({ id, label, entity }) {
     if (newPageSizeInt > rows.length && cursor !== null) {
       setLoading(true);
       fetchData({ ensemblId, efoId, cursor, size: newPageSizeInt }).then(res => {
-        const { cursor: newCursor, rows: newRows } = res.data.disease.evidences;
+        const { cursor: newCursor, rows: newRows } = res.data.disease.impc;
         setRows([...rows, ...newRows]);
         setLoading(false);
         setCursor(newCursor);

--- a/packages/sections/src/evidence/Impc/sectionQuery.gql
+++ b/packages/sections/src/evidence/Impc/sectionQuery.gql
@@ -1,7 +1,7 @@
 query impcQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor: String) {
   disease(efoId: $efoId) {
     id
-    evidences(
+    impc: evidences(
       ensemblIds: [$ensemblId]
       enableIndirect: true
       datasourceIds: ["impc"]


### PR DESCRIPTION
# [Platform]: SSP data download fix - gql query variable and reference change

## query variable name and reference updated for evidence sections: 
1. Chembl
2. Clinvar
3. Clinvar somatic
4. IMPC

**Issue:** # https://github.com/opentargets/issues/issues/3166
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: following sections download data addresses : 

1. Chembl
2. Clinvar
3. Clinvar somatic
4. IMPC


## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
