### PR TITLE
 [Platform]: AotF Prevent data widget closing if clicked on GraphiQL

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/Table/TableBody.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/Table/TableBody.jsx
@@ -44,6 +44,9 @@ function TableBody({ core, expanded, cols }) {
   const isExpandedInTable = expanded[3] === prefix && flatCols.includes(expanded[1]);
 
   const handleClickAway = () => {
+    if(e.srcElement.className === "CodeMirror-hint CodeMirror-hint-active"){
+      return;
+    }
     resetExpandler();
   };
 

--- a/apps/platform/src/components/AssociationsToolkit/Table/TableBody.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/Table/TableBody.jsx
@@ -43,7 +43,7 @@ function TableBody({ core, expanded, cols }) {
   const { prefix, loading } = core.getState();
   const isExpandedInTable = expanded[3] === prefix && flatCols.includes(expanded[1]);
 
-  const handleClickAway = () => {
+  const handleClickAway = (e) => {
     if(e.srcElement.className === "CodeMirror-hint CodeMirror-hint-active"){
       return;
     }


### PR DESCRIPTION
Platform: Don't close data widget in association table if clicked on Graphiql autocomplete

## Description

If a data widget is opened on the Association page, and the Graphiql tool is opened, if clicking on a Graphiql autocomplete it will close the complete data widget. This is because the "ClickAway" handler detects a click "away" from the data widget. (My colleague Anika Bongaarts found this bug). 

![image](https://github.com/opentargets/ot-ui-apps/assets/76998782/f00d62c5-894d-461f-b94b-9ff99879d61c)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Run `yarn dev:platform`

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
