### PR TITLE
[Platform]: Adding docs link to aotf upload 

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/DataUploader/DataUploader.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/DataUploader/DataUploader.jsx
@@ -27,7 +27,7 @@ import {
   faPlay,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Tooltip } from "ui";
+import { Link, Tooltip } from "ui";
 
 import useAotfContext from "../hooks/useAotfContext";
 import ValidationQuery from "./ValidationQuery.gql";
@@ -262,7 +262,13 @@ function DataUploader({ fileStem }) {
           >
             Please upload a text file here containing your custom list of targets/diseases. The file
             should contain a single {entityToGet} in every row. You will be able to visualise all
-            the potential matches upon validation of your input.
+            the potential matches upon validation of your input. <br />
+            <Link
+              to="https://home.opentargets.org/aotf-documentation#upload-to-associations-on-the-fly"
+              external
+            >
+              Read more details here.
+            </Link>
           </Typography>
           <FileExample entity={entityToGet} runAction={handleRunExample} />
           <Box sx={{ m: theme => `${theme.spacing(1)} 0 ${theme.spacing(4)} 0` }}>


### PR DESCRIPTION
# [Platform]: Adding docs link to aotf upload 

## Adding link to upload docs

**Issue:** # (link)
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: go to aotf upload popup and click on docs link

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
