### PR TITLE
[Platform]: Add QTL credible sets widget to study page

### DIFF
--- a/apps/platform/src/pages/StudyPage/Profile.tsx
+++ b/apps/platform/src/pages/StudyPage/Profile.tsx
@@ -1,34 +1,43 @@
+import { Suspense, lazy } from "react";
 import { gql } from "@apollo/client";
-import { PlatformApiProvider, SectionContainer, SummaryContainer, summaryUtils } from "ui";
+import {
+  PlatformApiProvider,
+  SectionContainer,
+  SummaryContainer,
+  SectionLoader,
+  summaryUtils,
+} from "ui";
+
+import QTLCredibleSetsSummary from "sections/src/study/QTLCredibleSets/Summary";
 
 import client from "../../client";
 import ProfileHeader from "./ProfileHeader";
 
-// const summaries = [
-// ];
+const QTLCredibleSetsSection = lazy(
+  () => import("sections/src/study/QTLCredibleSets/Body")
+);
 
-const STUDY = "study";
-// const STUDY_PROFILE_SUMMARY_FRAGMENT = summaryUtils.createSummaryFragment(summaries, "Gwas");
+const summaries = [
+  QTLCredibleSetsSummary,
+];
+
+const STUDY = "gwasStudy";
+const STUDY_PROFILE_SUMMARY_FRAGMENT = summaryUtils.createSummaryFragment(
+  summaries,
+  "Gwas",
+  "StudyProfileSummaryFragment"
+);
 const STUDY_PROFILE_QUERY = gql`
   query StudyProfileQuery($studyId: String!) {
     gwasStudy(studyId: $studyId) {
       studyId
       ...StudyProfileHeaderFragment
+      ...StudyProfileSummaryFragment
     }
   }
   ${ProfileHeader.fragments.profileHeader}
+  ${STUDY_PROFILE_SUMMARY_FRAGMENT}
 `;
-// const STUDY_PROFILE_QUERY = gql`
-//   query StudyProfileQuery($chemblId: String!) {
-//     gwasStudy(studyId: $studyId) {
-//       studyId
-//       ...StudyProfileHeaderFragment
-//       ...StudyProfileSummaryFragment
-//     }
-//   }
-//   ${ProfileHeader.fragments.profileHeader}
-//   ${STUDY_PROFILE_SUMMARY_FRAGMENT}
-// `;
 
 type ProfileProps = {
   studyId: string;
@@ -44,6 +53,21 @@ function Profile({ studyId, studyCategory }: ProfileProps) {
       client={client}
     >
       <ProfileHeader studyCategory={studyCategory} />
+
+      <SummaryContainer>
+        {studyCategory === "QTL" &&
+          <QTLCredibleSetsSummary /> 
+        }
+      </SummaryContainer>
+
+      <SectionContainer>
+        {studyCategory === "QTL" &&
+          <Suspense fallback={<SectionLoader />}>
+            <QTLCredibleSetsSection id={studyId} entity={STUDY} />
+          </Suspense>
+        }
+      </SectionContainer>
+
     </PlatformApiProvider>
   );
 }

--- a/apps/platform/src/pages/StudyPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/StudyPage/ProfileHeader.tsx
@@ -38,7 +38,7 @@ function ProfileHeader({ studyCategory }) {
     qualityControls,
     analysisFlags,
     discoverySamples,
-  } = data?.gwasStudy || {};
+  } = data?.gwasStudy?.[0] || {};
 
   return (
     <BaseProfileHeader>

--- a/apps/platform/src/pages/StudyPage/StudyPage.tsx
+++ b/apps/platform/src/pages/StudyPage/StudyPage.tsx
@@ -1,3 +1,4 @@
+
 import { Suspense } from "react";
 import { useQuery } from "@apollo/client";
 import { BasePage, ScrollToTop, LoadingBackdrop } from "ui";
@@ -25,12 +26,14 @@ function StudyPage() {
     variables: { studyId },
   });
 
