### PR TITLE
[Platform]: Update DateFilter labels

### DIFF
--- a/packages/sections/src/common/Literature/DateFilter.tsx
+++ b/packages/sections/src/common/Literature/DateFilter.tsx
@@ -25,7 +25,8 @@ const OTSlider = styled(Slider)({
 });
 
 const DateIndicator = styled("span")({
-  width: 65,
+  minWidth: 65,
+  maxWidth: 80,
 });
 
 const monthsBtwnDates = (startDate: Date, endDate: Date) =>
@@ -157,7 +158,7 @@ export function DateFilter() {
       const labelDate = selectedDate(value as number);
       return `${labelDate.getFullYear()}-${labelDate.getMonth() + 1}`;
     }
-    return value;
+    return "YYYY-MM";
   };
 
   const handleDateRangeChange = (_event: Event, value: number[] | number, _activeThumb: number) => {


### PR DESCRIPTION
# [Platform]: Update DateFilter labels

## Description

When the API response had no literature results and the earliest pub date was 0 we were seeing a value of 0 in the labels. This negatively impacts the user experience. It was decided that in this case we should display the value 'YYYY-MM'.

**Issue:** # [3233](https://github.com/opentargets/issues/issues/3233)
**Deploy preview:** [link](https://deploy-preview-341--ot-platform.netlify.app/disease/MONDO_0018997)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Check the literature widget for a disease with results in the response. The labels with the dates should be visible.
- [x] Check the literature widget for a disease. Select similar entities that cause the response to have no literature. The labels should have the value of 'YYYY-MM'.
- [x] Check the literature widget for a disease. Select similar entities that cause the response to have no literature. The labels should have the value of 'YYYY-MM'. Remove similar entities so that re response has literature data. The labels should be the available dates.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
