### PR TITLE
[Platform]: Moving aotf playground to another component

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/AotfApiPlayground.tsx
+++ b/apps/platform/src/components/AssociationsToolkit/AotfApiPlayground.tsx
@@ -16,7 +16,6 @@ function AotfApiPlayground() {
 
   const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
 
-  console.log("AotfApiPlayground -> QUERY", query);
   const variables = {
     id,
     index: pagination.pageIndex,

--- a/apps/platform/src/components/AssociationsToolkit/AotfApiPlayground.tsx
+++ b/apps/platform/src/components/AssociationsToolkit/AotfApiPlayground.tsx
@@ -1,0 +1,34 @@
+import { ApiPlaygroundDrawer } from "ui";
+import useAotfContext from "./hooks/useAotfContext";
+
+function AotfApiPlayground() {
+  const {
+    id,
+    pagination,
+    searhFilter,
+    sorting,
+    enableIndirect,
+    dataSourcesWeights,
+    entity,
+    dataSourcesRequired,
+    query,
+  } = useAotfContext();
+
+  const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
+
+  console.log("AotfApiPlayground -> QUERY", query);
+  const variables = {
+    id,
+    index: pagination.pageIndex,
+    size: pagination.pageSize,
+    filter: searhFilter,
+    sortBy: sorting[0].id,
+    enableIndirect,
+    datasources: dataSourcesWeights,
+    entity,
+    aggregationFilters,
+  };
+
+  return <ApiPlaygroundDrawer query={query.loc.source.body} variables={variables} />;
+}
+export default AotfApiPlayground;

--- a/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
+++ b/apps/platform/src/components/AssociationsToolkit/DataDownloader.jsx
@@ -148,7 +148,7 @@ const actions = {
   }),
 };
 
