### PR TITLE
[Platform] Add Uniprot id to Uniprot description link

### DIFF
--- a/packages/sections/src/variant/UniProtVariants/Description.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Description.tsx
@@ -7,11 +7,12 @@ type DescriptionProps = {
 };
 
 function Description({ variantId, data }: DescriptionProps) {
+  const { targetFromSourceId } = data.variant.uniProtVariants[0];
   return (
     <>
       Literature-based curation associating <strong>{variantId}</strong>{" "} to a disease/phenotype. Source:{" "}
-      <Link external to={identifiersOrgLink("uniprot", data.variant.uniProtVariants[0].targetFromSourceId)}>
-        UniProt
+      <Link external to={identifiersOrgLink("uniprot", targetFromSourceId)}>
+        UniProt ({targetFromSourceId})
       </Link>
     </>
   );


### PR DESCRIPTION

## Description

Add Uniprot id to Uniprot description link.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)

## Type of change

Please delete options that are not relevant.

## How Has This Been Tested?

Tested link in dev.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
