### PR TITLE
[Platform]: aotf crash on prioritisation url

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/hooks/useAssociationsData.js
+++ b/apps/platform/src/components/AssociationsToolkit/hooks/useAssociationsData.js
@@ -8,6 +8,7 @@ const INITIAL_ROW_COUNT = 30;
 
 const getEmptyRow = () => ({
   dataSources: {},
+  prioritisations: {},
   score: 0,
   disease: { id: v1() },
   target: { id: v1() },


### PR DESCRIPTION
# [Platform]: AotF crash on prioritisation url

## Description

Fix navigation to AotF when url `?table=prioritisations`

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Navigate to `/disease/MONDO_0001627/associations?table=prioritisations`

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
