### PR TITLE
[Platform] Fix Gtex mouseover feature

### DIFF
--- a/packages/sections/src/target/Expression/GtexVariability.jsx
+++ b/packages/sections/src/target/Expression/GtexVariability.jsx
@@ -144,12 +144,12 @@ function GtexVariability({ data }) {
       .attr("width", d => x(d.q3) - x(d.q1))
       .attr("height", rectHeight)
       .attr("fill", d => colour(d.tissueSiteDetailId))
-      .on("mouseover", d => {
+      .on("mouseover", (d, i, nodes) => {
         let X =
-          parseFloat(select(this).attr("x")) +
-          parseFloat(select(this).attr("width")) +
+          parseFloat(select(nodes[i]).attr("x")) +
+          parseFloat(select(nodes[i]).attr("width")) +
           tooltipSettings.offsetX;
-        let Y = parseFloat(select(this).attr("y")) + tooltipSettings.offsetY;
+        let Y = parseFloat(select(nodes[i]).attr("y")) + tooltipSettings.offsetY;
 
         tooltipText
           .attr("y", Y)


### PR DESCRIPTION
## Description

Mouseover functionality in the Gtex tab wasn't working due to `this` not being bound to the DOM element of the D3 event handler, returning a null value. Updated arrow function to match D3 v5 syntax used by ot-ui-apps  (https://devdocs.io/d3~5/d3-selection#selection_on)

**Issue:** NA
**Deploy preview:** NA

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Check Gtex tab of random entries and hover over boxplots

![image](https://github.com/opentargets/ot-ui-apps/assets/145066347/015162a4-6e98-45ce-bacb-a462d284b54c)

- [x] Manual test platform

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
