### PR TITLE
[Platform]: remove aggregation filter from AotF

### DIFF
--- a/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociationsQuery.gql
+++ b/apps/platform/src/pages/DiseasePage/DiseaseAssociations/DiseaseAssociationsQuery.gql
@@ -4,7 +4,6 @@ query DiseaseAssociationsQuery(
   $size: Int!
   $filter: String
   $sortBy: String!
-  $aggregationFilters: [AggregationFilter!]
   $enableIndirect: Boolean!
   $datasources: [DatasourceSettingsInput!]
   $rowsFilter: [String!]
@@ -17,7 +16,6 @@ query DiseaseAssociationsQuery(
       page: { index: $index, size: $size }
       orderByScore: $sortBy
       BFilter: $filter
-      aggregationFilters: $aggregationFilters
       enableIndirect: $enableIndirect
       datasources: $datasources
       Bs: $rowsFilter

--- a/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociationsQuery.gql
+++ b/apps/platform/src/pages/TargetPage/TargetAssociations/TargetAssociationsQuery.gql
@@ -4,7 +4,6 @@ query TargetAssociationsQuery(
   $size: Int!
   $filter: String
   $sortBy: String!
-  $aggregationFilters: [AggregationFilter!]
   $enableIndirect: Boolean!
   $datasources: [DatasourceSettingsInput!]
   $rowsFilter: [String!]
@@ -17,7 +16,6 @@ query TargetAssociationsQuery(
       page: { index: $index, size: $size }
       orderByScore: $sortBy
       BFilter: $filter
-      aggregationFilters: $aggregationFilters
       enableIndirect: $enableIndirect
       datasources: $datasources
       Bs: $rowsFilter

--- a/packages/ui/src/components/Link.tsx
+++ b/packages/ui/src/components/Link.tsx
@@ -1,5 +1,4 @@
-import { ReactNode } from "react";
-import PropTypes from "prop-types";
+import { ReactElement, ReactNode } from "react";
 import classNames from "classnames";
 import { Link as RouterLink } from "react-router-dom";
 import { makeStyles } from "@mui/styles";
@@ -33,12 +32,32 @@ const useStyles = makeStyles(theme => ({
     "&:hover": {
       color: theme.palette.primary.light,
       "text-decoration-color": theme.palette.primary.light,
-    "-webkit-text-decoration-color": theme.palette.primary.light,
+      "-webkit-text-decoration-color": theme.palette.primary.light,
     },
     display: "flex",
     alignItems: "center",
   },
 }));
+
+type LinkProptypes = {
+  className?: string;
+  to: string;
+  onClick?: () => void | null;
+  external: boolean;
+  newTab?: boolean;
+  footer: boolean;
+  tooltip?: unknown;
+  children: ReactNode;
+  ariaLabel?: string;
+};
+
+const defaultProps = {
+  external: false,
+  footer: false,
+  tooltip: false,
+  to: "/",
+  children: <></>,
+};
 
 function Link({
   children,
@@ -50,17 +69,7 @@ function Link({
   tooltip,
   className,
   ariaLabel,
-}: {
-  className?: string;
-  to: string;
-  onClick?: () => void;
-  external: boolean;
-  newTab?: boolean;
-  footer: boolean;
-  tooltip?: unknown;
-  children: ReactNode;
-  ariaLabel?: string;
-}) {
+}: LinkProptypes = defaultProps): ReactElement {
   const classes = useStyles();
   const ariaLabelProp = ariaLabel ? { "aria-label": ariaLabel } : {};
   const newTabProps = newTab ? { target: "_blank", rel: "noopener noreferrer" } : {};
@@ -100,26 +109,5 @@ function Link({
     </RouterLink>
   );
 }
-
-Link.propTypes = {
-  /** Whether the link directs to an external site. */
-  external: PropTypes.bool,
-  /** Whether the link is used within the footer section. */
-  footer: PropTypes.bool,
-  /** Whether the link is used within a tooltip. */
-  tooltip: PropTypes.bool,
-  /** The handler to call on click. */
-  onClick: PropTypes.func,
-  /** The url to visit on clicking the link. */
-  to: PropTypes.string.isRequired,
-};
-
-Link.defaultProps = {
-  external: false,
-  footer: false,
-  tooltip: false,
-  onClick: null,
-  to: "/",
-};
 
 export default Link;


### PR DESCRIPTION
# [Platform]: remove aggregation filter from AotF

## Description

As AggregationFilter was removed from the API, it needs to be removed from the UI queries

**Issue:** https://github.com/opentargets/issues/issues/3360

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Check target associations
- Check disease associations

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
