### PR TITLE
[Platform]: Remove reported protein column from UniProt widget in variant page 

### DIFF
--- a/packages/sections/src/variant/UniProtVariants/Body.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Body.tsx
@@ -4,22 +4,12 @@ import { Link, SectionItem, Tooltip, PublicationsDrawer, DataTable } from "ui";
 import { definition } from "../../variant/UniProtVariants";
 import Description from "../../variant/UniProtVariants/Description";
 import { epmcUrl } from "../../utils/urls";
-import { identifiersOrgLink } from "../../utils/global";
 import { defaultRowsPerPageOptions, sectionsBaseSizeQuery,
 } from "../../constants";
 // import UNIPROT_VARIANTS_QUERY from "./UniprotVariantsQuery.gql";
 
 function getColumns(label: string) {
   return [
-    {
-      id: "targetFromSourceId",
-      label: "Reported protein",
-      renderCell: ({ targetFromSourceId }) => (
-        <Link external to={identifiersOrgLink("uniprot", targetFromSourceId)}>
-          {targetFromSourceId}
-        </Link>
-      ),
-    },
     {
       id: "disease.name",
       label: "Disease/phenotype",
@@ -81,9 +71,6 @@ type BodyProps = {
 
 export function Body({ id, label, entity }) {
 
-  // ID IS JUST THE VARIANT ID STRING FOR NOW
-  // const { ensgId, efoId } = id;
-
   // const variables = {
   //   ensemblId: ensgId,
   //   efoId,
@@ -102,8 +89,8 @@ export function Body({ id, label, entity }) {
       definition={definition}
       request={request}
       entity={entity}
-      renderDescription={() => <Description variantId={id} />}
-      renderBody={({ disease }) => {
+      renderDescription={data => <Description variantId={id} data={data} />}
+      renderBody={() => {
         // const { rows } = disease.uniprotVariantsSummary;
         const rows = request.data.variant.uniProtVariants;      
         return (

--- a/packages/sections/src/variant/UniProtVariants/Description.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Description.tsx
@@ -1,14 +1,16 @@
 import { Link } from "ui";
+import { identifiersOrgLink } from "../../utils/global";
 
 type DescriptionProps = {
   variantId: string;
+  data: any;
 };
 
-function Description({ variantId }: DescriptionProps) {
+function Description({ variantId, data }: DescriptionProps) {
   return (
     <>
       Literature-based curation associating <strong>{variantId}</strong>{" "} to a disease/phenotype. Source:{" "}
-      <Link to="https://www.uniprot.org" external>
+      <Link external to={identifiersOrgLink("uniprot", data.variant.uniProtVariants[0].targetFromSourceId)}>
         UniProt
       </Link>
     </>


### PR DESCRIPTION
## Description

Removed reported protein column (since all rows the same) and updated UniProt link in widget description so that specific to the protein.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)

## How Has This Been Tested?

Checked in dev environment.

## Checklist:

- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
