### PR TITLE
[Package]: migrate ErrorBoundary component to TypeScript

### DIFF
--- a/apps/platform/src/pages/SearchPage/SearchContainer.jsx
+++ b/apps/platform/src/pages/SearchPage/SearchContainer.jsx
@@ -13,7 +13,7 @@ import {
   faDna,
   faMapPin,
   faPrescriptionBottleAlt,
-  faStethoscope
+  faStethoscope,
 } from "@fortawesome/free-solid-svg-icons";
 import { ErrorBoundary } from "ui";
 
@@ -25,6 +25,8 @@ import TargetDetail from "./TargetDetail";
 import TargetResult from "./TargetResult";
 import VariantDetail from "./VariantDetail";
 import VariantResult from "./VariantResult";
+
+import config from "../../config";
 
 const getCounts = entities => {
   const counts = {
@@ -71,7 +73,9 @@ const SearchFilters = ({ entities, entitiesCount, setEntity }) => {
       />
       <FormControlLabel
         className={classes.label}
-        control={<Checkbox checked={entities.includes("variant")} onChange={setEntity("variant")} />}
+        control={
+          <Checkbox checked={entities.includes("variant")} onChange={setEntity("variant")} />
+        }
         label={
           <>
             <FontAwesomeIcon icon={faMapPin} fixedWidth className={classes.labelIcon} />
@@ -158,7 +162,7 @@ function TopHitDetail({ topHit }) {
   else if (topHit[TYPE_NAME] === "Drug") COMPONENT = <DrugDetail data={topHit} />;
   return (
     <Card elevation={0}>
-      <ErrorBoundary>{COMPONENT}</ErrorBoundary>
+      <ErrorBoundary config={config}>{COMPONENT}</ErrorBoundary>
     </Card>
   );
 }

--- a/packages/sections/src/target/Expression/AtlasTab.jsx
+++ b/packages/sections/src/target/Expression/AtlasTab.jsx
@@ -1,6 +1,7 @@
 import { Suspense, lazy } from "react";
 import { Helmet } from "react-helmet";
 import { ErrorBoundary } from "ui";
+import config from "../../config";
 
 const ExpressionAtlasHeatmap = lazy(() =>
   import("@ebi-gene-expression-group/expression-atlas-heatmap-highcharts")
@@ -8,7 +9,10 @@ const ExpressionAtlasHeatmap = lazy(() =>
 
 function AtlasTab({ ensgId, symbol }) {
   return (
-    <ErrorBoundary message={`There was an error loading the Expression Atlas plugin for ${symbol}`}>
+    <ErrorBoundary
+      message={`There was an error loading the Expression Atlas plugin for ${symbol}`}
+      config={config}
+    >
       <Helmet
         link={[
           {

--- a/packages/ui/src/components/ErrorBoundary.tsx
+++ b/packages/ui/src/components/ErrorBoundary.tsx
@@ -1,27 +1,51 @@
-import { Component } from "react";
+import { Component, ReactNode } from "react";
 import { Typography } from "@mui/material";
 import Link from "./Link";
 
-const defaultConfig = {
+type ErrorBoundaryConfig = {
   profile: {
+    communityTicketUrl: string;
+    communityUrl: string;
+    isPartnerPreview: boolean;
+    helpdeskEmail?: string;
+  };
+};
+
+type ErrorBoundaryProps = {
+  children: ReactNode;
+  config: ErrorBoundaryConfig;
+  message?: string;
+};
+
+type ErrorBoundaryState = {
+  hasError: boolean;
+};
+
+const defaultConfig: ErrorBoundaryConfig = {
+  profile: {
+    communityTicketUrl: "",
     communityUrl: "",
     isPartnerPreview: false,
   },
 };
 
-class ErrorBoundary extends Component {
-  constructor(props) {
+class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  static readonly defaultProps = {
+    config: defaultConfig,
+  };
+
+  constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = {
       hasError: false,
     };
   }
 
-  static getDerivedStateFromError() {
+  static getDerivedStateFromError(): ErrorBoundaryState {
     return { hasError: true };
   }
 
-  render() {
+  render(): ReactNode {
     const { children, config } = this.props;
     const { isPartnerPreview } = config.profile;
     const { hasError } = this.state;
@@ -31,7 +55,7 @@ class ErrorBoundary extends Component {
         // PPP error message
         <div>
           Something went wrong. Please contact Open Targets at{" "}
-          <Link to={`mailto: ${config.profile.helpdeskEmail}`} external>
+          <Link to={`mailto: ${config.profile.helpdeskEmail}`} external footer={false}>
             {config.profile.helpdeskEmail}
           </Link>
         </div>
@@ -39,7 +63,7 @@ class ErrorBoundary extends Component {
         // public platform error message
         <div>
           Something went wrong. Please{" "}
-          <Link to={config.profile.communityTicketUrl} external>
+          <Link to={config.profile.communityTicketUrl} external footer={false}>
             submit a bug report
           </Link>{" "}
           on the Open Targets Community ({config.profile.communityUrl})
@@ -56,9 +80,5 @@ class ErrorBoundary extends Component {
     );
   }
 }
-
-ErrorBoundary.defaultProps = {
-  config: defaultConfig,
-};
 
 export default ErrorBoundary;

--- a/packages/ui/src/components/GlobalSearch/GlobalSearchDialog.jsx
+++ b/packages/ui/src/components/GlobalSearch/GlobalSearchDialog.jsx
@@ -8,6 +8,7 @@ import { SearchContext, SearchInputProvider } from "./SearchContext";
 import GlobalSearchInput from "./GlobalSearchInput";
 import GlobalSearchFreeListItem from "./GlobalSearchFreeListItem";
 import ErrorBoundary from "../ErrorBoundary";
+import config from "../../config";
 
 const EscButton = styled("button")(({ theme }) => ({
   display: "block",
@@ -49,7 +50,7 @@ function GlobalSearchDialog() {
         },
       }}
     >
-      <ErrorBoundary>
+      <ErrorBoundary config={config}>
         <SearchInputProvider setValue={setInputValue}>
           <DialogTitle>
             <Box sx={{ display: "flex", alignItems: "center" }}>


### PR DESCRIPTION
## Description

Migrate the ErrorBoundary component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Applications were built locally. Component was imported into `StudiesPage` from `ui` and manually inspected in the UI.

**Condition:** No error
![image](https://github.com/user-attachments/assets/fb0c38ae-9ede-489a-af9f-4fef83b75c3e)

**Condition:** With error, community view
![image](https://github.com/user-attachments/assets/dcace36f-414d-4449-8af0-6bc63da8ee9a)

**Condition:** With error, partner view
![image](https://github.com/user-attachments/assets/84215e94-cb7f-4715-a3de-24901a629463)

**Condition:** With error, dummy error message
![image](https://github.com/user-attachments/assets/fd2de2f2-3b53-4688-8f93-93df0fe230cc)

## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
