### PR TITLE
[Platform]: Updated GTEx API calls to v2 on target page

### DIFF
--- a/packages/sections/src/target/Expression/GtexTab.jsx
+++ b/packages/sections/src/target/Expression/GtexTab.jsx
@@ -37,11 +37,11 @@ const transformData = (data) =>
 
 export async function getData(symbol) {
   try {
-    const urlGene = `https://gtexportal.org/rest/v1/reference/gene?format=json&geneId=${symbol}`;
+    const urlGene = `https://gtexportal.org/api/v2/reference/gene?format=json&geneId=${symbol}`;
     const resGene = await fetch(urlGene);
     const rawGene = await resGene.json();
-    const { gencodeId } = rawGene.gene[0];
-    const urlData = `https://gtexportal.org/rest/v1/expression/geneExpression?gencodeId=${gencodeId}`;
+    const { gencodeId } = rawGene.data[0];
+    const urlData = `https://gtexportal.org/api/v2/expression/geneExpression?gencodeId=${gencodeId}`;
     const resData = await fetch(urlData);
     const rawData = await resData.json();
     // TODO:
@@ -49,7 +49,7 @@ export async function getData(symbol) {
     // Ideally when switching tabs we don't want to check and hide the widget, so this should be handled differently
     const data = {
       target: {
-        expressions: transformData(rawData.geneExpression),
+        expressions: transformData(rawData.data),
       },
     };
 


### PR DESCRIPTION
GTEx tab was broken because the API was outdated (v1). Updated target page to use the GTEx API v2.

## Type of change
Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?
Ran yarn dev:platform locally

## Checklist:
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules