### PR TITLE
[Package]: migrate Highlights component to TypeScript

### DIFF
--- a/packages/ui/src/components/Highlights.tsx
+++ b/packages/ui/src/components/Highlights.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
-import { Typography } from "@mui/material";
+import { ReactNode, useState } from "react";
+import { Theme, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme: Theme) => ({
   showMore: {
     cursor: "pointer",
     color: theme.palette.primary.main,
@@ -12,7 +12,13 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function Highlights({ highlights }) {
+type HighlightItem = string | TrustedHTML;
+
+type HighlightsProps = {
+  highlights: HighlightItem[];
+};
+
+function Highlights({ highlights }: HighlightsProps): ReactNode {
   const classes = useStyles();
   const [showMore, setShowMore] = useState(false);
 


### PR DESCRIPTION
## Description

Migrate the Highlights component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Applications were built locally. Component was manually inspected in the UI.

![image](https://github.com/user-attachments/assets/c4565bb5-49f1-4d3f-b6f4-37388576eaa8)


## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
