### PR TITLE
[Platform]: Update higher limit calc

### DIFF
--- a/packages/sections/src/common/Literature/DateFilter.tsx
+++ b/packages/sections/src/common/Literature/DateFilter.tsx
@@ -73,7 +73,7 @@ export function DateFilter() {
     // the publication year has changed
     if (earliestPubYear && earliestPubYear !== pubYear) {
       const earliestDate = getDateFromYear(earliestPubYear);
-      const limit = monthsBtwnDates(earliestDate, new Date()) - 1;
+      const limit = monthsBtwnDates(earliestDate, new Date());
 
       const lowerLimit = getLowerLimit(earliestDate);
 


### PR DESCRIPTION
# [Platform]: Update higher limit calc

## Description

There was an issue with the months calculation where a month was being subtracted and that was causing an issue with the higher limit of the filter

**Issue:** # [2578](https://github.com/opentargets/issues/issues/2578)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Loading a random target and making sure that the current month is being selected
- [x] Select a different date and change the related entities to check that when the earliest publication date changes the calculation is correct

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
