### PR TITLE
[Platform]: Display long variant ID appropriately in variant page header

### DIFF
--- a/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
+++ b/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
@@ -1,0 +1,124 @@
+import { useState } from "react";
+import { Box, Button, Popover, Typography } from "@mui/material";
+
+function DisplayVariantId({ variantId, referenceAllele, alternateAllele, maxChars = 3 }) {
+
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleClick = (event) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const id = open ? 'popover' : undefined;
+
+  const stem = variantId.split('_').slice(0, -2).join('_');
+  const longReferenceAllele = referenceAllele.length > maxChars;
+  const longAlternateAllele = alternateAllele.length > maxChars;
+  const fullName = `${stem}_${referenceAllele}_${alternateAllele}`;
+
+  if (longReferenceAllele || longAlternateAllele) {
+    return (
+      <div>
+        <Box
+          aria-describedby={id}
+          onClick={handleClick}
+          sx={{
+            cursor: "pointer",
+            // outline: "2px solid",
+            "&:hover": {
+              // outlineColor: "red"
+              // background: "pink"
+            }
+          }}
+        >
+          {stem}
+          _
+          {longReferenceAllele
+            ? <HighlightBox>...</HighlightBox>  // or use DEL
+            : referenceAllele
+          }
+          _
+          {longAlternateAllele
+            ? <HighlightBox>...</HighlightBox>  // or use INS
+            : alternateAllele
+          }
+        </Box>
+        <Popover
+          id={id}
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: 'bottom',
+            horizontal: 'left',
+          }}
+          // marginThreshold={32}
+          slotProps={{
+            paper: {
+              sx: {
+                padding: 1,
+              }
+            }
+          }}  
+        >
+          <Typography
+            variant="body2"
+            sx={{
+              textWrap: "wrap",
+              wordWrap: "break-word",
+            }}
+          >
+            {fullName}
+          </Typography>
+          <Button sx={{mt: "1em", float: "right"}}>
+            Copy icon
+          </Button>
+        </Popover>
+      </div>
+    );
+  }
+
+  return fullName;
+
+}
+
+function HighlightBox({ children }) {
+  return (
+    <Box
+      display="inline-block"
+      border="1px solid"
+      borderRadius={5}
+      mx={0.5}
+      px={0.5}
+      bgcolor="#3489ca22"  // HARDCODED! - and may want faint of current color
+    >
+      {children}
+    </Box>
+  );
+}
+
+export default DisplayVariantId;
+
+// TODO:
+// - when hover on name, highlight the div - maybe with outline and offset to avoid space
+//   differences to when no hover or other entities, but not currently working?! - because
+//   parent cutting it off?
+//   - will need to make space in the header component itself - keep appearance change to a min
+// - copy button
+//   - use copy icon
+//   - add functinality! - see copy from data-downalaods schema or from AOTF export
+//     - create e.g. package/ui/utiil - create a helpers file with a copy function
+//            and snackbar component ideally
+//   - indicate that copied to clipboard after click?
+// - ensure works anywhere use variant name
+// - larger space to sides of box when wide - but using marginThreshold does not work?
+// - test with variant names of different sizes
+// - what set maxChars to?
+// - add a type for the props
+// - add space between name and popover
+// - does popover need a close button?

