### PR TITLE
[Package]: migrate EllsWrapper component to TypeScript

### DIFF
--- a/packages/ui/src/components/EllsWrapper.tsx
+++ b/packages/ui/src/components/EllsWrapper.tsx
@@ -1,4 +1,5 @@
 import { makeStyles } from "@mui/styles";
+import { ReactElement } from "react";
 
 const useStyles = makeStyles(() => ({
   ellipseContainer: {
@@ -11,11 +12,16 @@ const useStyles = makeStyles(() => ({
   },
 }));
 
-function EllsWrapper({ children, title }) {
+type EllsWrapperProps = {
+  title?: string;
+  children?: ReactElement | string;
+};
+
+function EllsWrapper({ children, title }: EllsWrapperProps): ReactElement {
   const classes = useStyles();
 
   return (
-    <div className={classes.ellipseContainer} title={title || children}>
+    <div className={classes.ellipseContainer} title={title || (children as string)}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Description

Migrate the EllsWrapper component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Applications were built locally. Component was manually inspected in the UI.

![image](https://github.com/user-attachments/assets/4f18539c-5340-4be6-a069-5cffb0704be7)

## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
