### PR TITLE
[Platform]: Clean cursor when date filter changes.

### DIFF
--- a/packages/sections/src/common/Literature/DateFilter.tsx
+++ b/packages/sections/src/common/Literature/DateFilter.tsx
@@ -118,7 +118,7 @@ export function DateFilter() {
       id,
       category,
       entities,
-      cursor,
+      cursor: null,
       earliestPubYear,
       globalEntity,
       selectedEntities,
@@ -132,7 +132,7 @@ export function DateFilter() {
     const data = request.data[globalEntity];
     const update = {
       id,
-      cursor,
+      cursor: data.literatureOcurrences?.cursor,
       query,
       entities: data.similarEntities,
       loadingEntities: false,
@@ -211,7 +211,7 @@ export function DateFilter() {
             valueLabelDisplay="auto"
             onChange={handleDateRangeChange}
             onChangeCommitted={handleDateRangeChangeCommitted}
-            getAriaLabel={() => ("date-range-slider")}
+            getAriaLabel={() => "date-range-slider"}
             max={numberOfMonths}
             valueLabelFormat={valueLabelFormat}
           />


### PR DESCRIPTION
# [Platform]: Clean cursor when date filter changes.

## Description

There was a case when the date filter was updated and the results weren't being shown. This was because the cursor wasn't being cleaned after the filter had changed

**Issue:** # [2578](https://github.com/opentargets/issues/issues/2578)
**Deploy preview:** [link](https://deploy-preview-353--ot-platform.netlify.app)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Go to [cancer](https://platform.dev.opentargets.xyz/disease/MONDO_0004992) disease and change the higher limit to 1800-2 and check that you get the 5 results from the count in the list

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
