### PR TITLE
[Platform]: Remove mapping between drug warning and MedDRA

### DIFF
--- a/apps/platform/src/pages/APIPage/DrugAnnotation.gql
+++ b/apps/platform/src/pages/APIPage/DrugAnnotation.gql
@@ -9,7 +9,6 @@ query drugApprovalWithdrawnWarningData {
       warningType
       description
       toxicityClass
-      meddraSocCode
       year
       references {
         id

--- a/packages/sections/src/drug/DrugWarnings/DrugWarningsQuery.gql
+++ b/packages/sections/src/drug/DrugWarnings/DrugWarningsQuery.gql
@@ -5,7 +5,6 @@ query DrugWarningsQuery($chemblId: String!) {
       warningType
       description
       toxicityClass
-      meddraSocCode
       country
       year
       efoTerm


### PR DESCRIPTION
# [Platform]: Remove mapping between drug warning and MedDRA

## Description

Remove mapping between drug warning and MedDRA, from widget and from sample query.

**Issue:** # https://github.com/opentargets/issues/issues/3003
**Deploy preview:** https://deploy-preview-337--ot-platform.netlify.app/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: drug warning widget should work as expected 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
