### PR TITLE
[Platform]: Adding api query playground to aotf 

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/CopyUrlButton.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/CopyUrlButton.jsx
@@ -1,6 +1,6 @@
 import { faLink } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Slide, Snackbar } from "@mui/material";
+import { IconButton, Slide, Snackbar } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { useState } from "react";
 import { Tooltip } from "ui";
@@ -25,16 +25,15 @@ function CopyUrlButton() {
   return (
     <>
       <Tooltip placement="bottom" title="Copy URL. Data sources controls not included">
-        <Button
-          sx={{ mr: theme => theme.spacing(1) }}
-          variant="outlined"
+        <IconButton
+          // variant="text"
           onClick={() => {
             setUrlSnackbar(true);
             navigator.clipboard.writeText(window.location.href);
           }}
         >
-          <FontAwesomeIcon icon={faLink} />
-        </Button>
+          <FontAwesomeIcon size="xs" icon={faLink} />
+        </IconButton>
       </Tooltip>
 
       <Snackbar

--- a/apps/platform/src/components/AssociationsToolkit/CopyUrlButton.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/CopyUrlButton.jsx
@@ -26,7 +26,6 @@ function CopyUrlButton() {
     <>
       <Tooltip placement="bottom" title="Copy URL. Data sources controls not included">
         <IconButton
-          // variant="text"
           onClick={() => {
             setUrlSnackbar(true);
             navigator.clipboard.writeText(window.location.href);

--- a/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
@@ -27,7 +27,7 @@ import {
 } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { makeStyles } from "@mui/styles";
-import { faCloudArrowDown, faCaretDown } from "@fortawesome/free-solid-svg-icons";
+import { faCaretDown, faShareFromSquare } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { Tooltip, useConfigContext } from "ui";
 import useBatchDownloader from "./hooks/useBatchDownloader";
@@ -42,6 +42,7 @@ import {
   getFilteredColumnArray,
 } from "./utils/downloads";
 import config from "../../config";
+import CopyUrlButton from "./CopyUrlButton";
 
 const { isPartnerPreview } = config.profile;
 
@@ -274,14 +275,14 @@ function DataDownloader({ fileStem }) {
 
   return (
     <div>
-      <Tooltip placement="bottom" title="Export results">
+      <Tooltip placement="bottom" title="Share / Export">
         <Button
           aria-describedby={popoverId}
           onClick={handleClickBTN}
           variant="outlined"
           disableElevation
         >
-          <FontAwesomeIcon icon={faCloudArrowDown} size="lg" />
+          <FontAwesomeIcon icon={faShareFromSquare} size="lg" />
         </Button>
       </Tooltip>
       <Dialog
@@ -295,7 +296,9 @@ function DataDownloader({ fileStem }) {
           },
         }}
       >
-        <DialogTitle>Export: {fileStem} data</DialogTitle>
+        <DialogTitle sx={{ display: "flex", justifyContent: "space-between" }}>
+          Export: {fileStem} data <CopyUrlButton />
+        </DialogTitle>
         <DialogContent>
           <Typography
             sx={{ m: theme => `${theme.spacing(1)} 0 ${theme.spacing(4)} 0` }}

--- a/apps/platform/src/components/AssociationsToolkit/context/AssociationsContext.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/context/AssociationsContext.jsx
@@ -1,19 +1,14 @@
-import { createContext, useState, useMemo, useEffect } from 'react';
-import { isEqual } from 'lodash';
-import { useStateParams } from 'ui';
-import {
-  defaulDatasourcesWeigths,
-  getControlChecked,
-  getCellId,
-  checkBoxPayload,
-} from '../utils';
-import dataSources from '../static_datasets/dataSourcesAssoc';
+import { createContext, useState, useMemo, useEffect } from "react";
+import { isEqual } from "lodash";
+import { useStateParams } from "ui";
+import { defaulDatasourcesWeigths, getControlChecked, getCellId, checkBoxPayload } from "../utils";
+import dataSources from "../static_datasets/dataSourcesAssoc";
 
-import useAssociationsData from '../hooks/useAssociationsData';
+import useAssociationsData from "../hooks/useAssociationsData";
 
 const AssociationsContext = createContext();
 
-const initialIndirect = entity => entity !== 'target';
+const initialIndirect = entity => entity !== "target";
 const initialPagination = {
   pageIndex: 0,
   pageSize: 50,
@@ -40,31 +35,28 @@ function AssociationsProvider({ children, entity, id, query }) {
 
   // Data controls
   const [enableIndirect, setEnableIndirect] = useState(initialIndirect(entity));
-  const [dataSourcesWeights, setDataSourcesWeights] = useState(
-    defaulDatasourcesWeigths
-  );
+  const [dataSourcesWeights, setDataSourcesWeights] = useState(defaulDatasourcesWeigths);
   const [dataSourcesRequired, setDataSourcesRequired] = useState([]);
-  const [modifiedSourcesDataControls, setModifiedSourcesDataControls] =
-    useState(false);
-  const [searhFilter, setSearhFilter] = useState('');
-  const [sorting, setSorting] = useState([{ id: 'score', desc: true }]);
+  const [modifiedSourcesDataControls, setModifiedSourcesDataControls] = useState(false);
+  const [searhFilter, setSearhFilter] = useState("");
+  const [sorting, setSorting] = useState([{ id: "score", desc: true }]);
 
   // Data controls UI
   const [activeHeadersControlls, setActiveHeadersControlls] = useState(false);
 
   // only two posible (associations || prioritisations)
   const [displayedTable, setDisplayedTable] = useStateParams(
-    'associations',
-    'table',
+    "associations",
+    "table",
     arr => arr,
     str => str
   );
 
   const [pinnedEntries, setPinnedEntries] = useStateParams(
     [],
-    'pinned',
-    arr => arr.join(','),
-    str => str.split(',')
+    "pinned",
+    arr => arr.join(","),
+    str => str.split(",")
   );
 
   const { data, initialLoading, loading, error, count } = useAssociationsData({
@@ -102,18 +94,13 @@ function AssociationsProvider({ children, entity, id, query }) {
   });
 
   useEffect(() => {
-    if (
-      isEqual(defaulDatasourcesWeigths, dataSourcesWeights) &&
-      isEqual(dataSourcesRequired, [])
-    )
+    if (isEqual(defaulDatasourcesWeigths, dataSourcesWeights) && isEqual(dataSourcesRequired, []))
       setModifiedSourcesDataControls(false);
     else setModifiedSourcesDataControls(true);
   }, [dataSourcesWeights, dataSourcesRequired]);
 
   const handleAggregationClick = aggregationId => {
-    const aggregationDatasources = dataSources.filter(
-      el => el.aggregation === aggregationId
-    );
+    const aggregationDatasources = dataSources.filter(el => el.aggregation === aggregationId);
     let isAllActive = true;
     aggregationDatasources.forEach(e => {
       if (getControlChecked(dataSourcesRequired, e.id) === false) {
@@ -123,9 +110,7 @@ function AssociationsProvider({ children, entity, id, query }) {
     if (isAllActive) {
       let newPayload = [...dataSourcesRequired];
       aggregationDatasources.forEach(element => {
-        const indexToRemove = newPayload.findIndex(
-          datasource => datasource.id === element.id
-        );
+        const indexToRemove = newPayload.findIndex(datasource => datasource.id === element.id);
         const newRequiredElement = [
           ...newPayload.slice(0, indexToRemove),
           ...newPayload.slice(indexToRemove + 1),
@@ -144,7 +129,7 @@ function AssociationsProvider({ children, entity, id, query }) {
     }
   };
 
-  const entityToGet = entity === 'target' ? 'disease' : 'target';
+  const entityToGet = entity === "target" ? "disease" : "target";
 
   const resetToInitialPagination = () => {
     setTableExpanded({});
@@ -161,7 +146,7 @@ function AssociationsProvider({ children, entity, id, query }) {
   const handleSortingChange = newSortingFunc => {
     const newSorting = newSortingFunc();
     if (newSorting[0].id === sorting[0].id) {
-      setSorting([{ id: 'score', desc: true }]);
+      setSorting([{ id: "score", desc: true }]);
       return;
     }
     setSorting(newSorting);
@@ -174,13 +159,8 @@ function AssociationsProvider({ children, entity, id, query }) {
   };
 
   const expanderHandler = tableExpanderController => (cell, tablePrefix) => {
-    const expandedId = getCellId(
-      cell,
-      entityToGet,
-      displayedTable,
-      tablePrefix
-    );
-    if (expanded.join('-') === expandedId.join('-')) {
+    const expandedId = getCellId(cell, entityToGet, displayedTable, tablePrefix);
+    if (expanded.join("-") === expandedId.join("-")) {
       setTableExpanded({});
       setExpanded([]);
       return;
@@ -231,6 +211,8 @@ function AssociationsProvider({ children, entity, id, query }) {
     pinnedCount,
     pinExpanded,
     pinnedEntries,
+    pageIndex,
+    pageSize,
     resetToInitialPagination,
     setPinnedEntries,
     setPinExpanded,
@@ -251,9 +233,7 @@ function AssociationsProvider({ children, entity, id, query }) {
   }));
 
   return (
-    <AssociationsContext.Provider value={contextVariables}>
-      {children}
-    </AssociationsContext.Provider>
+    <AssociationsContext.Provider value={contextVariables}>{children}</AssociationsContext.Provider>
   );
 }
 

--- a/apps/platform/src/components/AssociationsToolkit/context/AssociationsContext.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/context/AssociationsContext.jsx
@@ -211,8 +211,6 @@ function AssociationsProvider({ children, entity, id, query }) {
     pinnedCount,
     pinExpanded,
     pinnedEntries,
-    pageIndex,
-    pageSize,
     resetToInitialPagination,
     setPinnedEntries,
     setPinExpanded,

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -15,9 +15,35 @@ import {
 } from "../../../components/AssociationsToolkit";
 import DISEASE_ASSOCIATIONS_QUERY from "./DiseaseAssociationsQuery.gql";
 import CopyUrlButton from "../../../components/AssociationsToolkit/CopyUrlButton";
+import ApiPlaygroundDrawer from "ui/src/components/ApiPlaygroundDrawer";
 
 function AssociationsWrapper() {
-  const { initialLoading, id } = useAotfContext();
+  const {
+    initialLoading,
+    id,
+    pageIndex,
+    pageSize,
+    searhFilter,
+    sorting,
+    enableIndirect,
+    dataSourcesWeights,
+    entity,
+    dataSourcesRequired,
+  } = useAotfContext();
+
+  const variables = {
+    id,
+    index: pageIndex,
+    size: pageSize,
+    filter: searhFilter,
+    sortBy: sorting[0].id,
+    enableIndirect,
+    datasources: dataSourcesWeights,
+    entity,
+    aggregationFilters: dataSourcesRequired,
+  };
+
+  console.log(DISEASE_ASSOCIATIONS_QUERY);
 
   if (initialLoading) return <AotFLoader />;
 
@@ -37,6 +63,10 @@ function AssociationsWrapper() {
           </OptionsControlls>
         </Box>
         <Box>
+          <ApiPlaygroundDrawer
+            query={DISEASE_ASSOCIATIONS_QUERY.loc.source.body}
+            variables={variables}
+          />
           <TargetPrioritisationSwitch />
         </Box>
       </ControlsSection>

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -14,7 +14,6 @@ import {
   DataUploader,
 } from "../../../components/AssociationsToolkit";
 import DISEASE_ASSOCIATIONS_QUERY from "./DiseaseAssociationsQuery.gql";
-import CopyUrlButton from "../../../components/AssociationsToolkit/CopyUrlButton";
 import ApiPlaygroundDrawer from "ui/src/components/ApiPlaygroundDrawer";
 
 function AssociationsWrapper() {

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -56,7 +56,6 @@ function AssociationsWrapper() {
             </PrivateWrapper>
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-targets`} />
-            <CopyUrlButton />
             <ApiPlaygroundDrawer
               query={DISEASE_ASSOCIATIONS_QUERY.loc.source.body}
               variables={variables}

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -14,7 +14,7 @@ import {
   DataUploader,
 } from "../../../components/AssociationsToolkit";
 import DISEASE_ASSOCIATIONS_QUERY from "./DiseaseAssociationsQuery.gql";
-import ApiPlaygroundDrawer from "ui/src/components/ApiPlaygroundDrawer";
+import { ApiPlaygroundDrawer } from "ui";
 
 function AssociationsWrapper() {
   const {

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -21,8 +21,7 @@ function AssociationsWrapper() {
   const {
     initialLoading,
     id,
-    pageIndex,
-    pageSize,
+    pagination,
     searhFilter,
     sorting,
     enableIndirect,
@@ -33,8 +32,8 @@ function AssociationsWrapper() {
 
   const variables = {
     id,
-    index: pageIndex,
-    size: pageSize,
+    index: pagination.pageIndex,
+    size: pagination.pageSize,
     filter: searhFilter,
     sortBy: sorting[0].id,
     enableIndirect,
@@ -42,8 +41,6 @@ function AssociationsWrapper() {
     entity,
     aggregationFilters: dataSourcesRequired,
   };
-
-  console.log(DISEASE_ASSOCIATIONS_QUERY);
 
   if (initialLoading) return <AotFLoader />;
 
@@ -60,13 +57,13 @@ function AssociationsWrapper() {
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-targets`} />
             <CopyUrlButton />
+            <ApiPlaygroundDrawer
+              query={DISEASE_ASSOCIATIONS_QUERY.loc.source.body}
+              variables={variables}
+            />
           </OptionsControlls>
         </Box>
         <Box>
-          <ApiPlaygroundDrawer
-            query={DISEASE_ASSOCIATIONS_QUERY.loc.source.body}
-            variables={variables}
-          />
           <TargetPrioritisationSwitch />
         </Box>
       </ControlsSection>

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -56,7 +56,6 @@ function AssociationsWrapper() {
             </PrivateWrapper>
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-diseases`} />
-            <CopyUrlButton />
             <ApiPlaygroundDrawer
               query={TARGET_ASSOCIATIONS_QUERY.loc.source.body}
               variables={variables}

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -14,8 +14,7 @@ import {
   DataUploader,
 } from "../../../components/AssociationsToolkit";
 import TARGET_ASSOCIATIONS_QUERY from "./TargetAssociationsQuery.gql";
-import CopyUrlButton from "../../../components/AssociationsToolkit/CopyUrlButton";
-import ApiPlaygroundDrawer from "ui/src/components/ApiPlaygroundDrawer";
+import { ApiPlaygroundDrawer } from "ui";
 
 function AssociationsWrapper() {
   const {

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -15,9 +15,33 @@ import {
 } from "../../../components/AssociationsToolkit";
 import TARGET_ASSOCIATIONS_QUERY from "./TargetAssociationsQuery.gql";
 import CopyUrlButton from "../../../components/AssociationsToolkit/CopyUrlButton";
+import ApiPlaygroundDrawer from "ui/src/components/ApiPlaygroundDrawer";
 
 function AssociationsWrapper() {
-  const { initialLoading, id } = useContext(AssociationsContext);
+  const {
+    initialLoading,
+    id,
+    pagination,
+    searhFilter,
+    sorting,
+    enableIndirect,
+    dataSourcesWeights,
+    entity,
+    dataSourcesRequired,
+  } = useContext(AssociationsContext);
+
+  const variables = {
+    id,
+    index: pagination.pageIndex,
+    size: pagination.pageSize,
+    filter: searhFilter,
+    sortBy: sorting[0].id,
+    enableIndirect,
+    datasources: dataSourcesWeights,
+    entity,
+    aggregationFilters: dataSourcesRequired,
+  };
+
   if (initialLoading) return <AotFLoader />;
 
   return (
@@ -33,6 +57,10 @@ function AssociationsWrapper() {
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-diseases`} />
             <CopyUrlButton />
+            <ApiPlaygroundDrawer
+              query={TARGET_ASSOCIATIONS_QUERY.loc.source.body}
+              variables={variables}
+            />
           </OptionsControlls>
         </Box>
         <Box></Box>

--- a/packages/ui/src/components/ApiPlaygroundDrawer.jsx
+++ b/packages/ui/src/components/ApiPlaygroundDrawer.jsx
@@ -1,0 +1,117 @@
+import { faXmark } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Button, Drawer, Grid, IconButton, Paper, Typography } from "@mui/material";
+import { makeStyles } from "@mui/styles";
+
+import Link from "./Link";
+import { Suspense, lazy, useState } from "react";
+import { fetcher } from "../utils/global";
+
+const styles = makeStyles(theme => ({
+  backdrop: {
+    "& .MuiBackdrop-root": {
+      opacity: "0 !important",
+    },
+  },
+  container: {
+    width: "80%",
+    backgroundColor: theme.palette.grey[300],
+  },
+  paper: {
+    margin: "1.5rem",
+    padding: "1rem",
+  },
+  title: {
+    display: "flex",
+    justifyContent: "space-between",
+    backgroundColor: "white",
+    borderBottom: "1px solid #ccc",
+    fontSize: "1.2rem",
+    fontWeight: "bold",
+    padding: "1rem",
+  },
+  playgroundContainer: {
+    margin: "0 1.5rem 1.5rem 1.5rem",
+    height: "100%",
+  },
+}));
+
+// lazy load GraphiQL and remove Logo and Toolbar
+const GraphiQL = lazy(() =>
+  import("graphiql").then(module => {
+    // eslint-disable-next-line react/display-name
+    module.default.Logo = function () {
+      return null;
+    };
+    // eslint-disable-next-line react/display-name
+    module.default.Toolbar = function () {
+      return null;
+    };
+    return module;
+  })
+);
+
+function ApiPlaygroundDrawer({ query, variables }) {
+  console.log("ApiPlaygroundDrawer -> variables", variables);
+  console.log("ApiPlaygroundDrawer -> query", query);
+  const classes = styles();
+  const [open, setOpen] = useState(false);
+
+  function close(e) {
+    if (e.key === "Escape") return;
+    setOpen(false);
+  }
+  function togglePlayground() {
+    setOpen(!open);
+  }
+
+  return (
+    <>
+      {" "}
+      {query ? (
+        <Grid item>
+          <Button variant="outlined" size="small" onClick={() => togglePlayground()}>
+            API query
+          </Button>
+        </Grid>
+      ) : null}
+      <Drawer
+        classes={{ root: classes.backdrop, paper: classes.container }}
+        open={open}
+        onClose={e => close(e)}
+        anchor="right"
+      >
+        <Typography className={classes.title}>
+          API query
+          <IconButton onClick={e => close(e)}>
+            <FontAwesomeIcon icon={faXmark} />
+          </IconButton>
+        </Typography>
+        <Paper className={classes.paper} variant="outlined">
+          Press the Play button to explore the GraphQL API query used to populate this table. You
+          can also visit our{" "}
+          <Link external to="https://platform-docs.opentargets.org/data-access/graphql-api">
+            GraphQL API documentation
+          </Link>{" "}
+          and{" "}
+          <Link external to="https://community.opentargets.org">
+            Community
+          </Link>{" "}
+          for more how-to guides and tutorials.
+        </Paper>
+        {query ? (
+          <div className={classes.playgroundContainer}>
+            <Suspense fallback={<div>Loading...</div>}>
+              <GraphiQL
+                fetcher={fetcher}
+                query={query}
+                variables={JSON.stringify(variables, null, 2)}
+              />
+            </Suspense>
+          </div>
+        ) : null}
+      </Drawer>
+    </>
+  );
+}
+export default ApiPlaygroundDrawer;

--- a/packages/ui/src/components/ApiPlaygroundDrawer.jsx
+++ b/packages/ui/src/components/ApiPlaygroundDrawer.jsx
@@ -16,6 +16,7 @@ const styles = makeStyles(theme => ({
   container: {
     width: "80%",
     backgroundColor: theme.palette.grey[300],
+    overflowY: "hidden !important",
   },
   paper: {
     margin: "1.5rem",
@@ -52,8 +53,6 @@ const GraphiQL = lazy(() =>
 );
 
 function ApiPlaygroundDrawer({ query, variables }) {
-  console.log("ApiPlaygroundDrawer -> variables", variables);
-  console.log("ApiPlaygroundDrawer -> query", query);
   const classes = styles();
   const [open, setOpen] = useState(false);
 

--- a/packages/ui/src/components/ApiPlaygroundDrawer.tsx
+++ b/packages/ui/src/components/ApiPlaygroundDrawer.tsx
@@ -1,6 +1,6 @@
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Box, Button, Drawer, Grid, IconButton, Paper, Typography } from "@mui/material";
+import { Box, Button, Drawer, Grid, IconButton, Paper } from "@mui/material";
 
 import Link from "./Link";
 import { KeyboardEvent, Suspense, lazy, useState } from "react";

--- a/packages/ui/src/components/ApiPlaygroundDrawer.tsx
+++ b/packages/ui/src/components/ApiPlaygroundDrawer.tsx
@@ -1,62 +1,35 @@
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { Button, Drawer, Grid, IconButton, Paper, Typography } from "@mui/material";
-import { makeStyles } from "@mui/styles";
+import { Box, Button, Drawer, Grid, IconButton, Paper, Typography } from "@mui/material";
 
 import Link from "./Link";
-import { Suspense, lazy, useState } from "react";
+import { KeyboardEvent, Suspense, lazy, useState } from "react";
 import { fetcher } from "../utils/global";
-
-const styles = makeStyles(theme => ({
-  backdrop: {
-    "& .MuiBackdrop-root": {
-      opacity: "0 !important",
-    },
-  },
-  container: {
-    width: "80%",
-    backgroundColor: theme.palette.grey[300],
-    overflowY: "hidden !important",
-  },
-  paper: {
-    margin: "1.5rem",
-    padding: "1rem",
-  },
-  title: {
-    display: "flex",
-    justifyContent: "space-between",
-    backgroundColor: "white",
-    borderBottom: "1px solid #ccc",
-    fontSize: "1.2rem",
-    fontWeight: "bold",
-    padding: "1rem",
-  },
-  playgroundContainer: {
-    margin: "0 1.5rem 1.5rem 1.5rem",
-    height: "100%",
-  },
-}));
 
 // lazy load GraphiQL and remove Logo and Toolbar
 const GraphiQL = lazy(() =>
   import("graphiql").then(module => {
-    // eslint-disable-next-line react/display-name
-    module.default.Logo = function () {
-      return null;
-    };
-    // eslint-disable-next-line react/display-name
-    module.default.Toolbar = function () {
-      return null;
-    };
+    function GraphiQLEmpty() {
+      return <></>;
+    }
+    GraphiQLEmpty.displayName = "";
+
+    module.default.Toolbar = GraphiQLEmpty;
+    module.default.Logo = GraphiQLEmpty;
+
     return module;
   })
 );
 
-function ApiPlaygroundDrawer({ query, variables }) {
-  const classes = styles();
+type ApiPlaygroundDrawerProps = {
+  query: string;
+  variables: any;
+};
+
+function ApiPlaygroundDrawer({ query, variables }: ApiPlaygroundDrawerProps) {
   const [open, setOpen] = useState(false);
 
-  function close(e) {
+  function close(e: KeyboardEvent<HTMLInputElement>) {
     if (e.key === "Escape") return;
     setOpen(false);
   }
@@ -75,18 +48,34 @@ function ApiPlaygroundDrawer({ query, variables }) {
         </Grid>
       ) : null}
       <Drawer
-        classes={{ root: classes.backdrop, paper: classes.container }}
+        sx={{ width: "80%", overflowY: "hidden" }}
+        PaperProps={{
+          sx: { width: "80%", overflowY: "hidden" },
+        }}
         open={open}
         onClose={e => close(e)}
         anchor="right"
       >
-        <Typography className={classes.title}>
+        <Box
+          sx={{
+            typography: "h6",
+            display: "flex",
+            justifyContent: "space-between",
+            backgroundColor: "white",
+            borderBottom: "1px solid #ccc",
+            fontWeight: "bold",
+            p: theme => theme.spacing(2),
+          }}
+        >
           API query
           <IconButton onClick={e => close(e)}>
             <FontAwesomeIcon icon={faXmark} />
           </IconButton>
-        </Typography>
-        <Paper className={classes.paper} variant="outlined">
+        </Box>
+        <Paper
+          sx={{ m: theme => theme.spacing(2), p: theme => theme.spacing(2) }}
+          variant="outlined"
+        >
           Press the Play button to explore the GraphQL API query used to populate this table. You
           can also visit our{" "}
           <Link external to="https://platform-docs.opentargets.org/data-access/graphql-api">
@@ -99,7 +88,7 @@ function ApiPlaygroundDrawer({ query, variables }) {
           for more how-to guides and tutorials.
         </Paper>
         {query ? (
-          <div className={classes.playgroundContainer}>
+          <Box sx={{ height: 1, m: theme => theme.spacing(2), mt: 0 }}>
             <Suspense fallback={<div>Loading...</div>}>
               <GraphiQL
                 fetcher={fetcher}
@@ -107,7 +96,7 @@ function ApiPlaygroundDrawer({ query, variables }) {
                 variables={JSON.stringify(variables, null, 2)}
               />
             </Suspense>
-          </div>
+          </Box>
         ) : null}
       </Drawer>
     </>

--- a/packages/ui/src/components/ApiPlaygroundDrawer.tsx
+++ b/packages/ui/src/components/ApiPlaygroundDrawer.tsx
@@ -102,4 +102,5 @@ function ApiPlaygroundDrawer({ query, variables }: ApiPlaygroundDrawerProps) {
     </>
   );
 }
+
 export default ApiPlaygroundDrawer;

--- a/packages/ui/src/components/Table/DataDownloader.jsx
+++ b/packages/ui/src/components/Table/DataDownloader.jsx
@@ -1,38 +1,10 @@
 import FileSaver from "file-saver";
-import { Suspense, useState, lazy } from "react";
+import { useState } from "react";
 import _ from "lodash";
-import {
-  Button,
-  Grid,
-  Typography,
-  CircularProgress,
-  Snackbar,
-  Slide,
-  Drawer,
-  Paper,
-  IconButton,
-} from "@mui/material";
+import { Button, Grid, Typography, CircularProgress, Snackbar, Slide } from "@mui/material";
 import { makeStyles } from "@mui/styles";
-import { faXmark } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import "graphiql/graphiql.min.css";
-import { fetcher } from "../../utils/global";
-import Link from "../Link";
-
-// lazy load GraphiQL and remove Logo and Toolbar
-const GraphiQL = lazy(() =>
-  import("graphiql").then(module => {
-    // eslint-disable-next-line react/display-name
-    module.default.Logo = function () {
-      return null;
-    };
-    // eslint-disable-next-line react/display-name
-    module.default.Toolbar = function () {
-      return null;
-    };
-    return module;
-  })
-);
+import ApiPlaygroundDrawer from "../ApiPlaygroundDrawer";
 
 const asJSON = (columns, rows) => {
   const rowStrings = rows.map(row =>
@@ -127,37 +99,11 @@ const styles = makeStyles(theme => ({
   snackbarContentRoot: {
     padding: 0,
   },
-  backdrop: {
-    "& .MuiBackdrop-root": {
-      opacity: "0 !important",
-    },
-  },
-  container: {
-    width: "80%",
-    backgroundColor: theme.palette.grey[300],
-  },
-  paper: {
-    margin: "1.5rem",
-    padding: "1rem",
-  },
-  title: {
-    display: "flex",
-    justifyContent: "space-between",
-    backgroundColor: "white",
-    borderBottom: "1px solid #ccc",
-    fontSize: "1.2rem",
-    fontWeight: "bold",
-    padding: "1rem",
-  },
-  playgroundContainer: {
-    margin: "0 1.5rem 1.5rem 1.5rem",
-    height: "100%",
-  },
 }));
 
 function DataDownloader({ columns, rows, fileStem, query, variables }) {
   const [downloading, setDownloading] = useState(false);
-  const [open, setOpen] = useState(false);
+
   const classes = styles();
 
   const downloadData = async (format, dataColumns, dataRows, dataFileStem) => {
@@ -186,15 +132,6 @@ function DataDownloader({ columns, rows, fileStem, query, variables }) {
     downloadData("tsv", columns, rows, fileStem);
   };
 
-  function togglePlayground() {
-    setOpen(!open);
-  }
-
-  function close(e) {
-    if (e.key === "Escape") return;
-    setOpen(false);
-  }
-
   return (
     <>
       <Grid container alignItems="center" justifyContent="flex-end" spacing={1}>
@@ -211,13 +148,7 @@ function DataDownloader({ columns, rows, fileStem, query, variables }) {
             TSV
           </Button>
         </Grid>
-        {query ? (
-          <Grid item>
-            <Button variant="outlined" size="small" onClick={() => togglePlayground()}>
-              API query
-            </Button>
-          </Grid>
-        ) : null}
+        {query ? <ApiPlaygroundDrawer query={query} variables={variables} /> : null}
       </Grid>
       <Snackbar
         anchorOrigin={{ vertical: "bottom", horizontal: "left" }}
@@ -236,42 +167,6 @@ function DataDownloader({ columns, rows, fileStem, query, variables }) {
           </>
         }
       />
-      <Drawer
-        classes={{ root: classes.backdrop, paper: classes.container }}
-        open={open}
-        onClose={e => close(e)}
-        anchor="right"
-      >
-        <Typography className={classes.title}>
-          API query
-          <IconButton onClick={e => close(e)}>
-            <FontAwesomeIcon icon={faXmark} />
-          </IconButton>
-        </Typography>
-        <Paper className={classes.paper} variant="outlined">
-          Press the Play button to explore the GraphQL API query used to populate this table. You
-          can also visit our{" "}
-          <Link external to="https://platform-docs.opentargets.org/data-access/graphql-api">
-            GraphQL API documentation
-          </Link>{" "}
-          and{" "}
-          <Link external to="https://community.opentargets.org">
-            Community
-          </Link>{" "}
-          for more how-to guides and tutorials.
-        </Paper>
-        {query ? (
-          <div className={classes.playgroundContainer}>
-            <Suspense fallback={<div>Loading...</div>}>
-              <GraphiQL
-                fetcher={fetcher}
-                query={query}
-                variables={JSON.stringify(variables, null, 2)}
-              />
-            </Suspense>
-          </div>
-        ) : null}
-      </Drawer>
     </>
   );
 }

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -30,6 +30,7 @@ export { default as ScientificNotation } from "./components/ScientificNotation";
 export { default as MouseModelAllelicComposition } from "./components/MouseModelAllelicComposition";
 export { default as DataDownloader } from "./components/DataDownloader";
 export { default as Legend } from "./components/Legend";
+export { default as ApiPlaygroundDrawer } from "./components/ApiPlaygroundDrawer";
 
 export { default as EmptyPage } from "./pages/EmptyPage";
 export { default as NotFoundPage } from "./pages/NotFoundPage";


### PR DESCRIPTION
# [Platform]: Adding api query playground to aotf 

## Description

Extracting the component from DataDownloader.jsx and creating a separate component ApiPlaygroundDrawer.jsx and using in original component and in aotf pages.

**Issue:** # https://github.com/opentargets/issues/issues/3199
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: Go to aotf and click on Api query button 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
