### PR TITLE
[Platform]: removing subtext from evidence summary

### DIFF
--- a/packages/sections/src/evidence/CRISPR/Summary.jsx
+++ b/packages/sections/src/evidence/CRISPR/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = crisprSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/CRISPRScreen/Summary.jsx
+++ b/packages/sections/src/evidence/CRISPRScreen/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = CrisprScreenSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/CancerBiomarkers/Summary.jsx
+++ b/packages/sections/src/evidence/CancerBiomarkers/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = cancerBiomarkersSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={definition.dataType}
     />
   );
 }

--- a/packages/sections/src/evidence/CancerGeneCensus/Summary.jsx
+++ b/packages/sections/src/evidence/CancerGeneCensus/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = cancerGeneCensusSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.somatic_mutation}
     />
   );
 }

--- a/packages/sections/src/evidence/Chembl/Summary.jsx
+++ b/packages/sections/src/evidence/Chembl/Summary.jsx
@@ -15,7 +15,6 @@ function Summary() {
         const { count } = chembl;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.known_drug}
     />
   );
 }

--- a/packages/sections/src/evidence/ClinGen/Summary.jsx
+++ b/packages/sections/src/evidence/ClinGen/Summary.jsx
@@ -15,7 +15,6 @@ function Summary() {
         const { count } = clingenSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/EVA/Summary.jsx
+++ b/packages/sections/src/evidence/EVA/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = evaSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/EVASomatic/Summary.jsx
+++ b/packages/sections/src/evidence/EVASomatic/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = eva_somatic;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.somatic_mutation}
     />
   );
 }

--- a/packages/sections/src/evidence/EuropePmc/Summary.jsx
+++ b/packages/sections/src/evidence/EuropePmc/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
       renderSummary={data =>
         `${data.europePmc.count} entr${data.europePmc.count === 1 ? "y" : "ies"}`
       }
-      subText={dataTypesMap.literature}
     />
   );
 }

--- a/packages/sections/src/evidence/ExpressionAtlas/Summary.jsx
+++ b/packages/sections/src/evidence/ExpressionAtlas/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = expressionAtlasSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.rna_expression}
     />
   );
 }

--- a/packages/sections/src/evidence/Gene2Phenotype/Summary.jsx
+++ b/packages/sections/src/evidence/Gene2Phenotype/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
       renderSummary={data =>
         `${data.gene2Phenotype.count} entr${data.gene2Phenotype.count === 1 ? "y" : "ies"}`
       }
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/GeneBurden/Summary.jsx
+++ b/packages/sections/src/evidence/GeneBurden/Summary.jsx
@@ -15,7 +15,6 @@ function Summary() {
         const { count } = geneBurdenSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/GenomicsEngland/Summary.jsx
+++ b/packages/sections/src/evidence/GenomicsEngland/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
       renderSummary={data =>
         `${data.genomicsEngland.count} entr${data.genomicsEngland.count === 1 ? "y" : "ies"}`
       }
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/Impc/Summary.jsx
+++ b/packages/sections/src/evidence/Impc/Summary.jsx
@@ -12,7 +12,6 @@ function Summary() {
       definition={definition}
       request={request}
       renderSummary={data => `${data.impc.count} entr${data.impc.count === 1 ? "y" : "ies"}`}
-      subText={dataTypesMap.animal_model}
     />
   );
 }

--- a/packages/sections/src/evidence/IntOgen/Summary.jsx
+++ b/packages/sections/src/evidence/IntOgen/Summary.jsx
@@ -12,7 +12,6 @@ function Summary() {
       definition={definition}
       request={request}
       renderSummary={data => `${data.intOgen.count} entr${data.intOgen.count === 1 ? "y" : "ies"}`}
-      subText={dataTypesMap.somatic_mutation}
     />
   );
 }

--- a/packages/sections/src/evidence/OTCRISPR/Summary.jsx
+++ b/packages/sections/src/evidence/OTCRISPR/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = OtCrisprSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.ot_partner}
     />
   );
 }

--- a/packages/sections/src/evidence/OTEncore/Summary.jsx
+++ b/packages/sections/src/evidence/OTEncore/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = otEncoreSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.ot_partner}
     />
   );
 }

--- a/packages/sections/src/evidence/OTGenetics/Summary.jsx
+++ b/packages/sections/src/evidence/OTGenetics/Summary.jsx
@@ -16,7 +16,6 @@ function Summary() {
           data.openTargetsGenetics.count === 1 ? "y" : "ies"
         }`
       }
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/OTValidation/Summary.jsx
+++ b/packages/sections/src/evidence/OTValidation/Summary.jsx
@@ -15,7 +15,6 @@ function Summary() {
         const { count } = otValidationSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.ot_validation_lab}
     />
   );
 }

--- a/packages/sections/src/evidence/Orphanet/Summary.jsx
+++ b/packages/sections/src/evidence/Orphanet/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = orphanetSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/Progeny/Summary.jsx
+++ b/packages/sections/src/evidence/Progeny/Summary.jsx
@@ -12,7 +12,6 @@ function Summary() {
       definition={definition}
       request={request}
       renderSummary={data => `${data.progeny.count} entr${data.progeny.count === 1 ? "y" : "ies"}`}
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/Reactome/Summary.jsx
+++ b/packages/sections/src/evidence/Reactome/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = reactomeSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/SlapEnrich/Summary.jsx
+++ b/packages/sections/src/evidence/SlapEnrich/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
       renderSummary={data =>
         `${data.slapEnrich.count} entr${data.slapEnrich.count === 1 ? "y" : "ies"}`
       }
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/SysBio/Summary.jsx
+++ b/packages/sections/src/evidence/SysBio/Summary.jsx
@@ -12,7 +12,6 @@ function Summary() {
       definition={definition}
       request={request}
       renderSummary={data => `${data.sysBio.count} entr${data.sysBio.count === 1 ? "y" : "ies"}`}
-      subText={dataTypesMap.affected_pathway}
     />
   );
 }

--- a/packages/sections/src/evidence/UniProtLiterature/Summary.jsx
+++ b/packages/sections/src/evidence/UniProtLiterature/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = uniprotLiteratureSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }

--- a/packages/sections/src/evidence/UniProtVariants/Summary.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Summary.jsx
@@ -14,7 +14,6 @@ function Summary() {
         const { count } = uniprotVariantsSummary;
         return `${count} ${count === 1 ? "entry" : "entries"}`;
       }}
-      subText={dataTypesMap.genetic_association}
     />
   );
 }


### PR DESCRIPTION
# [Platform]: removing subtext from evidence summary

## Description
Removing subtext from evidence summary

**Issue:** # https://github.com/opentargets/issues/issues/3330
**Deploy preview:** https://deploy-preview-387--ot-platform.netlify.app

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: go to evidence page and see the summary cards

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