-  if (data && !data.gwasStudy) {
+  const studyInfo = data?.gwasStudy?.[0];
+
+  if (data && !studyInfo) {
     return <NotFoundPage />;
   }
 
   // !!!!! CURRENTLY RESOLVE STUDY CATEGORY PURELY FROM PROJECT ID
-  const { projectId } = data?.gwasStudy || {};
+  const { projectId } = studyInfo || {};
   let studyCategory = '';
   if (projectId) {
     if (projectId === "GCST") studyCategory = "GWAS";
@@ -47,10 +50,10 @@ function StudyPage() {
       <Header 
         loading={loading}
         studyId={studyId}
-        traitFromSource={data?.gwasStudy?.traitFromSource}
-        backgroundTraits={data?.gwasStudy?.backgroundTraits}
-        targetId={data?.gwasStudy?.target?.id}
-        diseaseId={data?.gwasStudy?.diseases?.[0]?.id}
+        traitFromSource={studyInfo?.traitFromSource}
+        backgroundTraits={studyInfo?.backgroundTraits}
+        targetId={studyInfo?.target?.id}
+        diseaseId={studyInfo?.diseases?.[0]?.id}
         studyCategory={studyCategory}
       />
       <ScrollToTop />

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -1,0 +1,109 @@
+import { useQuery } from "@apollo/client";
+import {
+  Link,
+  SectionItem,
+  DataTable,
+  ScientificNotation,
+  DisplayVariantId
+} from "ui";
+import { naLabel, defaultRowsPerPageOptions } from "../../constants";
+import { definition } from ".";
+import Description from "./Description";
+import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
+
+const columns = [
+  {
+    id: "leadVariant",
+    label: "Lead Variant",
+    renderCell: ({ variant }) => {
+      if (!variant) return naLabel;
+      const { id: variantId, referenceAllele, alternateAllele } = variant;
+      return <Link to={`/variant/${variantId}`}>
+        <DisplayVariantId
+          variantId={variantId}
+          referenceAllele={referenceAllele}
+          alternateAllele={alternateAllele}
+          expand={false}
+        />
+      </Link>;
+    },
+    exportValue: ({ variant }) => variant?.id,
+  },
+  {
+    id: "pValue",
+    label: "P-Value",
+    comparator: (a, b) =>
+      a?.pValueMantissa * 10 ** a?.pValueExponent -
+        b?.pValueMantissa * 10 ** b?.pValueExponent,
+    sortable: true,
+    renderCell: ({ pValueMantissa, pValueExponent }) => {
+      if (typeof pValueMantissa !== "number" ||
+          typeof pValueExponent !== "number") return naLabel;
+      return <ScientificNotation number={[pValueMantissa, pValueExponent]} />;
+    },
+    exportValue: ({ pValueMantissa, pValueExponent }) => {
+      if (typeof pValueMantissa !== "number" ||
+          typeof pValueExponent !== "number") return null;
+      return `${pValueMantissa}x10${pValueExponent}`;
+    },
+  },
+  {
+    id: "beta",
+    label: "Beta",
+    tooltip: "Beta with respect to the ALT allele",
+    renderCell: ({ beta }) => {
+      if (typeof beta !== "number") return naLabel;
+      return beta.toPrecision(3);
+    },
+  },
+  {
+    id: "finemappingMethod",
+    label: "Finemapping Method",
+  },
+  {
+    id: "credibleSetSize",
+    label: "Credible Set Size",
+    comparator: (a, b) => a.locus?.length - b.locus?.length,
+    sortable: true,
+    renderCell: ({ locus }) => locus?.length ?? naLabel,
+    exportValue: ({ locus }) => locus?.length,
+  }
+];
+
+type BodyProps = {
+  id: string,
+  entity: string,
+};
+
+function Body({ id, entity }: BodyProps) {
+  const variables = {
+    studyId: id,
+  };
+
+  const request = useQuery(QTL_CREDIBLE_SETS_QUERY, {
+    variables,
+  });
+  
+  return (
+    <SectionItem
+      definition={definition}
+      entity={entity}
+      request={request}
+      renderDescription={({ gwasStudy }) => <Description studyId={gwasStudy[0].studyId} />}
+      renderBody={({ gwasStudy }) => (
+        <DataTable
+          dataDownloader
+          sortBy="pValue"
+          columns={columns}
+          rows={gwasStudy[0].credibleSets}
+          rowsPerPageOptions={defaultRowsPerPageOptions}
+          query={QTL_CREDIBLE_SETS_QUERY.loc.source.body}
+          variables={variables}
+        />
+      )}
+    />
+  );
+
+}
+
+export default Body;

--- a/packages/sections/src/study/QTLCredibleSets/Description.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Description.tsx
@@ -1,0 +1,19 @@
+import { Link } from "ui";
+
+type DescriptionProps = {
+  studyId: string;
+};
+
+function Description({ studyId }: DescriptionProps) {
+  return (
+    <>
+      molQTL 99% credible sets associated with study{" "}
+      <strong>{studyId}</strong>. Source{" "}
+      <Link external to="https://www.ebi.ac.uk/eqtl/" >
+        eQTL Catalog
+      </Link>
+    </>
+  );
+}
+
+export default Description;

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -1,0 +1,19 @@
+query QTLCredibleSetsQuery($studyId: String!) {
+  gwasStudy(studyId: $studyId) {
+    studyId
+    credibleSets {
+      variant {
+        id
+        referenceAllele
+        alternateAllele
+      }
+      pValueMantissa
+      pValueExponent
+      beta
+      locus {
+        is95CredibleSet
+      }
+      finemappingMethod
+    }
+  }
+}

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,0 +1,5 @@
+fragment QTLCredibleSetsSummaryFragment on Gwas {
+  qtlCredibleSets: credibleSets {
+    beta
+  }
+}

--- a/packages/sections/src/study/QTLCredibleSets/Summary.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Summary.tsx
@@ -1,0 +1,16 @@
+import { SummaryItem, usePlatformApi } from "ui";
+
+import { definition } from ".";
+import QTL_CREDIBLE_SETS_SUMMARY from "./QTLCredibleSetsSummaryFragment.gql";
+
+function Summary() {
+  const request = usePlatformApi(QTL_CREDIBLE_SETS_SUMMARY);
+  
+  return <SummaryItem definition={definition} request={request} />;
+}
+
+Summary.fragments = {
+  QTLCredibleSetsSummaryFragment: QTL_CREDIBLE_SETS_SUMMARY,
+};
+
+export default Summary;

--- a/packages/sections/src/study/QTLCredibleSets/index.ts
+++ b/packages/sections/src/study/QTLCredibleSets/index.ts
@@ -1,0 +1,8 @@
+const id = "qtl_credible_sets";
+export const definition = {
+  id,
+  name: "molQTL Credible Sets",
+  shortName: "QT",
+  hasData: data => data?.[0]?.qtlCredibleSets?.length > 0 ||
+                   data?.[0]?.credibleSets?.length > 0,
+};


### PR DESCRIPTION
## Description

Add QTL credible sets widget to study page.

**Issue:** [#3377](https://github.com/opentargets/issues/issues/3377)
**Deploy preview: https://deploy-preview-465--ot-platform.netlify.app/study/GTEx_adipose_subcutaneous_ENSG00000189337.17_1_13892792_13893756**

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
