### PR TITLE
[Platform]: Update VEP widget on variant page

### DIFF
--- a/packages/sections/src/variant/VariantEffectPredictor/Body.tsx
+++ b/packages/sections/src/variant/VariantEffectPredictor/Body.tsx
@@ -8,7 +8,7 @@ import { identifiersOrgLink } from "../../utils/global";
 import VARIANT_EFFECT_PREDICTOR_QUERY from "./VariantEffectPredictorQuery.gql";
 
 function formatVariantConsequenceLabel(label) {
-  return label.replace(/_/g, ' ');
+  return label.replace(/_/g, " ");
 }
 
 const columns = [
@@ -16,6 +16,7 @@ const columns = [
     id: "transcriptId",
     label: "Transcript",
     tooltip: "Ensembl canonical transcript",
+    comparator: (a, b) => a.transcriptIndex - b.transcriptIndex,
     renderCell: ({ transcriptId, target }) => {
       if (!transcriptId) return naLabel;
       if (!target) return transcriptId;
@@ -52,14 +53,13 @@ const columns = [
     },
   },
   {
-    id: 'impact',
-    label: 'Impact',
+    id: "impact",
+    label: "Impact",
     renderCell: ({ impact }) => impact?.toLowerCase?.() ?? naLabel,
   },
-  { // !!!!! UPDATE ONCE IN API
+  {
     id: "consequenceScore",
     label: "Consequence Score",
-    renderCell: () => "Not in API"
   },
   {
     id: "target.approvedName",
@@ -71,39 +71,22 @@ const columns = [
     ),
   },
   {
-    id: 'aminoAcidChange',
-    label: 'Amino acid change',
+    id: "aminoAcidChange",
+    label: "Amino acid change",
     renderCell: ({ aminoAcidChange }) => aminoAcidChange ?? naLabel,
   },
   {
-    id: 'codons',
-    label: 'Coding change',
+    id: "codons",
+    label: "Coding change",
     renderCell: ({ codons }) => codons ?? naLabel,
   },
-  {  // !!!!! UPDATE ONCE IN API - AND DIST SHOULD BE 0 IN DATA THEN INSTEAD OF NULL
-    id: "distance",
+  {
+    id: "distanceFromFootprint",
     label: "Distance from footprint",
-    renderCell: ({ distance }) => distance ?? 0,
   },
-  {  // !!!!! UPDATE ONCE IN API
+  {
     id: "distanceFromTss",
     label: "Distance from start site",
-    renderCell: () => "Not in API",
-  },
-  {
-    id: "lofteePrediction",
-    label: "Loftee prediction",
-    renderCell: ({ lofteePrediction }) => lofteePrediction ?? naLabel,
-  },
-  {
-    id: "siftPrediction",
-    label: "Sift prediction",
-    renderCell: ({ siftPrediction }) => siftPrediction ?? naLabel,
-  },
-  {
-    id: "polyphenPrediction",
-    label: "Polyphen prediction",
-    renderCell: ({ polyphenPrediction }) => polyphenPrediction ?? naLabel,
   },
   {
     id: "uniprotAccession",
@@ -154,6 +137,7 @@ export function Body({ id, entity }: BodyProps) {
             rowsPerPageOptions={defaultRowsPerPageOptions}
             query={VARIANT_EFFECT_PREDICTOR_QUERY.loc.source.body}
             variables={variables}
+            sortBy="transcriptId"
           />
         );
       }}

--- a/packages/sections/src/variant/VariantEffectPredictor/VariantEffectPredictorQuery.gql
+++ b/packages/sections/src/variant/VariantEffectPredictor/VariantEffectPredictorQuery.gql
@@ -8,12 +8,15 @@ query VariantEffectPredictorQuery($variantId: String!) {
       aminoAcidChange
       uniprotAccessions
       codons
-      distance
+      distanceFromFootprint
+      distanceFromTss
       target {
         id
         approvedName
       }
       impact
+      consequenceScore
+      transcriptIndex
       transcriptId
       lofteePrediction
       siftPrediction


### PR DESCRIPTION
## Description

Update VEP widget to reflect API changes:

- sort on `transcriptIndex`
- add `consequenceScore` column
- remove predictors columns (since mostly `null`)
- replace old `distance` column with the 2 new distance columns

**Issue:** [#3386](https://github.com/opentargets/issues/issues/3386)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
