### PR TITLE
[Platform]: Optional chaining added to known drugs column

### DIFF
--- a/packages/sections/src/disease/Phenotypes/Body.jsx
+++ b/packages/sections/src/disease/Phenotypes/Body.jsx
@@ -41,7 +41,7 @@ const columns = [
       } else if (phenotypeHPO && phenotypeHPO.name) content = phenotypeHPO.name;
       else content = naLabel;
 
-      return phenotypeHPO.description ? (
+      return phenotypeHPO?.description ? (
         <Tooltip title={`Description: ${phenotypeHPO.description}`} showHelpIcon>
           {content}
         </Tooltip>
@@ -57,7 +57,7 @@ const columns = [
     id: "phenotypeHDOid",
     label: "Phenotype ID",
     renderCell: ({ phenotypeHPO }) => {
-      const id = phenotypeHPO.id.replace("_", ":");
+      const id = phenotypeHPO?.id.replace("_", ":");
       return (
         <Link external to={`https://identifiers.org/ols/${id}`}>
           {id}


### PR DESCRIPTION
# [Platform]: Optional chaining added to known drugs column

## Description

Optional chaining added to known drugs column to avoid widget crashing when data/required data is not there.

**Issue:** # (link)
**Deploy preview:** https://deploy-preview-402--ot-platform.netlify.app/disease/MONDO_0010831

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [x] Test A: https://platform.opentargets.org/disease/MONDO_0010831 test known drugs section

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