-function DataDownloader({ fileStem }) {
+function DataDownloader() {
   const [state, dispatch] = useReducer(reducer, initialState);
   const { version } = useConfigContext();
   const classes = styles();
@@ -166,6 +166,7 @@ function DataDownloader({ fileStem }) {
     dataSourcesWeights,
     dataSourcesRequired,
   } = useAotfContext();
+  const fileStem = `OT-${id}-associated-${entityToGet}s`;
   const [onlyPinnedCheckBox, setOnlyPinnedCheckBox] = useState(false);
   const [weightControlCheckBox, setWeightControlCheckBox] = useState(modifiedSourcesDataControls);
   const [onlyTargetData, setOnlyTargetData] = useState(false);

--- a/apps/platform/src/components/AssociationsToolkit/index.js
+++ b/apps/platform/src/components/AssociationsToolkit/index.js
@@ -4,6 +4,7 @@ export { default as TargetPrioritisationSwitch } from "./TargetPrioritisationSwi
 export { default as SearhInput } from "./SearchInput";
 export { default as DataDownloader } from "./DataDownloader";
 export { default as DataUploader } from "./DataUploader/DataUploader";
+export { default as AotfApiPlayground } from "./AotfApiPlayground";
 export {
   default as AssociationsContext,
   AssociationsStateProvider as AssociationsProvider,

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -14,34 +14,10 @@ import {
   DataUploader,
 } from "../../../components/AssociationsToolkit";
 import DISEASE_ASSOCIATIONS_QUERY from "./DiseaseAssociationsQuery.gql";
-import { ApiPlaygroundDrawer } from "ui";
+import AotfApiPlayground from "../../../components/AssociationsToolkit/AotfApiPlayground";
 
 function AssociationsWrapper() {
-  const {
-    initialLoading,
-    id,
-    pagination,
-    searhFilter,
-    sorting,
-    enableIndirect,
-    dataSourcesWeights,
-    entity,
-    dataSourcesRequired,
-  } = useAotfContext();
-
-  const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
-
-  const variables = {
-    id,
-    index: pagination.pageIndex,
-    size: pagination.pageSize,
-    filter: searhFilter,
-    sortBy: sorting[0].id,
-    enableIndirect,
-    datasources: dataSourcesWeights,
-    entity,
-    aggregationFilters,
-  };
+  const { initialLoading, id } = useAotfContext();
 
   if (initialLoading) return <AotFLoader />;
 
@@ -57,10 +33,7 @@ function AssociationsWrapper() {
             </PrivateWrapper>
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-targets`} />
-            <ApiPlaygroundDrawer
-              query={DISEASE_ASSOCIATIONS_QUERY.loc.source.body}
-              variables={variables}
-            />
+            <AotfApiPlayground />
           </OptionsControlls>
         </Box>
         <Box>

--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociations.jsx
@@ -12,9 +12,9 @@ import {
   OptionsControlls,
   AotFLoader,
   DataUploader,
+  AotfApiPlayground,
 } from "../../../components/AssociationsToolkit";
 import DISEASE_ASSOCIATIONS_QUERY from "./DiseaseAssociationsQuery.gql";
-import AotfApiPlayground from "../../../components/AssociationsToolkit/AotfApiPlayground";
 
 function AssociationsWrapper() {
   const { initialLoading, id } = useAotfContext();
@@ -32,7 +32,7 @@ function AssociationsWrapper() {
               <DataUploader />
             </PrivateWrapper>
             <Divider orientation="vertical" />
-            <DataDownloader fileStem={`OT-${id}-associated-targets`} />
+            <DataDownloader />
             <AotfApiPlayground />
           </OptionsControlls>
         </Box>

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -12,9 +12,9 @@ import {
   OptionsControlls,
   AotFLoader,
   DataUploader,
+  AotfApiPlayground,
 } from "../../../components/AssociationsToolkit";
 import TARGET_ASSOCIATIONS_QUERY from "./TargetAssociationsQuery.gql";
-import AotfApiPlayground from "../../../components/AssociationsToolkit/AotfApiPlayground";
 
 function AssociationsWrapper() {
   const { initialLoading, id } = useContext(AssociationsContext);
@@ -32,7 +32,7 @@ function AssociationsWrapper() {
               <DataUploader />
             </PrivateWrapper>
             <Divider orientation="vertical" />
-            <DataDownloader fileStem={`OT-${id}-associated-diseases`} />
+            <DataDownloader />
             <AotfApiPlayground />
           </OptionsControlls>
         </Box>

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociations.jsx
@@ -14,34 +14,10 @@ import {
   DataUploader,
 } from "../../../components/AssociationsToolkit";
 import TARGET_ASSOCIATIONS_QUERY from "./TargetAssociationsQuery.gql";
-import { ApiPlaygroundDrawer } from "ui";
+import AotfApiPlayground from "../../../components/AssociationsToolkit/AotfApiPlayground";
 
 function AssociationsWrapper() {
-  const {
-    initialLoading,
-    id,
-    pagination,
-    searhFilter,
-    sorting,
-    enableIndirect,
-    dataSourcesWeights,
-    entity,
-    dataSourcesRequired,
-  } = useContext(AssociationsContext);
-
-  const aggregationFilters = dataSourcesRequired.map(({ id, ...obj }) => ({ ...obj }));
-
-  const variables = {
-    id,
-    index: pagination.pageIndex,
-    size: pagination.pageSize,
-    filter: searhFilter,
-    sortBy: sorting[0].id,
-    enableIndirect,
-    datasources: dataSourcesWeights,
-    entity,
-    aggregationFilters,
-  };
+  const { initialLoading, id } = useContext(AssociationsContext);
 
   if (initialLoading) return <AotFLoader />;
 
@@ -57,10 +33,7 @@ function AssociationsWrapper() {
             </PrivateWrapper>
             <Divider orientation="vertical" />
             <DataDownloader fileStem={`OT-${id}-associated-diseases`} />
-            <ApiPlaygroundDrawer
-              query={TARGET_ASSOCIATIONS_QUERY.loc.source.body}
-              variables={variables}
-            />
+            <AotfApiPlayground />
           </OptionsControlls>
         </Box>
         <Box></Box>


### PR DESCRIPTION
# [Platform]: Moving aotf playground to another component

## Description

Moving aotf playground to separate component to use advantage of aotf context instead of props.

**Issue:** # https://github.com/opentargets/issues/issues/3290
**Deploy preview:** https://deploy-preview-363--ot-platform.netlify.app/

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: go to aotf page and test api query 

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