--- a/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
+++ b/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
@@ -24,19 +24,20 @@ type DisplayVariantIdProps = {
 };
 
 function DisplayVariantId({
-    variantId,
-    referenceAllele,
-    alternateAllele,
-    maxChars = 6}: DisplayVariantIdProps) {
+      variantId: otVariantId,
+      referenceAllele,
+      alternateAllele,
+      maxChars = 6
+    }: DisplayVariantIdProps) {
 
   const [open, setOpen] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
-  const handleClick = () => {
+  function handleClick() {
     setOpen(true);
   };
 
-  const handleClose = () => {
+  function handleClose() {
     setOpen(false);
   };
 
@@ -49,21 +50,32 @@ function DisplayVariantId({
     navigator.clipboard.writeText(text);
   }
 
-  const stem = variantId.split('_').slice(0, -1).join('_');
+  const idParts = otVariantId.split('_');
+  let isHashed, stem, fullVariantId;
+  if (idParts.at(-2) === referenceAllele &&
+      idParts.at(-1) === alternateAllele) {
+    isHashed = false;
+    stem = idParts.slice(0, -2).join('_');
+    fullVariantId = otVariantId;
+  } else {
+    isHashed = true;
+    stem = idParts.slice(0, -1).join('_');
+    fullVariantId = `${stem}_${referenceAllele}_${alternateAllele}`;
+  }
+
   const longReferenceAllele = referenceAllele.length > maxChars;
   const longAlternateAllele = alternateAllele.length > maxChars;
-  const fullVariantId = `${stem}_${referenceAllele}_${alternateAllele}`;
 
-  if (longReferenceAllele || longAlternateAllele) {
+  if (isHashed || longReferenceAllele || longAlternateAllele) {
     return (
-      <div>
+      <>
         <Box
           onClick={handleClick}
-          title="Show full variant ID"
+          title="Show variant ID"
           sx={{
             cursor: "pointer",
-            padding: "2px 6px",
-            borderRadius: "10px",
+            padding: "0 2px",
+            borderRadius: "8px",
             "&:hover": {
               background: highlightBackground,
             }
@@ -90,7 +102,7 @@ function DisplayVariantId({
           maxWidth="md"
         >
           <DialogTitle id="dialog-title">
-            <Typography variant="h6">
+            <Typography variant="h6" component="span">
               Variant ID
             </Typography>
             <IconButton
@@ -110,14 +122,16 @@ function DisplayVariantId({
             dividers={true}
             sx={{ padding: "0 1.5em 3em" }}
           >
+            { isHashed &&
+                <CopyPanel
+                  label="Hashed Variant ID"
+                  tooltipText="Variant ID used in Open Targets data."
+                  text={otVariantId}
+                  copyToClipboard={copyToClipboard}
+                />
+            }
             <CopyPanel
-              heading="Hashed Variant ID"
-              tooltipText="The variant ID used in Open Targets data."
-              text={variantId}
-              copyToClipboard={copyToClipboard}
-            />
-            <CopyPanel
-              heading="Full Variant ID"
+              label="Full Variant ID"
               text={fullVariantId}
               copyToClipboard={copyToClipboard}
             />
@@ -129,7 +143,7 @@ function DisplayVariantId({
           message="Copied to clipboard"
           autoHideDuration={3000}
         />
-      </div>
+      </>
     );
   }
 
@@ -151,15 +165,22 @@ function HighlightBox({ children }) {
   );
 }
 
-function CopyPanel({ heading, text, tooltipText, copyToClipboard }) {
+type CopyPanelProps = {
+  label: string;
+  text: string;
+  tooltipText?: string;
+  copyToClipboard: (text: string) => void;
+};
+
+function CopyPanel({ label, text, tooltipText, copyToClipboard }: CopyPanelProps) {
   return (
     <Box mt={2}>
       {
         tooltipText
           ? <Tooltip title={tooltipText} showHelpIcon>
-              <Typography variant="subtitle1" component="span">{heading}</Typography>
+              <Typography variant="subtitle1" component="span">{label}</Typography>
             </Tooltip>
-          : <Typography variant="subtitle1">{heading}</Typography>
+          : <Typography variant="subtitle1">{label}</Typography>
       }
       <Box sx={{
           marginTop: '0.1em',

--- a/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
+++ b/apps/platform/src/pages/VariantPage/DisplayVariantId.tsx
@@ -1,5 +1,13 @@
 import { useState } from "react";
-import { Box, Popover, Typography, IconButton, Snackbar } from "@mui/material";
+import {
+  Box,
+  Typography,
+  IconButton,
+  Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+} from "@mui/material";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faXmark } from "@fortawesome/free-solid-svg-icons";
 import { faClipboard } from "@fortawesome/free-regular-svg-icons";
@@ -9,47 +17,47 @@ import { lighten } from "polished";
 const highlightBackground = theme => lighten(0.4, theme.palette.primary.main);
 
 type DisplayVariantIdProps = {
-  variandId: string;
+  variantId: string;
   referenceAllele: string;
   alternateAllele: string;
   maxChars?: number;
 };
 
-function DisplayVariantId({ variantId, referenceAllele, alternateAllele, maxChars = 5 }) {
+function DisplayVariantId({
+    variantId,
+    referenceAllele,
+    alternateAllele,
+    maxChars = 6}: DisplayVariantIdProps) {
 
-  const [anchorEl, setAnchorEl] = useState(null);
+  const [open, setOpen] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
 
-  const handleClick = (event) => {
-    setAnchorEl(event.currentTarget);
+  const handleClick = () => {
+    setOpen(true);
   };
 
   const handleClose = () => {
-    setAnchorEl(null);
+    setOpen(false);
   };
 
   function handleCloseSnackbar() {
     setSnackbarOpen(false);
   }
 
-  function copyToClipboard() {
+  function copyToClipboard(text: string) {
     setSnackbarOpen(true);
-    navigator.clipboard.writeText(fullName);
+    navigator.clipboard.writeText(text);
   }
-
-  const open = Boolean(anchorEl);
-  const id = open ? 'popover' : undefined;
 
   const stem = variantId.split('_').slice(0, -1).join('_');
   const longReferenceAllele = referenceAllele.length > maxChars;
   const longAlternateAllele = alternateAllele.length > maxChars;
-  const fullName = `${stem}_${referenceAllele}_${alternateAllele}`;
+  const fullVariantId = `${stem}_${referenceAllele}_${alternateAllele}`;
 
   if (longReferenceAllele || longAlternateAllele) {
     return (
       <div>
         <Box
-          aria-describedby={id}
           onClick={handleClick}
           title="Show full variant ID"
           sx={{
@@ -73,32 +81,16 @@ function DisplayVariantId({ variantId, referenceAllele, alternateAllele, maxChar
             : alternateAllele
           }
         </Box>
-        <Popover
-          id={id}
+        <Dialog
           open={open}
-          anchorEl={anchorEl}
           onClose={handleClose}
-          anchorOrigin={{
-            vertical: 'bottom',
-            horizontal: 'left',
-          }}
-          slotProps={{
-            paper: {
-              sx: { position: "relative" }
-            }
-          }}  
+          scroll="paper"
+          aria-labelledby="dialog-title"
+          aria-describedby="dialog-description"
+          maxWidth="md"
         >
-          <Box
-            position="fixed"
-            width="100%"
-            // display="flex"
-            // left={0}
-            // right={0}
-            bgcolor="white"
-            sx={{borderBottom: "1px solid #ccc"}}
-            zIndex={2}
-          >
-            <Typography variant="h6" padding="1rem">
+          <DialogTitle id="dialog-title">
+            <Typography variant="h6">
               Variant ID
             </Typography>
             <IconButton
@@ -113,54 +105,35 @@ function DisplayVariantId({ variantId, referenceAllele, alternateAllele, maxChar
             >
               <FontAwesomeIcon icon={faXmark} />
             </IconButton>
-          </Box>
-          <Box p="5em 2em">
-            <Box 
-              sx={{
-                backgroundColor: theme => theme.palette.grey[300],
-                padding: "1em 3.5em 1em 1em",   
-                fontSize: "0.9em",
-                position: "relative"
-              }}
-            >
-              <Tooltip
-                title="Copy JSON to clipboard"
-              >
-                <IconButton
-                  onClick={copyToClipboard}
-                  sx={{
-                    position: "absolute !important",
-                    top: "0",
-                    right: "0",
-                    padding: "0.4em 0.5em !important",
-                  }}
-                >
-                  <FontAwesomeIcon icon={faClipboard} />
-                </IconButton>
-              </Tooltip>
-              <Typography
-                variant="body2"
-                sx={{
-                  textWrap: "wrap",
-                  wordWrap: "break-word",
-                }}
-              >
-                {fullName}
-              </Typography>
-            </Box>
-          </Box>
-        </Popover>
+          </DialogTitle>
+          <DialogContent
+            dividers={true}
+            sx={{ padding: "0 1.5em 3em" }}
+          >
+            <CopyPanel
+              heading="Hashed Variant ID"
+              tooltipText="The variant ID used in Open Targets data."
+              text={variantId}
+              copyToClipboard={copyToClipboard}
+            />
+            <CopyPanel
+              heading="Full Variant ID"
+              text={fullVariantId}
+              copyToClipboard={copyToClipboard}
+            />
+          </DialogContent>
+        </Dialog>
         <Snackbar
           open={snackbarOpen}
           onClose={handleCloseSnackbar}
-          message="Variant ID copied"
+          message="Copied to clipboard"
           autoHideDuration={3000}
         />
       </div>
     );
   }
 
-  return fullName;
+  return fullVariantId;
 
 }
 
@@ -174,6 +147,47 @@ function HighlightBox({ children }) {
       bgcolor={highlightBackground}
     >
       {children}
+    </Box>
+  );
+}
+
+function CopyPanel({ heading, text, tooltipText, copyToClipboard }) {
+  return (
+    <Box mt={2}>
+      {
+        tooltipText
+          ? <Tooltip title={tooltipText} showHelpIcon>
+              <Typography variant="subtitle1" component="span">{heading}</Typography>
+            </Tooltip>
+          : <Typography variant="subtitle1">{heading}</Typography>
+      }
+      <Box sx={{
+          marginTop: '0.1em',
+          backgroundColor: theme => theme.palette.grey[300],
+          position: "relative",
+        }}
+      >
+        <Box position="absolute" top={0} right={0}>
+          <Tooltip title="Copy to clipboard">
+            <IconButton
+              onClick={() => copyToClipboard(text)}
+              sx={{ padding: "0.4em 0.5em !important" }}
+            >
+              <FontAwesomeIcon icon={faClipboard} />
+            </IconButton>
+          </Tooltip>
+        </Box>
+        <Typography
+          variant="body2"
+          sx={{
+            padding: "1em 3.2em 1em 1em",   
+            textWrap: "wrap",
+            wordWrap: "break-word",
+          }}
+        >
+          {text}
+        </Typography>
+      </Box>
     </Box>
   );
 }

--- a/apps/platform/src/pages/VariantPage/Header.tsx
+++ b/apps/platform/src/pages/VariantPage/Header.tsx
@@ -1,6 +1,7 @@
 import { faMapPin } from "@fortawesome/free-solid-svg-icons";
 import { Header as HeaderBase, XRefLinks } from "ui";
 import { VariantPageDataType } from "./types";
+import DisplayVariantId from "./DisplayVariantId";
 
 const xrefsToDisplay = {
   ensembl_variation: {
@@ -61,7 +62,11 @@ function Header({ loading, variantId, variantPageData }: HeaderProps) {
   return (
     <HeaderBase
       loading={loading}
-      title={variantId}
+      title={<DisplayVariantId
+        variantId={variantId}
+        referenceAllele={variantPageData?.referenceAllele}
+        alternateAllele={variantPageData?.alternateAllele}
+      />}
       Icon={faMapPin}
       externalLinks={
         <>


### PR DESCRIPTION
## Description

For hashed ID, show shortened ID - when click on it, show both the hashed ID and the full ID.

If the ID is not hashed but still too long to show in the header, show shortened ID - when click it, show full ID.

Since full variant ID can be very long, implementation relies on a click event and a dialogue component (rather than a hover event and a popover).

**Issue:** [#3390](https://github.com/opentargets/issues/issues/3390)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev. Example variant IDs (from short to long):

- 19_10112623_C_T
- OTVAR_12_54283979_209e9d0553810834370f743a4f1f554d
- OTVAR_2_189001286_75a16febfb01d76c72337aa605d02e34

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
