### PR TITLE
[Platform]: prevent drug widgets from crashing by new references

### DIFF
--- a/packages/sections/src/common/KnownDrugs/SourceDrawer.jsx
+++ b/packages/sections/src/common/KnownDrugs/SourceDrawer.jsx
@@ -76,6 +76,9 @@ const tableSourceLabel = name =>
     ClinicalTrials: "ClinicalTrials.gov",
     DailyMed: "DailyMed",
     FDA: "FDA",
+    EMA: "European Medicines Agency",
+    INN: "International Nonproprietary Names",
+    USAN: "United States Adopted Name",
   }[name]);
 
 const drawerSourceLabel = (name, url) => {
@@ -91,7 +94,7 @@ const drawerSourceLabel = (name, url) => {
   if (name === "ATC") {
     return url.split("code=")[1] || `${tableSourceLabel(name)} reference`;
   }
-  return `${url.name} entry`;
+  return `${name} entry`;
 };
 
 function SourceDrawer({ references }) {

--- a/packages/sections/src/constants.js
+++ b/packages/sections/src/constants.js
@@ -59,6 +59,9 @@ export const sourceMap = {
   DailyMed: "DailyMed",
   "ATC Information": "ATC",
   ATC: "ATC",
+  EMA: "European Medicines Agency",
+  INN: "International Nonproprietary Names",
+  USAN: "United States Adopted Name",
 };
 
 export const clinvarStarMap = {

--- a/packages/sections/src/utils/urls.js
+++ b/packages/sections/src/utils/urls.js
@@ -79,11 +79,26 @@ function dailyMedUrl(id) {
   return `http://dailymed.nlm.nih.gov/dailymed/drugInfo.cfm?setid=${id}`;
 }
 
+function innUrl() {
+  return "https://www.who.int/publications/m/item/inn-pl-126";
+}
+
+function emaUrl() {
+  return "https://www.ema.europa.eu/en/medicines";
+}
+
+function usanUrl(id) {
+  return `https://searchusan.ama-assn.org/finder/usan/search/${id}/relevant/1`;
+}
+
 export const referenceUrls = {
   ClinicalTrials: clinicalTrialsUrl,
   FDA: fdaUrl,
   ATC: atcUrl,
   DailyMed: dailyMedUrl,
+  INN: innUrl,
+  EMA: emaUrl,
+  USAN: usanUrl,
 };
 
 // Associations and URL PPP


### PR DESCRIPTION
# [Platform]: prevent drug widgets from crashing by new references

**Issue:**  https://github.com/opentargets/issues/issues/3348

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Check multiple drug page

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
