### PR TITLE
[Platform] Add QTL credible sets widget to variant page

### DIFF
--- a/apps/platform/src/pages/VariantPage/Profile.tsx
+++ b/apps/platform/src/pages/VariantPage/Profile.tsx
@@ -9,6 +9,7 @@ import {
 import InSilicoPredictorsSummary from "sections/src/variant/InSilicoPredictors/Summary";
 import EVASummary from "sections/src/variant/EVA/Summary";
 import UniProtVariantsSummary from "sections/src/variant/UniProtVariants/Summary";
+import QTLCredibleSetsSummary from "sections/src/variant/QTLCredibleSets/Summary";
 import PharmacogenomicsSummary from "sections/src/variant/Pharmacogenomics/Summary";
 
 import ProfileHeader from "./ProfileHeader";
@@ -16,12 +17,14 @@ import ProfileHeader from "./ProfileHeader";
 const InSilicoPredictorsSection = lazy(() => import("sections/src/variant/InSilicoPredictors/Body"));
 const EVASection = lazy(() => import("sections/src/variant/EVA/Body"));
 const UniProtVariantsSection = lazy(() => import("sections/src/variant/UniProtVariants/Body"));
+const QTLCredibleSetsSection = lazy(() => import("sections/src/variant/QTLCredibleSets/Body"));
 const PharmacogenomicsSection = lazy(() => import("sections/src/variant/Pharmacogenomics/Body"));
 
 const summaries = [
   InSilicoPredictorsSummary,
   EVASummary,
   UniProtVariantsSummary,
+  QTLCredibleSetsSummary,
   PharmacogenomicsSummary,
 ];
 
@@ -51,6 +54,7 @@ function Profile({ varId }: ProfileProps) {
         <InSilicoPredictorsSummary />
         <EVASummary />
         <UniProtVariantsSummary />
+        <QTLCredibleSetsSummary />
         <PharmacogenomicsSummary />
       </SummaryContainer>
     
@@ -65,9 +69,11 @@ function Profile({ varId }: ProfileProps) {
           <UniProtVariantsSection id={varId} label='NO-LABEL!' entity={VARIANT} />
         </Suspense>
         <Suspense fallback={<SectionLoader />}>
+          <QTLCredibleSetsSection id={varId} label='NO-LABEL!' entity={VARIANT} />
+        </Suspense>
+        <Suspense fallback={<SectionLoader />}>
           <PharmacogenomicsSection id={varId} label='NO-LABEL!' entity={VARIANT} />
         </Suspense>
-        {/* NEED ANYTHING IN <PrivateWrapper> ???? see evidence page */}
       </SectionContainer>
   
     </>

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -21,31 +21,29 @@ function getColumns(id: string, label: string) {
       exportLabel: "Lead Variant",
     },
     {
-      id: "trait",
-      label: "Trait",
-      renderCell: d => (
-        "???"
-        // <Link to={`/disease/${d["study.disease.id"]}`}>
-        //   {d["study.disease.name"]}
-        // </Link>
-      ),
-      exportLabel: "Trait",
-    },
-    {
       id: "study",
       label: "Study",
       renderCell: d => (
-        // <Link external to={`??????????????????????????/${d["study.id"]}`}>
-        //   {d["study.id"]}
-        // </Link>
-        `${d["study.id"]} (url???)`
+        <Link external to="https://www.ebi.ac.uk/eqtl/Studies/">
+          {d["study.projectId"]}
+        </Link>
       ),
+      exportLabel: "Study",
+    },
+    {
+      id: "type",
+      label: "Type",
+      renderCell: d => d["study.studyType"],
       exportLabel: "Study",
     },
     {
       id: "tissue",
       label: "Tissue",
-      renderCell: d => "???",
+      renderCell: d => (
+        <Link external to={`https://www.ebi.ac.uk/ols4/search?q=${d.tissueFromSourceId}&ontology=uberon`}>
+          {d["tissue.label"] || <i>({d["tissue.id"]})</i>}
+        </Link>
+      ),
       exportLabel: "Tissue",
     },
     {
@@ -66,15 +64,6 @@ function getColumns(id: string, label: string) {
       renderCell: ({ beta }) => beta || beta === 0 ? beta.toPrecision(3) : naLabel,
       exportLabel: "Beta",
     },
-    // // {
-    // //   id: "ldr2",
-    // //   label: "LD (r2)",
-    // //   tooltip: "Linkage disequilibrium with the queried variant",
-    // //   renderCell: ({ locus }) => (
-    // //     locus.find(obj => obj.variantId === id).r2Overall.toFixed(2)
-    // //   ),
-    // //   exportLabel: "LD (r2)",
-    // // },
     {
       id: "fineMappingMethod",
       label: "Finemapping Method",
@@ -82,25 +71,14 @@ function getColumns(id: string, label: string) {
       exportLabel: "Finemapping Method",
     },
     {
-      id: "topL2G",
-      label: "Top L2G",
-      tooltip: "Top gene prioritised by our locus-to-gene model",
+      id: "gene",
+      label: "Gene",
       renderCell: d => (
-        "???"
-        // <Link to={`/target/${d["l2g.target.id"]}`}>
-        //   {d["l2g.target.approvedSymbol"]}
-        // </Link>
+        <Link to={`/target/${d["target.id"]}`}>
+          {d["target.approvedSymbol"]}
+        </Link>
       ),
-      exportLabel: "Top L2G",
-    },
-    {
-      id: "l2gScore",
-      label: "L2G score",
-      comparator: (a, b) => a["l2g.score"] - b["l2g.score"],
-      sortable: true,
-      renderCell: d => "???",
-      // renderCell: d => d["l2g.score"].toFixed(3),
-      exportLabel: "L2G score", 
+      exportLabel: "Gene",
     },
     {
       id: "credibleSetSize",
@@ -164,647 +142,979 @@ function mockQuery() {
   "TAG_VARIANT_ID": "10_100315722_G_A",
   "variant": {
     "gwasCredibleSets": [
-        {
-            "variantId": "2_8302417_G_A",
-            "study.id": "GTEx_brain_putamen_ENST00000668369",
-            "study.studyType": "eqtl",
-            "study.projectId": "GTEx",
-            "pValueMantissa": 2.359,
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_brain_putamen_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 2.359,
+        "pValueExponent": -8,
+        "beta": 0.694055,
+        "posteriorProbability": 0.0248072063095605,
+        "tissue.id": "UBERON_0001874",
+        "tissue.label": "putamen",
+        "tissue.organs": [
+          "brain"
+        ],
+        "tissue.anatomicalSystems": [
+          "nervous system"
+        ],
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
             "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300216_T_C"
+          },
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300315_CACCA_C"
+          },
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300442_G_A"
+          },
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300228_C_A"
+          },
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300184_A_G"
+          },
+          {
+            "beta": 0.642905,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.6040572828625,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.124,
+            "posteriorProbability": 0.0711130529884503,
+            "standardError": 0.106521,
+            "variantId": "2_8300257_G_A"
+          },
+          {
+            "beta": 0.710524,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.599567286068,
+            "pValueExponent": -9,
+            "pValueMantissa": 7.823,
+            "posteriorProbability": 0.0709443341781754,
+            "standardError": 0.116336,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": 0.710524,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.599567286068,
+            "pValueExponent": -9,
+            "pValueMantissa": 7.823,
+            "posteriorProbability": 0.0709443341781754,
+            "standardError": 0.116336,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": 0.707031,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.3380989257068,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.013,
+            "posteriorProbability": 0.05493800379884,
+            "standardError": 0.116746,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8301354_T_C"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8299775_T_C"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8301617_G_C"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8301238_AG_A"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8301922_G_A"
+          },
+          {
+            "beta": 0.627503,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0559753546737,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.981,
+            "posteriorProbability": 0.0416366528677439,
+            "standardError": 0.105964,
+            "variantId": "2_8300902_T_A"
+          },
+          {
+            "beta": 0.617058,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.0362580958606,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.9,
+            "posteriorProbability": 0.0408672957421271,
+            "standardError": 0.104052,
+            "variantId": "2_8299499_G_A"
+          },
+          {
             "beta": 0.694055,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.5117080110389,
+            "pValueExponent": -8,
+            "pValueMantissa": 2.359,
             "posteriorProbability": 0.0248072063095605,
-            "tissueFromSourceId": "UBERON_0001874",
-            "target.id": "ENSG00000236790",
-            "target.approvedSymbol": "LINC00299",
-            "finemappingMethod": "SuSie",
-            "locus": [
-              {
-                "variantId": "2_8300216_T_C",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300315_CACCA_C",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300442_G_A",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300228_C_A",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300184_A_G",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300257_G_A",
-                "posteriorProbability": 0.0711130529884503,
-                "pValueMantissa": 1.124,
-                "pValueExponent": -8,
-                "logBF": 17.6040572828625,
-                "beta": 0.642905,
-                "standardError": 0.106521,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302118_G_A",
-                "posteriorProbability": 0.0709443341781754,
-                "pValueMantissa": 7.823,
-                "pValueExponent": -9,
-                "logBF": 17.599567286068,
-                "beta": 0.710524,
-                "standardError": 0.116336,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8303673_G_A",
-                "posteriorProbability": 0.0709443341781754,
-                "pValueMantissa": 7.823,
-                "pValueExponent": -9,
-                "logBF": 17.599567286068,
-                "beta": 0.710524,
-                "standardError": 0.116336,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301605_C_G",
-                "posteriorProbability": 0.05493800379884,
-                "pValueMantissa": 1.013,
-                "pValueExponent": -8,
-                "logBF": 17.3380989257068,
-                "beta": 0.707031,
-                "standardError": 0.116746,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301354_T_C",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8299775_T_C",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301617_G_C",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301238_AG_A",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301922_G_A",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8300902_T_A",
-                "posteriorProbability": 0.0416366528677439,
-                "pValueMantissa": 1.981,
-                "pValueExponent": -8,
-                "logBF": 17.0559753546737,
-                "beta": 0.627503,
-                "standardError": 0.105964,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8299499_G_A",
-                "posteriorProbability": 0.0408672957421271,
-                "pValueMantissa": 1.9,
-                "pValueExponent": -8,
-                "logBF": 17.0362580958606,
-                "beta": 0.617058,
-                "standardError": 0.104052,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302417_G_A",
-                "posteriorProbability": 0.0248072063095605,
-                "pValueMantissa": 2.359,
-                "pValueExponent": -8,
-                "logBF": 16.5117080110389,
-                "beta": 0.694055,
-                "standardError": 0.117906,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301854_G_C",
-                "posteriorProbability": 0.0227548621765494,
-                "pValueMantissa": 3.6,
-                "pValueExponent": -8,
-                "logBF": 16.425230102072,
-                "beta": 0.62834,
-                "standardError": 0.108323,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8299556_T_A",
-                "posteriorProbability": 0.0186121956658267,
-                "pValueMantissa": 4.056,
-                "pValueExponent": -8,
-                "logBF": 16.2116375202122,
-                "beta": 0.614712,
-                "standardError": 0.106421,
-                "is95CredibleSet": false,
-                "is99CredibleSet": true
-              }
-            ]
+            "standardError": 0.117906,
+            "variantId": "2_8302417_G_A"
           },
           {
-            "variantId": "2_8302417_G_A",
-            "study.id": "GTEx_blood_ENST00000668369",
-            "study.studyType": "eqtl",
-            "study.projectId": "GTEx",
-            "pValueMantissa": 1.316,
-            "pValueExponent": -13,
-            "beta": 0.437502,
-            "posteriorProbability": 0.206320522430541,
-            "tissueFromSourceId": "UBERON_0000178",
-            "target.id": "ENSG00000236790",
-            "target.approvedSymbol": "LINC00299",
-            "finemappingMethod": "SuSie",
-            "locus": [
-              {
-                "variantId": "2_8303673_G_A",
-                "posteriorProbability": 0.437585247168172,
-                "pValueMantissa": 6.226,
-                "pValueExponent": -14,
-                "logBF": 27.5844258581983,
-                "beta": 0.441853,
-                "standardError": 0.0576047,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302118_G_A",
-                "posteriorProbability": 0.268767540614083,
-                "pValueMantissa": 1.0,
-                "pValueExponent": -13,
-                "logBF": 27.0953274288198,
-                "beta": 0.439394,
-                "standardError": 0.0577853,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302417_G_A",
-                "posteriorProbability": 0.206320522430541,
-                "pValueMantissa": 1.316,
-                "pValueExponent": -13,
-                "logBF": 26.8295969712965,
-                "beta": 0.437502,
-                "standardError": 0.0578308,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301605_C_G",
-                "posteriorProbability": 0.0660264004283134,
-                "pValueMantissa": 4.28,
-                "pValueExponent": -13,
-                "logBF": 25.678130696286,
-                "beta": 0.427533,
-                "standardError": 0.0577982,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              }
-            ]
+            "beta": 0.62834,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.425230102072,
+            "pValueExponent": -8,
+            "pValueMantissa": 3.6,
+            "posteriorProbability": 0.0227548621765494,
+            "standardError": 0.108323,
+            "variantId": "2_8301854_G_C"
           },
           {
-            "variantId": "2_8302417_G_A",
-            "study.id": "OneK1K_NK_ENSG00000236790",
-            "study.studyType": "eqtl",
-            "study.projectId": "OneK1K",
-            "pValueMantissa": 2.615,
-            "pValueExponent": -9,
-            "beta": -0.234293,
-            "posteriorProbability": 0.00675924439887354,
-            "tissueFromSourceId": "CL_0000623",
-            "target.id": "ENSG00000236790",
-            "target.approvedSymbol": "LINC00299",
-            "finemappingMethod": "SuSie",
-            "locus": [
-              {
-                "variantId": "2_8317950_G_A",
-                "posteriorProbability": 0.274712436451997,
-                "pValueMantissa": 1.723,
-                "pValueExponent": -11,
-                "logBF": 17.2516206510268,
-                "beta": -0.271104,
-                "standardError": 0.0398152,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8319274_C_T",
-                "posteriorProbability": 0.274342370894736,
-                "pValueMantissa": 1.725,
-                "pValueExponent": -11,
-                "logBF": 17.2502726069861,
-                "beta": -0.271095,
-                "standardError": 0.0398149,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8328080_G_T",
-                "posteriorProbability": 0.14241675323407,
-                "pValueMantissa": 3.462,
-                "pValueExponent": -11,
-                "logBF": 16.5946293668575,
-                "beta": -0.271475,
-                "standardError": 0.0404998,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8318470_CAA_C",
-                "posteriorProbability": 0.0967445137874696,
-                "pValueMantissa": 6.97,
-                "pValueExponent": -11,
-                "logBF": 16.207924249784,
-                "beta": -0.269839,
-                "standardError": 0.0409132,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8318470_CAA_C",
-                "posteriorProbability": 0.0967445137874696,
-                "pValueMantissa": 6.97,
-                "pValueExponent": -11,
-                "logBF": 16.207924249784,
-                "beta": -0.269839,
-                "standardError": 0.0409132,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8318470_CAA_C",
-                "posteriorProbability": 0.0967445137874696,
-                "pValueMantissa": 6.97,
-                "pValueExponent": -11,
-                "logBF": 16.207924249784,
-                "beta": -0.269839,
-                "standardError": 0.0409132,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8321295_G_C",
-                "posteriorProbability": 0.0754513364335386,
-                "pValueMantissa": 1.076,
-                "pValueExponent": -10,
-                "logBF": 15.9593114306933,
-                "beta": -0.265941,
-                "standardError": 0.0407396,
-                "is95CredibleSet": false,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8326356_C_G",
-                "posteriorProbability": 0.0231288588741211,
-                "pValueMantissa": 5.806,
-                "pValueExponent": -10,
-                "logBF": 14.7767588466438,
-                "beta": -0.250459,
-                "standardError": 0.0400143,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8330530_G_A",
-                "posteriorProbability": 0.020413996505835,
-                "pValueMantissa": 3.317,
-                "pValueExponent": -10,
-                "logBF": 14.6517634254716,
-                "beta": -0.268473,
-                "standardError": 0.0422823,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8321272_G_A",
-                "posteriorProbability": 0.014184311179504,
-                "pValueMantissa": 9.779,
-                "pValueExponent": -10,
-                "logBF": 14.2876759204919,
-                "beta": -0.249102,
-                "standardError": 0.040346,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8302118_G_A",
-                "posteriorProbability": 0.00808799095217061,
-                "pValueMantissa": 2.204,
-                "pValueExponent": -9,
-                "logBF": 13.7255582849134,
-                "beta": -0.235415,
-                "standardError": 0.0389802,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8301605_C_G",
-                "posteriorProbability": 0.00744683074699681,
-                "pValueMantissa": 2.429,
-                "pValueExponent": -9,
-                "logBF": 13.6429102465236,
-                "beta": -0.234261,
-                "standardError": 0.0388939,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8302417_G_A",
-                "posteriorProbability": 0.00675924439887354,
-                "pValueMantissa": 2.615,
-                "pValueExponent": -9,
-                "logBF": 13.5459654738097,
-                "beta": -0.234293,
-                "standardError": 0.0389794,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8303673_G_A",
-                "posteriorProbability": 0.00629822953336312,
-                "pValueMantissa": 2.714,
-                "pValueExponent": -9,
-                "logBF": 13.4752592670769,
-                "beta": -0.233958,
-                "standardError": 0.0389641,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              },
-              {
-                "variantId": "2_8331189_G_A",
-                "posteriorProbability": 0.0060003978172174,
-                "pValueMantissa": 1.219,
-                "pValueExponent": -9,
-                "logBF": 13.4266225989143,
-                "beta": -0.260677,
-                "standardError": 0.0424708,
-                "is95CredibleSet": false,
-                "is99CredibleSet": false
-              }
-            ]
-          },
-          {
-            "variantId": "2_8302417_G_A",
-            "study.id": "GTEx_brain_hippocampus_ENST00000668369",
-            "study.studyType": "eqtl",
-            "study.projectId": "GTEx",
-            "pValueMantissa": 1.538,
-            "pValueExponent": -12,
-            "beta": 0.835806,
-            "posteriorProbability": 0.165901511700505,
-            "tissueFromSourceId": "UBERON_0001954",
-            "target.id": "ENSG00000236790",
-            "target.approvedSymbol": "LINC00299",
-            "finemappingMethod": "SuSie",
-            "locus": [
-              {
-                "variantId": "2_8311368_A_G",
-                "posteriorProbability": 0.456618152566933,
-                "pValueMantissa": 5.857,
-                "pValueExponent": -13,
-                "logBF": 31.9502944290118,
-                "beta": 0.851218,
-                "standardError": 0.107896,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301605_C_G",
-                "posteriorProbability": 0.179810930741611,
-                "pValueMantissa": 1.414,
-                "pValueExponent": -12,
-                "logBF": 31.0181593663888,
-                "beta": 0.839676,
-                "standardError": 0.108583,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302417_G_A",
-                "posteriorProbability": 0.165901511700505,
-                "pValueMantissa": 1.538,
-                "pValueExponent": -12,
-                "logBF": 30.9376219772967,
-                "beta": 0.835806,
-                "standardError": 0.108293,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302118_G_A",
-                "posteriorProbability": 0.165901511700505,
-                "pValueMantissa": 1.538,
-                "pValueExponent": -12,
-                "logBF": 30.9376219772967,
-                "beta": 0.835806,
-                "standardError": 0.108293,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              }
-            ]
-          },
-          {
-            "variantId": "2_8302417_G_A",
-            "study.id": "OneK1K_NK_ENSG00000235665",
-            "study.studyType": "eqtl",
-            "study.projectId": "OneK1K",
-            "pValueMantissa": 5.725,
-            "pValueExponent": -9,
-            "beta": -0.271797,
-            "posteriorProbability": 0.192983930988765,
-            "tissueFromSourceId": "CL_0000623",
-            "target.id": "ENSG00000235665",
-            "target.approvedSymbol": "LINC00298",
-            "finemappingMethod": "SuSie",
-            "locus": [
-              {
-                "variantId": "2_8302417_G_A",
-                "posteriorProbability": 0.192983930988765,
-                "pValueMantissa": 5.725,
-                "pValueExponent": -9,
-                "logBF": 15.2241703106444,
-                "beta": -0.271797,
-                "standardError": 0.0462429,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8302118_G_A",
-                "posteriorProbability": 0.192530791669411,
-                "pValueMantissa": 5.737,
-                "pValueExponent": -9,
-                "logBF": 15.2218194819916,
-                "beta": -0.271833,
-                "standardError": 0.0462518,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8303673_G_A",
-                "posteriorProbability": 0.186583542163576,
-                "pValueMantissa": 5.929,
-                "pValueExponent": -9,
-                "logBF": 15.1904424703745,
-                "beta": -0.271412,
-                "standardError": 0.0462246,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8301605_C_G",
-                "posteriorProbability": 0.158092245682673,
-                "pValueMantissa": 7.051,
-                "pValueExponent": -9,
-                "logBF": 15.0247420804285,
-                "beta": -0.269625,
-                "standardError": 0.0461546,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8298563_C_T",
-                "posteriorProbability": 0.0814314934103171,
-                "pValueMantissa": 1.409,
-                "pValueExponent": -8,
-                "logBF": 14.3613254794471,
-                "beta": -0.2654,
-                "standardError": 0.0463882,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8309993_A_G",
-                "posteriorProbability": 0.0640584295744518,
-                "pValueMantissa": 1.814,
-                "pValueExponent": -8,
-                "logBF": 14.1213590132954,
-                "beta": -0.263233,
-                "standardError": 0.0463698,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8311368_A_G",
-                "posteriorProbability": 0.0417204122512237,
-                "pValueMantissa": 2.839,
-                "pValueExponent": -8,
-                "logBF": 13.6925538957963,
-                "beta": -0.25805,
-                "standardError": 0.0461046,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8311571_T_C",
-                "posteriorProbability": 0.0225973287224273,
-                "pValueMantissa": 5.392,
-                "pValueExponent": -8,
-                "logBF": 13.0793950855009,
-                "beta": -0.258396,
-                "standardError": 0.0471427,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              },
-              {
-                "variantId": "2_8319274_C_T",
-                "posteriorProbability": 0.0160322428284877,
-                "pValueMantissa": 7.748,
-                "pValueExponent": -8,
-                "logBF": 12.7361652556066,
-                "beta": -0.257731,
-                "standardError": 0.0475987,
-                "is95CredibleSet": true,
-                "is99CredibleSet": true
-              }
-            ]
+            "beta": 0.614712,
+            "is95CredibleSet": false,
+            "is99CredibleSet": true,
+            "logBF": 16.2116375202122,
+            "pValueExponent": -8,
+            "pValueMantissa": 4.056,
+            "posteriorProbability": 0.0186121956658267,
+            "standardError": 0.106421,
+            "variantId": "2_8299556_T_A"
           }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_blood_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 1.316,
+        "pValueExponent": -13,
+        "beta": 0.437502,
+        "posteriorProbability": 0.206320522430541,
+        "tissue.id": "UBERON_0000178",
+        "tissue.label": "blood",
+        "tissue.organs": [
+          "blood"
+        ],
+        "tissue.anatomicalSystems": [
+          "circulatory system",
+          "hemolymphoid system",
+          "hematopoietic system"
+        ],
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.441853,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 27.5844258581983,
+            "pValueExponent": -14,
+            "pValueMantissa": 6.226,
+            "posteriorProbability": 0.437585247168172,
+            "standardError": 0.0576047,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": 0.439394,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 27.0953274288198,
+            "pValueExponent": -13,
+            "pValueMantissa": 1.0,
+            "posteriorProbability": 0.268767540614083,
+            "standardError": 0.0577853,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": 0.437502,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 26.8295969712965,
+            "pValueExponent": -13,
+            "pValueMantissa": 1.316,
+            "posteriorProbability": 0.206320522430541,
+            "standardError": 0.0578308,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.427533,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 25.678130696286,
+            "pValueExponent": -13,
+            "pValueMantissa": 4.28,
+            "posteriorProbability": 0.0660264004283134,
+            "standardError": 0.0577982,
+            "variantId": "2_8301605_C_G"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "OneK1K_NK_ENSG00000236790",
+        "study.projectId": "OneK1K",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 2.615,
+        "pValueExponent": -9,
+        "beta": -0.234293,
+        "posteriorProbability": 0.00675924439887354,
+        "tissue.id": "CL_0000623",
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": -0.271104,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.2516206510268,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.723,
+            "posteriorProbability": 0.274712436451997,
+            "standardError": 0.0398152,
+            "variantId": "2_8317950_G_A"
+          },
+          {
+            "beta": -0.271095,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 17.2502726069861,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.725,
+            "posteriorProbability": 0.274342370894736,
+            "standardError": 0.0398149,
+            "variantId": "2_8319274_C_T"
+          },
+          {
+            "beta": -0.271475,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.5946293668575,
+            "pValueExponent": -11,
+            "pValueMantissa": 3.462,
+            "posteriorProbability": 0.14241675323407,
+            "standardError": 0.0404998,
+            "variantId": "2_8328080_G_T"
+          },
+          {
+            "beta": -0.269839,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.207924249784,
+            "pValueExponent": -11,
+            "pValueMantissa": 6.97,
+            "posteriorProbability": 0.0967445137874696,
+            "standardError": 0.0409132,
+            "variantId": "2_8318470_CAA_C"
+          },
+          {
+            "beta": -0.269839,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.207924249784,
+            "pValueExponent": -11,
+            "pValueMantissa": 6.97,
+            "posteriorProbability": 0.0967445137874696,
+            "standardError": 0.0409132,
+            "variantId": "2_8318470_CAA_C"
+          },
+          {
+            "beta": -0.269839,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 16.207924249784,
+            "pValueExponent": -11,
+            "pValueMantissa": 6.97,
+            "posteriorProbability": 0.0967445137874696,
+            "standardError": 0.0409132,
+            "variantId": "2_8318470_CAA_C"
+          },
+          {
+            "beta": -0.265941,
+            "is95CredibleSet": false,
+            "is99CredibleSet": true,
+            "logBF": 15.9593114306933,
+            "pValueExponent": -10,
+            "pValueMantissa": 1.076,
+            "posteriorProbability": 0.0754513364335386,
+            "standardError": 0.0407396,
+            "variantId": "2_8321295_G_C"
+          },
+          {
+            "beta": -0.250459,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 14.7767588466438,
+            "pValueExponent": -10,
+            "pValueMantissa": 5.806,
+            "posteriorProbability": 0.0231288588741211,
+            "standardError": 0.0400143,
+            "variantId": "2_8326356_C_G"
+          },
+          {
+            "beta": -0.268473,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 14.6517634254716,
+            "pValueExponent": -10,
+            "pValueMantissa": 3.317,
+            "posteriorProbability": 0.020413996505835,
+            "standardError": 0.0422823,
+            "variantId": "2_8330530_G_A"
+          },
+          {
+            "beta": -0.249102,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 14.2876759204919,
+            "pValueExponent": -10,
+            "pValueMantissa": 9.779,
+            "posteriorProbability": 0.014184311179504,
+            "standardError": 0.040346,
+            "variantId": "2_8321272_G_A"
+          },
+          {
+            "beta": -0.235415,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 13.7255582849134,
+            "pValueExponent": -9,
+            "pValueMantissa": 2.204,
+            "posteriorProbability": 0.00808799095217061,
+            "standardError": 0.0389802,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": -0.234261,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 13.6429102465236,
+            "pValueExponent": -9,
+            "pValueMantissa": 2.429,
+            "posteriorProbability": 0.00744683074699681,
+            "standardError": 0.0388939,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": -0.234293,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 13.5459654738097,
+            "pValueExponent": -9,
+            "pValueMantissa": 2.615,
+            "posteriorProbability": 0.00675924439887354,
+            "standardError": 0.0389794,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": -0.233958,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 13.4752592670769,
+            "pValueExponent": -9,
+            "pValueMantissa": 2.714,
+            "posteriorProbability": 0.00629822953336312,
+            "standardError": 0.0389641,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": -0.260677,
+            "is95CredibleSet": false,
+            "is99CredibleSet": false,
+            "logBF": 13.4266225989143,
+            "pValueExponent": -9,
+            "pValueMantissa": 1.219,
+            "posteriorProbability": 0.0060003978172174,
+            "standardError": 0.0424708,
+            "variantId": "2_8331189_G_A"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_brain_hippocampus_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 1.538,
+        "pValueExponent": -12,
+        "beta": 0.835806,
+        "posteriorProbability": 0.165901511700505,
+        "tissue.id": "UBERON_0001954",
+        "tissue.label": "hippocampus proper",
+        "tissue.organs": [
+          "brain"
+        ],
+        "tissue.anatomicalSystems": [
+          "nervous system"
+        ],
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.851218,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 31.9502944290118,
+            "pValueExponent": -13,
+            "pValueMantissa": 5.857,
+            "posteriorProbability": 0.456618152566933,
+            "standardError": 0.107896,
+            "variantId": "2_8311368_A_G"
+          },
+          {
+            "beta": 0.839676,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 31.0181593663888,
+            "pValueExponent": -12,
+            "pValueMantissa": 1.414,
+            "posteriorProbability": 0.179810930741611,
+            "standardError": 0.108583,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.835806,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.9376219772967,
+            "pValueExponent": -12,
+            "pValueMantissa": 1.538,
+            "posteriorProbability": 0.165901511700505,
+            "standardError": 0.108293,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.835806,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.9376219772967,
+            "pValueExponent": -12,
+            "pValueMantissa": 1.538,
+            "posteriorProbability": 0.165901511700505,
+            "standardError": 0.108293,
+            "variantId": "2_8302118_G_A"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "OneK1K_NK_ENSG00000235665",
+        "study.projectId": "OneK1K",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 5.725,
+        "pValueExponent": -9,
+        "beta": -0.271797,
+        "posteriorProbability": 0.192983930988765,
+        "tissue.id": "CL_0000623",
+        "target.approvedSymbol": "LINC00298",
+        "target.id": "ENSG00000235665",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": -0.271797,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 15.2241703106444,
+            "pValueExponent": -9,
+            "pValueMantissa": 5.725,
+            "posteriorProbability": 0.192983930988765,
+            "standardError": 0.0462429,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": -0.271833,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 15.2218194819916,
+            "pValueExponent": -9,
+            "pValueMantissa": 5.737,
+            "posteriorProbability": 0.192530791669411,
+            "standardError": 0.0462518,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": -0.271412,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 15.1904424703745,
+            "pValueExponent": -9,
+            "pValueMantissa": 5.929,
+            "posteriorProbability": 0.186583542163576,
+            "standardError": 0.0462246,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": -0.269625,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 15.0247420804285,
+            "pValueExponent": -9,
+            "pValueMantissa": 7.051,
+            "posteriorProbability": 0.158092245682673,
+            "standardError": 0.0461546,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": -0.2654,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 14.3613254794471,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.409,
+            "posteriorProbability": 0.0814314934103171,
+            "standardError": 0.0463882,
+            "variantId": "2_8298563_C_T"
+          },
+          {
+            "beta": -0.263233,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 14.1213590132954,
+            "pValueExponent": -8,
+            "pValueMantissa": 1.814,
+            "posteriorProbability": 0.0640584295744518,
+            "standardError": 0.0463698,
+            "variantId": "2_8309993_A_G"
+          },
+          {
+            "beta": -0.25805,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 13.6925538957963,
+            "pValueExponent": -8,
+            "pValueMantissa": 2.839,
+            "posteriorProbability": 0.0417204122512237,
+            "standardError": 0.0461046,
+            "variantId": "2_8311368_A_G"
+          },
+          {
+            "beta": -0.258396,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 13.0793950855009,
+            "pValueExponent": -8,
+            "pValueMantissa": 5.392,
+            "posteriorProbability": 0.0225973287224273,
+            "standardError": 0.0471427,
+            "variantId": "2_8311571_T_C"
+          },
+          {
+            "beta": -0.257731,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 12.7361652556066,
+            "pValueExponent": -8,
+            "pValueMantissa": 7.748,
+            "posteriorProbability": 0.0160322428284877,
+            "standardError": 0.0475987,
+            "variantId": "2_8319274_C_T"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_brain_frontal_cortex_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 1.647,
+        "pValueExponent": -11,
+        "beta": 0.830331,
+        "posteriorProbability": 0.170740875140783,
+        "tissue.id": "UBERON_0009834",
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.791836,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.4073796634121,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.18,
+            "posteriorProbability": 0.25605360330664,
+            "standardError": 0.10827,
+            "variantId": "2_8309993_A_G"
+          },
+          {
+            "beta": 0.835412,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.2112029910782,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.307,
+            "posteriorProbability": 0.210577225022572,
+            "standardError": 0.114515,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.830331,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.0005251675673,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.647,
+            "posteriorProbability": 0.170740875140783,
+            "standardError": 0.11447,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.830331,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 30.0005251675673,
+            "pValueExponent": -11,
+            "pValueMantissa": 1.647,
+            "posteriorProbability": 0.170740875140783,
+            "standardError": 0.11447,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": 0.815016,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 29.4233646571621,
+            "pValueExponent": -11,
+            "pValueMantissa": 2.896,
+            "posteriorProbability": 0.0962553420059085,
+            "standardError": 0.113961,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": 0.803417,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 29.2260690447822,
+            "pValueExponent": -11,
+            "pValueMantissa": 4.432,
+            "posteriorProbability": 0.0791844579537612,
+            "standardError": 0.113566,
+            "variantId": "2_8311368_A_G"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "BrainSeq_brain_ENSG00000236790.7_2_8301809_8302425",
+        "study.projectId": "BrainSeq",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 9.465,
+        "pValueExponent": -11,
+        "beta": 0.355105,
+        "posteriorProbability": 0.182954793751843,
+        "tissue.id": "UBERON_0009834",
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.348512,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 19.7118062384469,
+            "pValueExponent": -11,
+            "pValueMantissa": 4.363,
+            "posteriorProbability": 0.325265824142563,
+            "standardError": 0.0516138,
+            "variantId": "2_8303673_G_A"
+          },
+          {
+            "beta": 0.350213,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 19.6686661010807,
+            "pValueExponent": -11,
+            "pValueMantissa": 4.366,
+            "posteriorProbability": 0.31155351080831,
+            "standardError": 0.0518665,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.355105,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 19.1351840148282,
+            "pValueExponent": -11,
+            "pValueMantissa": 9.465,
+            "posteriorProbability": 0.182954793751843,
+            "standardError": 0.0535762,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.353183,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 19.1100319671448,
+            "pValueExponent": -11,
+            "pValueMantissa": 9.795,
+            "posteriorProbability": 0.178422962536864,
+            "standardError": 0.0533308,
+            "variantId": "2_8302118_G_A"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_brain_hypothalamus_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 7.41,
+        "pValueExponent": -17,
+        "beta": 0.987616,
+        "posteriorProbability": 0.203673012020257,
+        "tissue.id": "UBERON_0001898",
+        "tissue.label": "hypothalamus",
+        "tissue.organs": [
+          "brain"
+        ],
+        "tissue.anatomicalSystems": [
+          "nervous system"
+        ],
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.987616,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.8103660921336,
+            "pValueExponent": -17,
+            "pValueMantissa": 7.41,
+            "posteriorProbability": 0.203673012020257,
+            "standardError": 0.105202,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": 0.987616,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.8103660921336,
+            "pValueExponent": -17,
+            "pValueMantissa": 7.41,
+            "posteriorProbability": 0.203673012020257,
+            "standardError": 0.105202,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.965776,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.5998083046688,
+            "pValueExponent": -17,
+            "pValueMantissa": 6.952,
+            "posteriorProbability": 0.165190730726159,
+            "standardError": 0.10276,
+            "variantId": "2_8311368_A_G"
+          },
+          {
+            "beta": 0.944358,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.5538932664539,
+            "pValueExponent": -17,
+            "pValueMantissa": 8.847,
+            "posteriorProbability": 0.157825021421304,
+            "standardError": 0.100909,
+            "variantId": "2_8309993_A_G"
+          },
+          {
+            "beta": 0.986365,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.4920936073802,
+            "pValueExponent": -17,
+            "pValueMantissa": 9.943,
+            "posteriorProbability": 0.148399736070221,
+            "standardError": 0.105616,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.978528,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 45.3251774332668,
+            "pValueExponent": -16,
+            "pValueMantissa": 1.135,
+            "posteriorProbability": 0.125729484225722,
+            "standardError": 0.105023,
+            "variantId": "2_8303673_G_A"
+          }
+        ]
+      },
+      {
+        "variantId": "2_8302417_G_A",
+        "study.id": "GTEx_brain_spinal_cord_ENST00000668369",
+        "study.projectId": "GTEx",
+        "study.studyType": "eqtl",
+        "pValueMantissa": 3.806,
+        "pValueExponent": -12,
+        "beta": 0.967534,
+        "posteriorProbability": 0.453422800407135,
+        "tissue.id": "UBERON_0006469",
+        "tissue.label": "C1 segment of cervical spinal cord",
+        "tissue.organs": [
+          "spinal cord"
+        ],
+        "tissue.anatomicalSystems": [
+          "nervous system"
+        ],
+        "target.approvedSymbol": "LINC00299",
+        "target.id": "ENSG00000236790",
+        "finemappingMethod": "SuSie",
+        "locus": [
+          {
+            "beta": 0.967534,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 46.7855020162381,
+            "pValueExponent": -12,
+            "pValueMantissa": 3.806,
+            "posteriorProbability": 0.453422800407135,
+            "standardError": 0.124168,
+            "variantId": "2_8302417_G_A"
+          },
+          {
+            "beta": 0.957207,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 46.57806814963,
+            "pValueExponent": -12,
+            "pValueMantissa": 5.371,
+            "posteriorProbability": 0.368676961424256,
+            "standardError": 0.123914,
+            "variantId": "2_8311368_A_G"
+          },
+          {
+            "beta": 0.934523,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 44.7538794718291,
+            "pValueExponent": -11,
+            "pValueMantissa": 2.832,
+            "posteriorProbability": 0.0603001320652395,
+            "standardError": 0.126338,
+            "variantId": "2_8301605_C_G"
+          },
+          {
+            "beta": 0.934523,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 44.7538794718291,
+            "pValueExponent": -11,
+            "pValueMantissa": 2.832,
+            "posteriorProbability": 0.0603001320652395,
+            "standardError": 0.126338,
+            "variantId": "2_8302118_G_A"
+          },
+          {
+            "beta": 0.934523,
+            "is95CredibleSet": true,
+            "is99CredibleSet": true,
+            "logBF": 44.7538794718291,
+            "pValueExponent": -11,
+            "pValueMantissa": 2.832,
+            "posteriorProbability": 0.0603001320652395,
+            "standardError": 0.126338,
+            "variantId": "2_8303673_G_A"
+          }
+        ]
+      }
     ]
 }
 }`),

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -1,0 +1,812 @@
+import { Link, SectionItem, DataTable, ScientificNotation } from "ui";
+import { Box, Chip } from "@mui/material";
+import { naLabel, defaultRowsPerPageOptions } from "../../constants";
+import { definition } from ".";
+import Description from "./Description";
+
+function getColumns(id: string, label: string) {
+
+  return [
+    {
+      id: "leadVariant",
+      label: "Lead Variant",
+      renderCell: ({ variantId }) => (
+        variantId === id
+          ? <Box display="flex" alignContent="center" gap={0.5}>
+              <span>{variantId}</span>
+              <Chip label="self" variant="outlined" size="small"/>
+            </Box>
+          : <Link to={`/variant/${variantId}`}>{variantId}</Link>
+      ),
+      exportLabel: "Lead Variant",
+    },
+    {
+      id: "trait",
+      label: "Trait",
+      renderCell: d => (
+        "???"
+        // <Link to={`/disease/${d["study.disease.id"]}`}>
+        //   {d["study.disease.name"]}
+        // </Link>
+      ),
+      exportLabel: "Trait",
+    },
+    {
+      id: "study",
+      label: "Study",
+      renderCell: d => (
+        // <Link external to={`??????????????????????????/${d["study.id"]}`}>
+        //   {d["study.id"]}
+        // </Link>
+        `${d["study.id"]} (url???)`
+      ),
+      exportLabel: "Study",
+    },
+    {
+      id: "tissue",
+      label: "Tissue",
+      renderCell: d => "???",
+      exportLabel: "Tissue",
+    },
+    {
+      id: "pValue",
+      label: "P-Value",
+      comparator: (a, b) =>
+        a.pValueMantissa * 10 ** a.pValueExponent - b.pValueMantissa * 10 ** b.pValueExponent,
+      sortable: true,
+      renderCell: d => (
+        <ScientificNotation number={[d.pValueMantissa, d.pValueExponent]} />
+      ),
+      exportLabel: "P-Value",
+    },
+    {
+      id: "beta",
+      label: "Beta",
+      tooltip: "Beta with respect to the ALT allele",
+      renderCell: ({ beta }) => beta || beta === 0 ? beta.toPrecision(3) : naLabel,
+      exportLabel: "Beta",
+    },
+    // // {
+    // //   id: "ldr2",
+    // //   label: "LD (r2)",
+    // //   tooltip: "Linkage disequilibrium with the queried variant",
+    // //   renderCell: ({ locus }) => (
+    // //     locus.find(obj => obj.variantId === id).r2Overall.toFixed(2)
+    // //   ),
+    // //   exportLabel: "LD (r2)",
+    // // },
+    {
+      id: "fineMappingMethod",
+      label: "Finemapping Method",
+      renderCell: ({ finemappingMethod }) => finemappingMethod,
+      exportLabel: "Finemapping Method",
+    },
+    {
+      id: "topL2G",
+      label: "Top L2G",
+      tooltip: "Top gene prioritised by our locus-to-gene model",
+      renderCell: d => (
+        "???"
+        // <Link to={`/target/${d["l2g.target.id"]}`}>
+        //   {d["l2g.target.approvedSymbol"]}
+        // </Link>
+      ),
+      exportLabel: "Top L2G",
+    },
+    {
+      id: "l2gScore",
+      label: "L2G score",
+      comparator: (a, b) => a["l2g.score"] - b["l2g.score"],
+      sortable: true,
+      renderCell: d => "???",
+      // renderCell: d => d["l2g.score"].toFixed(3),
+      exportLabel: "L2G score", 
+    },
+    {
+      id: "credibleSetSize",
+      label: "Credible Set Size",
+      comparator: (a, b) => a.locus.length - b.locus.length,
+      sortable: true,
+      renderCell: ({ locus }) => locus.length,
+      exportLabel: "Credible Set Size",
+    }
+  ];
+}
+
+// !!!! LOAD LOCAL DATA FOR NOW
+// const [metadata, setMetadata] =
+//   useState<MetadataType | "waiting" | undefined>("waiting");
+const request = mockQuery();
+
+type BodyProps = {
+  id: string,
+  label: string,
+  entity: string,
+};
+
+// !! FOR NOW, RENAME id AND SET IT MANUALLY BELOW
+function Body({ id: doNotUseForNow, label, entity }: BodyProps) {
+  
+  // !! FOR NOW, SET id (IE THE PAGE VARIANT ID) TO FAKE TAG_VARIANT_ID
+  const id = request.data.TAG_VARIANT_ID;
+
+  const columns = getColumns(id, label);
+  const rows = request.data.variant.gwasCredibleSets;
+
+  return (
+    <SectionItem
+      definition={definition}
+      entity={entity}
+      request={request}
+      renderDescription={() => <Description variantId={id} />}
+      renderBody={() => (
+        <DataTable
+          dataDownloader
+          sortBy="pValue"
+          columns={columns}
+          rows={rows}
+          rowsPerPageOptions={defaultRowsPerPageOptions}
+        />
+      )}
+    />
+  );
+
+}
+
+export default Body;
+
+function mockQuery() {
+  return {
+    loading: false,
+    error: undefined,
+    data: JSON.parse(`
+{ 
+  "TAG_VARIANT_ID": "10_100315722_G_A",
+  "variant": {
+    "gwasCredibleSets": [
+        {
+            "variantId": "2_8302417_G_A",
+            "study.id": "GTEx_brain_putamen_ENST00000668369",
+            "study.studyType": "eqtl",
+            "study.projectId": "GTEx",
+            "pValueMantissa": 2.359,
+            "pValueExponent": -8,
+            "beta": 0.694055,
+            "posteriorProbability": 0.0248072063095605,
+            "tissueFromSourceId": "UBERON_0001874",
+            "target.id": "ENSG00000236790",
+            "target.approvedSymbol": "LINC00299",
+            "finemappingMethod": "SuSie",
+            "locus": [
+              {
+                "variantId": "2_8300216_T_C",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300315_CACCA_C",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300442_G_A",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300228_C_A",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300184_A_G",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300257_G_A",
+                "posteriorProbability": 0.0711130529884503,
+                "pValueMantissa": 1.124,
+                "pValueExponent": -8,
+                "logBF": 17.6040572828625,
+                "beta": 0.642905,
+                "standardError": 0.106521,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302118_G_A",
+                "posteriorProbability": 0.0709443341781754,
+                "pValueMantissa": 7.823,
+                "pValueExponent": -9,
+                "logBF": 17.599567286068,
+                "beta": 0.710524,
+                "standardError": 0.116336,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8303673_G_A",
+                "posteriorProbability": 0.0709443341781754,
+                "pValueMantissa": 7.823,
+                "pValueExponent": -9,
+                "logBF": 17.599567286068,
+                "beta": 0.710524,
+                "standardError": 0.116336,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301605_C_G",
+                "posteriorProbability": 0.05493800379884,
+                "pValueMantissa": 1.013,
+                "pValueExponent": -8,
+                "logBF": 17.3380989257068,
+                "beta": 0.707031,
+                "standardError": 0.116746,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301354_T_C",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8299775_T_C",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301617_G_C",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301238_AG_A",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301922_G_A",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8300902_T_A",
+                "posteriorProbability": 0.0416366528677439,
+                "pValueMantissa": 1.981,
+                "pValueExponent": -8,
+                "logBF": 17.0559753546737,
+                "beta": 0.627503,
+                "standardError": 0.105964,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8299499_G_A",
+                "posteriorProbability": 0.0408672957421271,
+                "pValueMantissa": 1.9,
+                "pValueExponent": -8,
+                "logBF": 17.0362580958606,
+                "beta": 0.617058,
+                "standardError": 0.104052,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302417_G_A",
+                "posteriorProbability": 0.0248072063095605,
+                "pValueMantissa": 2.359,
+                "pValueExponent": -8,
+                "logBF": 16.5117080110389,
+                "beta": 0.694055,
+                "standardError": 0.117906,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301854_G_C",
+                "posteriorProbability": 0.0227548621765494,
+                "pValueMantissa": 3.6,
+                "pValueExponent": -8,
+                "logBF": 16.425230102072,
+                "beta": 0.62834,
+                "standardError": 0.108323,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8299556_T_A",
+                "posteriorProbability": 0.0186121956658267,
+                "pValueMantissa": 4.056,
+                "pValueExponent": -8,
+                "logBF": 16.2116375202122,
+                "beta": 0.614712,
+                "standardError": 0.106421,
+                "is95CredibleSet": false,
+                "is99CredibleSet": true
+              }
+            ]
+          },
+          {
+            "variantId": "2_8302417_G_A",
+            "study.id": "GTEx_blood_ENST00000668369",
+            "study.studyType": "eqtl",
+            "study.projectId": "GTEx",
+            "pValueMantissa": 1.316,
+            "pValueExponent": -13,
+            "beta": 0.437502,
+            "posteriorProbability": 0.206320522430541,
+            "tissueFromSourceId": "UBERON_0000178",
+            "target.id": "ENSG00000236790",
+            "target.approvedSymbol": "LINC00299",
+            "finemappingMethod": "SuSie",
+            "locus": [
+              {
+                "variantId": "2_8303673_G_A",
+                "posteriorProbability": 0.437585247168172,
+                "pValueMantissa": 6.226,
+                "pValueExponent": -14,
+                "logBF": 27.5844258581983,
+                "beta": 0.441853,
+                "standardError": 0.0576047,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302118_G_A",
+                "posteriorProbability": 0.268767540614083,
+                "pValueMantissa": 1.0,
+                "pValueExponent": -13,
+                "logBF": 27.0953274288198,
+                "beta": 0.439394,
+                "standardError": 0.0577853,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302417_G_A",
+                "posteriorProbability": 0.206320522430541,
+                "pValueMantissa": 1.316,
+                "pValueExponent": -13,
+                "logBF": 26.8295969712965,
+                "beta": 0.437502,
+                "standardError": 0.0578308,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301605_C_G",
+                "posteriorProbability": 0.0660264004283134,
+                "pValueMantissa": 4.28,
+                "pValueExponent": -13,
+                "logBF": 25.678130696286,
+                "beta": 0.427533,
+                "standardError": 0.0577982,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              }
+            ]
+          },
+          {
+            "variantId": "2_8302417_G_A",
+            "study.id": "OneK1K_NK_ENSG00000236790",
+            "study.studyType": "eqtl",
+            "study.projectId": "OneK1K",
+            "pValueMantissa": 2.615,
+            "pValueExponent": -9,
+            "beta": -0.234293,
+            "posteriorProbability": 0.00675924439887354,
+            "tissueFromSourceId": "CL_0000623",
+            "target.id": "ENSG00000236790",
+            "target.approvedSymbol": "LINC00299",
+            "finemappingMethod": "SuSie",
+            "locus": [
+              {
+                "variantId": "2_8317950_G_A",
+                "posteriorProbability": 0.274712436451997,
+                "pValueMantissa": 1.723,
+                "pValueExponent": -11,
+                "logBF": 17.2516206510268,
+                "beta": -0.271104,
+                "standardError": 0.0398152,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8319274_C_T",
+                "posteriorProbability": 0.274342370894736,
+                "pValueMantissa": 1.725,
+                "pValueExponent": -11,
+                "logBF": 17.2502726069861,
+                "beta": -0.271095,
+                "standardError": 0.0398149,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8328080_G_T",
+                "posteriorProbability": 0.14241675323407,
+                "pValueMantissa": 3.462,
+                "pValueExponent": -11,
+                "logBF": 16.5946293668575,
+                "beta": -0.271475,
+                "standardError": 0.0404998,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8318470_CAA_C",
+                "posteriorProbability": 0.0967445137874696,
+                "pValueMantissa": 6.97,
+                "pValueExponent": -11,
+                "logBF": 16.207924249784,
+                "beta": -0.269839,
+                "standardError": 0.0409132,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8318470_CAA_C",
+                "posteriorProbability": 0.0967445137874696,
+                "pValueMantissa": 6.97,
+                "pValueExponent": -11,
+                "logBF": 16.207924249784,
+                "beta": -0.269839,
+                "standardError": 0.0409132,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8318470_CAA_C",
+                "posteriorProbability": 0.0967445137874696,
+                "pValueMantissa": 6.97,
+                "pValueExponent": -11,
+                "logBF": 16.207924249784,
+                "beta": -0.269839,
+                "standardError": 0.0409132,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8321295_G_C",
+                "posteriorProbability": 0.0754513364335386,
+                "pValueMantissa": 1.076,
+                "pValueExponent": -10,
+                "logBF": 15.9593114306933,
+                "beta": -0.265941,
+                "standardError": 0.0407396,
+                "is95CredibleSet": false,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8326356_C_G",
+                "posteriorProbability": 0.0231288588741211,
+                "pValueMantissa": 5.806,
+                "pValueExponent": -10,
+                "logBF": 14.7767588466438,
+                "beta": -0.250459,
+                "standardError": 0.0400143,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8330530_G_A",
+                "posteriorProbability": 0.020413996505835,
+                "pValueMantissa": 3.317,
+                "pValueExponent": -10,
+                "logBF": 14.6517634254716,
+                "beta": -0.268473,
+                "standardError": 0.0422823,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8321272_G_A",
+                "posteriorProbability": 0.014184311179504,
+                "pValueMantissa": 9.779,
+                "pValueExponent": -10,
+                "logBF": 14.2876759204919,
+                "beta": -0.249102,
+                "standardError": 0.040346,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8302118_G_A",
+                "posteriorProbability": 0.00808799095217061,
+                "pValueMantissa": 2.204,
+                "pValueExponent": -9,
+                "logBF": 13.7255582849134,
+                "beta": -0.235415,
+                "standardError": 0.0389802,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8301605_C_G",
+                "posteriorProbability": 0.00744683074699681,
+                "pValueMantissa": 2.429,
+                "pValueExponent": -9,
+                "logBF": 13.6429102465236,
+                "beta": -0.234261,
+                "standardError": 0.0388939,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8302417_G_A",
+                "posteriorProbability": 0.00675924439887354,
+                "pValueMantissa": 2.615,
+                "pValueExponent": -9,
+                "logBF": 13.5459654738097,
+                "beta": -0.234293,
+                "standardError": 0.0389794,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8303673_G_A",
+                "posteriorProbability": 0.00629822953336312,
+                "pValueMantissa": 2.714,
+                "pValueExponent": -9,
+                "logBF": 13.4752592670769,
+                "beta": -0.233958,
+                "standardError": 0.0389641,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              },
+              {
+                "variantId": "2_8331189_G_A",
+                "posteriorProbability": 0.0060003978172174,
+                "pValueMantissa": 1.219,
+                "pValueExponent": -9,
+                "logBF": 13.4266225989143,
+                "beta": -0.260677,
+                "standardError": 0.0424708,
+                "is95CredibleSet": false,
+                "is99CredibleSet": false
+              }
+            ]
+          },
+          {
+            "variantId": "2_8302417_G_A",
+            "study.id": "GTEx_brain_hippocampus_ENST00000668369",
+            "study.studyType": "eqtl",
+            "study.projectId": "GTEx",
+            "pValueMantissa": 1.538,
+            "pValueExponent": -12,
+            "beta": 0.835806,
+            "posteriorProbability": 0.165901511700505,
+            "tissueFromSourceId": "UBERON_0001954",
+            "target.id": "ENSG00000236790",
+            "target.approvedSymbol": "LINC00299",
+            "finemappingMethod": "SuSie",
+            "locus": [
+              {
+                "variantId": "2_8311368_A_G",
+                "posteriorProbability": 0.456618152566933,
+                "pValueMantissa": 5.857,
+                "pValueExponent": -13,
+                "logBF": 31.9502944290118,
+                "beta": 0.851218,
+                "standardError": 0.107896,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301605_C_G",
+                "posteriorProbability": 0.179810930741611,
+                "pValueMantissa": 1.414,
+                "pValueExponent": -12,
+                "logBF": 31.0181593663888,
+                "beta": 0.839676,
+                "standardError": 0.108583,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302417_G_A",
+                "posteriorProbability": 0.165901511700505,
+                "pValueMantissa": 1.538,
+                "pValueExponent": -12,
+                "logBF": 30.9376219772967,
+                "beta": 0.835806,
+                "standardError": 0.108293,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302118_G_A",
+                "posteriorProbability": 0.165901511700505,
+                "pValueMantissa": 1.538,
+                "pValueExponent": -12,
+                "logBF": 30.9376219772967,
+                "beta": 0.835806,
+                "standardError": 0.108293,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              }
+            ]
+          },
+          {
+            "variantId": "2_8302417_G_A",
+            "study.id": "OneK1K_NK_ENSG00000235665",
+            "study.studyType": "eqtl",
+            "study.projectId": "OneK1K",
+            "pValueMantissa": 5.725,
+            "pValueExponent": -9,
+            "beta": -0.271797,
+            "posteriorProbability": 0.192983930988765,
+            "tissueFromSourceId": "CL_0000623",
+            "target.id": "ENSG00000235665",
+            "target.approvedSymbol": "LINC00298",
+            "finemappingMethod": "SuSie",
+            "locus": [
+              {
+                "variantId": "2_8302417_G_A",
+                "posteriorProbability": 0.192983930988765,
+                "pValueMantissa": 5.725,
+                "pValueExponent": -9,
+                "logBF": 15.2241703106444,
+                "beta": -0.271797,
+                "standardError": 0.0462429,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8302118_G_A",
+                "posteriorProbability": 0.192530791669411,
+                "pValueMantissa": 5.737,
+                "pValueExponent": -9,
+                "logBF": 15.2218194819916,
+                "beta": -0.271833,
+                "standardError": 0.0462518,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8303673_G_A",
+                "posteriorProbability": 0.186583542163576,
+                "pValueMantissa": 5.929,
+                "pValueExponent": -9,
+                "logBF": 15.1904424703745,
+                "beta": -0.271412,
+                "standardError": 0.0462246,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8301605_C_G",
+                "posteriorProbability": 0.158092245682673,
+                "pValueMantissa": 7.051,
+                "pValueExponent": -9,
+                "logBF": 15.0247420804285,
+                "beta": -0.269625,
+                "standardError": 0.0461546,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8298563_C_T",
+                "posteriorProbability": 0.0814314934103171,
+                "pValueMantissa": 1.409,
+                "pValueExponent": -8,
+                "logBF": 14.3613254794471,
+                "beta": -0.2654,
+                "standardError": 0.0463882,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8309993_A_G",
+                "posteriorProbability": 0.0640584295744518,
+                "pValueMantissa": 1.814,
+                "pValueExponent": -8,
+                "logBF": 14.1213590132954,
+                "beta": -0.263233,
+                "standardError": 0.0463698,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8311368_A_G",
+                "posteriorProbability": 0.0417204122512237,
+                "pValueMantissa": 2.839,
+                "pValueExponent": -8,
+                "logBF": 13.6925538957963,
+                "beta": -0.25805,
+                "standardError": 0.0461046,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8311571_T_C",
+                "posteriorProbability": 0.0225973287224273,
+                "pValueMantissa": 5.392,
+                "pValueExponent": -8,
+                "logBF": 13.0793950855009,
+                "beta": -0.258396,
+                "standardError": 0.0471427,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              },
+              {
+                "variantId": "2_8319274_C_T",
+                "posteriorProbability": 0.0160322428284877,
+                "pValueMantissa": 7.748,
+                "pValueExponent": -8,
+                "logBF": 12.7361652556066,
+                "beta": -0.257731,
+                "standardError": 0.0475987,
+                "is95CredibleSet": true,
+                "is99CredibleSet": true
+              }
+            ]
+          }
+    ]
+}
+}`),
+};
+}

--- a/packages/sections/src/variant/QTLCredibleSets/Description.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Description.tsx
@@ -1,0 +1,18 @@
+import { Link } from "ui";
+
+type DescriptionProps = {
+  variantId: string;
+};
+
+function Description({ variantId }: DescriptionProps) {
+  return (
+    <>
+      QTL 99% credible sets containing <strong>{variantId}</strong>. Source{" "}
+      <Link to="../" >
+        Open Targets
+      </Link>
+    </>
+  );
+}
+
+export default Description;

--- a/packages/sections/src/variant/QTLCredibleSets/Summary.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Summary.tsx
@@ -1,0 +1,31 @@
+import { SummaryItem, usePlatformApi } from "ui";
+
+import { definition } from ".";
+
+function Summary() {
+
+  // !! USE PLACEHOLDER REQUEST FOR NOW !!
+  // const request = usePlatformApi(UNIPROT_VARIANTS_SUMMARY);
+  const request = {
+    loading: false,
+    error: undefined,
+    data: true,  // data is not actually used by summary - only cares if there is data
+  };
+
+  return (
+    <SummaryItem
+      definition={definition}
+      request={request}
+      renderSummary={() => {}}  // !! renderSummary PROP NOT USED ANYMORE ANYWAY?
+      subText=""
+      // subText={dataTypesMapTyped.genetic_association}
+    />
+  );
+}
+
+// !!!!!!!!!!!!!
+// Summary.fragments = {
+//   ?????????????
+// };
+
+export default Summary;

--- a/packages/sections/src/variant/QTLCredibleSets/index.ts
+++ b/packages/sections/src/variant/QTLCredibleSets/index.ts
@@ -1,0 +1,14 @@
+// !!!!!!!!!!
+// ADD POSSIBILITY FOR PRIVATE SECTIONS IN PARTNER PAGE
+// !!!!!!!!!!
+// import { isPrivateVariantSection } from "../../utils/partnerPreviewUtils";
+
+// !! NEED TO TYPE WHATEVER PASSED INTO HASDATA - SEE SUMMARY
+const id = "qtl_credible_sets";
+export const definition = {
+  id,
+  name: "QTL Credible Sets",
+  shortName: "QT",
+  hasData: () => true,   // !! CHANGE WHEN USE GQL !!
+  isPrivate: false,   // isPrivateVariantSection(id),
+};


### PR DESCRIPTION

## Description

Add QTL credible sets widget to variant page.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked in dev environment.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
