### PR TITLE
[Platform]: Changed DepMap widget description to include the target symbol

### DIFF
--- a/packages/sections/src/target/DepMap/Description.jsx
+++ b/packages/sections/src/target/DepMap/Description.jsx
@@ -3,7 +3,7 @@ import { Link } from "ui";
 function Description({ symbol }) {
   return (
     <>
-      Gene Essentiality assessment obtained through CRISPR loss-of-function screens in a wide range
+      Gene Essentiality assessment for <strong>{symbol}</strong> obtained through CRISPR loss-of-function screens in a wide range
       of cancer cell lines. Source:{" "}
       <Link external to="https://depmap.org/portal/">
         DepMap Portal


### PR DESCRIPTION
## Description

Updated the DepMap widget description (gene essentiality) to include the target symbol, so that screenshots would reflect which target they represent.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tested on my local computer in the target prioritisation view and the target profile page.

## Checklist:

- [x] My changes generate no new warnings