### PR TITLE
[Platform]: aotf api query bug and link text decoration

### DIFF
--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -29,6 +29,8 @@ function AssociationsWrapper() {
     dataSourcesRequired,
   } = useAotfContext();
 
+  const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
+
   const variables = {
     id,
     index: pagination.pageIndex,
@@ -38,7 +40,7 @@ function AssociationsWrapper() {
     enableIndirect,
     datasources: dataSourcesWeights,
     entity,
-    aggregationFilters: dataSourcesRequired,
+    aggregationFilters,
   };
 
   if (initialLoading) return <AotFLoader />;

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -29,6 +29,8 @@ function AssociationsWrapper() {
     dataSourcesRequired,
   } = useContext(AssociationsContext);
 
+  const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
+
   const variables = {
     id,
     index: pagination.pageIndex,
@@ -38,7 +40,7 @@ function AssociationsWrapper() {
     enableIndirect,
     datasources: dataSourcesWeights,
     entity,
-    aggregationFilters: dataSourcesRequired,
+    aggregationFilters,
   };
 
   if (initialLoading) return <AotFLoader />;

--- a/packages/ui/src/components/Footer.tsx
+++ b/packages/ui/src/components/Footer.tsx
@@ -47,7 +47,7 @@ const FooterLink = ({ label, url, icon }) => {
 
 const FooterSectionHeading = ({ children }) => (
   <Grid item xs={12}>
-    <Typography color="inherit">{children}</Typography>
+    <Typography variant="h6" color="inherit">{children}</Typography>
   </Grid>
 );
 

--- a/packages/ui/src/components/Link.tsx
+++ b/packages/ui/src/components/Link.tsx
@@ -28,8 +28,12 @@ const useStyles = makeStyles(theme => ({
   },
   baseFooter: {
     color: "white",
+    "text-decoration-color": "transparent",
+    "-webkit-text-decoration-color": "transparent",
     "&:hover": {
       color: theme.palette.primary.light,
+      "text-decoration-color": theme.palette.primary.light,
+    "-webkit-text-decoration-color": theme.palette.primary.light,
     },
     display: "flex",
     alignItems: "center",

--- a/packages/ui/src/components/NavBar.jsx
+++ b/packages/ui/src/components/NavBar.jsx
@@ -7,6 +7,7 @@ import {
   MenuItem,
   MenuList,
   useMediaQuery,
+  Box,
 } from "@mui/material";
 import { makeStyles, useTheme } from "@mui/styles";
 import { styled } from "@mui/material/styles";
@@ -58,6 +59,8 @@ const useStyles = makeStyles(theme => ({
   },
   menuLink: {
     color: theme.palette.secondary.contrastText,
+    margin: `0 ${theme.spacing(2)}`,
+    whiteSpace: "nowrap",
     "&:hover": {
       color: theme.palette.secondary.contrastText,
     },
@@ -144,28 +147,35 @@ function NavBar({ name, search, api, downloads, docs, contact, homepage, items, 
           {items && !isHomePageRegular ? <HeaderMenu items={items} placement={placement} /> : null}
 
           {isHomePageRegular && (
-            <MenuList className={classes.menuList}>
+            <Box sx={{ display: "flex" }}>
               {items.map(item => {
                 if (item.showOnlyPartner) {
                   return (
                     <PrivateWrapper key={v1()}>
-                      <MenuItem dense className={classes.menuItem}>
-                        <Link external={item.external} to={item.url} className={classes.menuLink}>
-                          {item.name}
-                        </Link>
-                      </MenuItem>
+                      <Link
+                        footer
+                        external={item.external}
+                        to={item.url}
+                        className={classes.menuLink}
+                      >
+                        <Typography variant="body2">{item.name}</Typography>
+                      </Link>
                     </PrivateWrapper>
                   );
                 }
                 return (
-                  <MenuItem key={v1()} dense className={classes.menuItem}>
-                    <Link external={item.external} to={item.url} className={classes.menuLink}>
-                      {item.name}
-                    </Link>
-                  </MenuItem>
+                  <Link
+                    key={v1()}
+                    footer
+                    external={item.external}
+                    to={item.url}
+                    className={classes.menuLink}
+                  >
+                    <Typography variant="body2">{item.name}</Typography>
+                  </Link>
                 );
               })}
-            </MenuList>
+            </Box>
           )}
         </div>
       </Toolbar>


### PR DESCRIPTION
# [Platform]: aotf api query bug and link text decoration

## Description

1. removed id from aggregation filter as it is not supported by query.
2. link component text decoration updated to suit home page nav bar and footer component.

**Issue:** # https://github.com/opentargets/issues/issues/3255
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A: 
Go to AOTF view page.
Click on 'Show data sources controls'
Select 'ClinVar' as required
Click on 'API query'
Run the API query and see error

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
