### PR TITLE
[Platform]: Use long text for alleles in variant page metadata 

### DIFF
--- a/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
@@ -3,7 +3,8 @@ import {
   usePlatformApi,
   Field,
   ProfileHeader as BaseProfileHeader,
-  Link, 
+  Link,
+  LongText,
 } from "ui";
 import { Box, Typography } from "@mui/material";
 import { identifiersOrgLink } from "../../utils/global";
@@ -27,10 +28,10 @@ function ProfileHeader() {
           {data?.variant.chromosome}:{data?.variant.position}
         </Field>
         <Field loading={loading} title="Reference Allele">
-          {data?.variant.referenceAllele}
+          <AlleleContent allele={data?.variant.referenceAllele} />
         </Field>
         <Field loading={loading} title="Alternative Allele (effect allele)">
-          {data?.variant.alternateAllele}
+          <AlleleContent allele={data?.variant.alternateAllele} />
         </Field>
         <Typography variant="subtitle1" mt={1}>Variant Effect Predictor (VEP)</Typography>
         <Field loading={loading} title="Most severe consequence">
@@ -59,6 +60,22 @@ ProfileHeader.fragments = {
 };
 
 export default ProfileHeader;
+
+
+function AlleleContent({ allele }) {
+  return allele?.length >= 15
+    ? <LongText lineLimit={2}>
+        <span style={{ textWrap: "wrap", wordWrap: "break-word" }}>
+          {allele}
+        </span>
+      </LongText>
+    : <>
+        {allele}
+      </>
+}
+
+
+
 
 
 // =====================

--- a/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
@@ -6,7 +6,7 @@ import {
   Link,
   LongText,
 } from "ui";
-import { Box, Typography } from "@mui/material";
+import { Box, Typography, Skeleton } from "@mui/material";
 import { identifiersOrgLink } from "../../utils/global";
 
 import VARIANT_PROFILE_HEADER_FRAGMENT from "./ProfileHeader.gql";
@@ -27,12 +27,16 @@ function ProfileHeader() {
         <Field loading={loading} title="GRCh38">
           {data?.variant.chromosome}:{data?.variant.position}
         </Field>
-        <Field loading={loading} title="Reference Allele">
-          <AlleleContent allele={data?.variant.referenceAllele} />
-        </Field>
-        <Field loading={loading} title="Alternative Allele (effect allele)">
-          <AlleleContent allele={data?.variant.alternateAllele} />
-        </Field>
+        <Allele
+          loading={loading}
+          label="Reference Allele"
+          value={data?.variant.referenceAllele}
+        />
+        <Allele
+          loading={loading}
+          label="Alternative Allele (effect allele)"
+          value={data?.variant.alternateAllele}
+        />
         <Typography variant="subtitle1" mt={1}>Variant Effect Predictor (VEP)</Typography>
         <Field loading={loading} title="Most severe consequence">
           <Link
@@ -62,20 +66,34 @@ ProfileHeader.fragments = {
 export default ProfileHeader;
 
 
-function AlleleContent({ allele }) {
-  return allele?.length >= 15
-    ? <LongText lineLimit={2}>
-        <span style={{ textWrap: "wrap", wordWrap: "break-word" }}>
-          {allele}
-        </span>
-      </LongText>
-    : <>
-        {allele}
+// ======
+// allele
+// ======
+
+type AlleleProps = {
+  loading: boolean;
+  label: string;
+  value: string;
+};
+
+function Allele({ loading, label, value }: AlleleProps) {
+  
+  if (loading) return <Skeleton />;
+  
+  return value?.length >= 15
+    ? <>
+        <Typography variant="subtitle2">{label}</Typography>
+        <LongText lineLimit={2} variant="body2">
+          <span style={{ textWrap: "wrap", wordWrap: "break-word" }}>
+            {value}
+          </span>
+        </LongText>
       </>
+    : <Field loading={loading} title={label}>
+        {value}
+      </Field>
+
 }
-
-
-
 
 
 // =====================


### PR DESCRIPTION
## Description

When alleles are long, use long text in variant page metadata.

**Issue:** [#3390](https://github.com/opentargets/issues/issues/3390)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev with e.g.:

- short alleles: 19_10112623_C_T
- long reference allele: OTVAR_12_54283979_209e9d0553810834370f743a4f1f554d

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
