### PR TITLE
[Platform]: fix: chembl apollo cache rows MechanismsOfAction

### DIFF
--- a/apps/platform/src/client.js
+++ b/apps/platform/src/client.js
@@ -14,7 +14,7 @@ const client = new ApolloClient({
         keyFields: [],
       },
       MechanismsOfAction: {
-        keyFields: [],
+        keyFields: ["rows"],
       },
       Hallmarks: {
         keyFields: [],

--- a/packages/sections/src/drug/MechanismsOfAction/MechanismsOfActionSummaryFragment.gql
+++ b/packages/sections/src/drug/MechanismsOfAction/MechanismsOfActionSummaryFragment.gql
@@ -2,13 +2,12 @@ fragment MechanismsOfActionSummaryFragment on Drug {
   mechanismsOfAction {
     uniqueActionTypes
     uniqueTargetTypes
-  }
-  parentMolecule {
-    id
-    name
-  }
-  childMolecules {
-    id
-    name
+    rows {
+      mechanismOfAction
+      targets {
+        id
+        approvedSymbol
+      }
+    }
   }
 }

--- a/packages/sections/src/evidence/Chembl/Body.jsx
+++ b/packages/sections/src/evidence/Chembl/Body.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useContext } from "react";
 import { makeStyles } from "@mui/styles";
 import {
   Link,
@@ -10,12 +10,12 @@ import {
   useCursorBatchDownloader,
   getComparator,
   getPage,
+  ConfigurationContext,
 } from "ui";
 import { defaultRowsPerPageOptions, phaseMap, sourceMap, naLabel } from "../../constants";
 import { dataTypesMap } from "../../dataTypes";
 import Description from "./Description";
 import { definition } from ".";
-import client from "../../client";
 
 import CHEMBL_QUERY from "./ChemblQuery.gql";
 
@@ -232,18 +232,6 @@ function getColumns(classes) {
   ];
 }
 
-function fetchData({ ensemblId, efoId, cursor, size }) {
-  return client.query({
-    query: CHEMBL_QUERY,
-    variables: {
-      ensemblId,
-      efoId,
-      cursor,
-      size,
-    },
-  });
-}
-
 function Body({ id, label, entity }) {
   const { ensgId: ensemblId, efoId } = id;
   const [initialLoading, setInitialLoading] = useState(true);
@@ -255,6 +243,7 @@ function Body({ id, label, entity }) {
   const [size, setPageSize] = useState(10);
   const [sortColumn, setSortColumn] = useState(null);
   const [sortOrder, setSortOrder] = useState("asc");
+  const { client } = useContext(ConfigurationContext);
 
   const classes = useStyles();
   const columns = getColumns(classes);
@@ -332,6 +321,18 @@ function Body({ id, label, entity }) {
 
   if (sortColumn) {
     processedRows.sort(getComparator(columns, sortOrder, sortColumn));
+  }
+
+  function fetchData({ ensemblId, efoId, cursor, size }) {
+    return client.query({
+      query: CHEMBL_QUERY,
+      variables: {
+        ensemblId,
+        efoId,
+        cursor,
+        size,
+      },
+    });
   }
 
   return (


### PR DESCRIPTION
# [Platform]: fix: chembl apollo cache rows MechanismsOfAction

## Adding rows inside mechanism of action to InMemoryCache to avoid cache and overlap of rows keys in the response.

**Issue:** # https://github.com/opentargets/issues/issues/3168
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: chembl widget for cancer working
- [ ] Test B: client js refactor pending. 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
