### PR TITLE
[Platform]: Pharmacogenetics is direct target column added

### DIFF
--- a/packages/sections/src/drug/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/drug/Pharmacogenomics/Body.jsx
@@ -68,17 +68,12 @@ function Body({ id: chemblId, label: name, entity }) {
     {
       id: "gene",
       label: "Gene",
-      renderCell: ({ target, isDirectTarget }) => {
+      renderCell: ({ target }) => {
         if (target) {
-          const tooltipText = isDirectTarget
-            ? "The variant is in the drug's primary target gene."
-            : "The variant is outside the drug's primary target gene.";
           return (
-            <Tooltip title={tooltipText} showHelpIcon>
-              <Link to={`/target/${target.id}`}>
-                <span>{target.approvedSymbol}</span>
-              </Link>
-            </Tooltip>
+            <Link to={`/target/${target.id}`}>
+              <span>{target.approvedSymbol}</span>
+            </Link>
           );
         }
         return naLabel;

--- a/packages/sections/src/drug/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/drug/Pharmacogenomics/Body.jsx
@@ -14,6 +14,8 @@ import {
   variantConsequenceSource,
 } from "../../constants";
 import { identifiersOrgLink, sentenceCase } from "../../utils/global";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
 
 const useStyles = makeStyles(theme => ({
   level: {
@@ -177,6 +179,12 @@ function Body({ id: chemblId, label: name, entity }) {
       label: "Drug Response Category",
       renderCell: ({ pgxCategory }) => pgxCategory || naLabel,
       filterValue: ({ pgxCategory }) => pgxCategory,
+    },
+    {
+      id: "isDirectTarget",
+      label: "Direct target of the Drug",
+      renderCell: ({ isDirectTarget }) =>
+        isDirectTarget && <FontAwesomeIcon icon={faCheck} size="sm" />,
     },
     {
       id: "confidenceLevel",

--- a/packages/sections/src/drug/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/drug/Pharmacogenomics/Body.jsx
@@ -15,7 +15,8 @@ import {
 } from "../../constants";
 import { identifiersOrgLink, sentenceCase } from "../../utils/global";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
+import { faCircleXmark } from "@fortawesome/free-regular-svg-icons";
 
 const useStyles = makeStyles(theme => ({
   level: {
@@ -34,6 +35,9 @@ const useStyles = makeStyles(theme => ({
   },
   blue: {
     background: theme.palette.primary.main,
+  },
+  blueIcon: {
+    color: theme.palette.primary.main,
   },
 }));
 
@@ -177,9 +181,11 @@ function Body({ id: chemblId, label: name, entity }) {
     },
     {
       id: "isDirectTarget",
-      label: "Direct target of the Drug",
-      renderCell: ({ isDirectTarget }) =>
-        isDirectTarget && <FontAwesomeIcon icon={faCheck} size="sm" />,
+      label: "Direct Drug Target",
+      renderCell: ({ isDirectTarget }) => {
+        const ICON_NAME = isDirectTarget ? faCircleCheck : faCircleXmark;
+        return <FontAwesomeIcon icon={ICON_NAME} size="lg" className={classes.blueIcon} />;
+      },
     },
     {
       id: "confidenceLevel",

--- a/packages/sections/src/target/Pharmacogenomics/Pharmacogenomics.gql
+++ b/packages/sections/src/target/Pharmacogenomics/Pharmacogenomics.gql
@@ -8,6 +8,7 @@ query PharmacogenomicsQuery($ensemblId: String!) {
         id
         label
       }
+      isDirectTarget
       drugFromSource
       drugId
       phenotypeFromSourceId

--- a/packages/sections/src/target/Pharmacogenomics/PharmacogenomicsTable.jsx
+++ b/packages/sections/src/target/Pharmacogenomics/PharmacogenomicsTable.jsx
@@ -10,6 +10,8 @@ import {
   variantConsequenceSource,
 } from "../../constants";
 import { identifiersOrgLink, sentenceCase } from "../../utils/global";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
 
 const useStyles = makeStyles(theme => ({
   level: {
@@ -161,6 +163,12 @@ function OverviewTab({ pharmacogenomics, query, variables }) {
       label: "Drug Response Category",
       renderCell: ({ pgxCategory }) => pgxCategory || naLabel,
       filterValue: ({ pgxCategory }) => pgxCategory,
+    },
+    {
+      id: "isDirectTarget",
+      label: "Direct target of the Drug",
+      renderCell: ({ isDirectTarget }) =>
+        isDirectTarget && <FontAwesomeIcon icon={faCheck} size="sm" />,
     },
     {
       id: "confidenceLevel",

--- a/packages/sections/src/target/Pharmacogenomics/PharmacogenomicsTable.jsx
+++ b/packages/sections/src/target/Pharmacogenomics/PharmacogenomicsTable.jsx
@@ -11,7 +11,8 @@ import {
 } from "../../constants";
 import { identifiersOrgLink, sentenceCase } from "../../utils/global";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck } from "@fortawesome/free-solid-svg-icons";
+import { faCircleCheck } from "@fortawesome/free-solid-svg-icons";
+import { faCircleXmark } from "@fortawesome/free-regular-svg-icons";
 
 const useStyles = makeStyles(theme => ({
   level: {
@@ -30,6 +31,9 @@ const useStyles = makeStyles(theme => ({
   },
   blue: {
     background: theme.palette.primary.main,
+  },
+  blueIcon: {
+    color: theme.palette.primary.main,
   },
 }));
 
@@ -166,9 +170,11 @@ function OverviewTab({ pharmacogenomics, query, variables }) {
     },
     {
       id: "isDirectTarget",
-      label: "Direct target of the Drug",
-      renderCell: ({ isDirectTarget }) =>
-        isDirectTarget && <FontAwesomeIcon icon={faCheck} size="sm" />,
+      label: "Direct Drug Target",
+      renderCell: ({ isDirectTarget }) => {
+        const ICON_NAME = isDirectTarget ? faCircleCheck : faCircleXmark;
+        return <FontAwesomeIcon icon={ICON_NAME} size="lg" className={classes.blueIcon} />;
+      },
     },
     {
       id: "confidenceLevel",


### PR DESCRIPTION
#[Platform]: Pharmacogenetics is direct target column added

## Description

A new column added to Pharmacogenetics widget on both drug and target page.

**Issue:** # https://github.com/opentargets/issues/issues/3202
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: go to Pharmacogenetics widget and look for "Direct target of the Drug"

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
