### PR TITLE
[Package]: migrate HeaderMenu component to TypeScript

### DIFF
--- a/packages/ui/src/components/HeaderMenu.tsx
+++ b/packages/ui/src/components/HeaderMenu.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { ReactElement, useState, MouseEvent, KeyboardEvent } from "react";
 import { v1 } from "uuid";
 import {
   MenuItem,
@@ -8,6 +8,7 @@ import {
   Fade,
   Paper,
   ClickAwayListener,
+  PopperPlacementType,
 } from "@mui/material";
 import { faXmark, faBars } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -15,7 +16,7 @@ import { makeStyles } from "@mui/styles";
 import Link from "./Link";
 import PrivateWrapper from "./PrivateWrapper";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles(() => ({
   icon: {
     marginLeft: "20px",
   },
@@ -32,12 +33,24 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function HeaderMenu({ items, placement }) {
+type HeaderMenuItem = {
+  external: boolean;
+  name: string;
+  showOnlyPartner?: boolean;
+  url: string;
+};
+
+type HeaderMenuProps = {
+  items: HeaderMenuItem[];
+  placement?: PopperPlacementType;
+};
+
+function HeaderMenu({ items, placement }: HeaderMenuProps): ReactElement {
   const classes = useStyles();
-  const [anchorEl, setAnchorEl] = useState(null);
+  const [anchorEl, setAnchorEl] = useState<null | HTMLButtonElement>(null);
   const isMenuOpen = Boolean(anchorEl);
 
-  const handleMenuToggle = event => {
+  const handleMenuToggle = (event: MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(anchorEl === null ? event.currentTarget : null);
   };
 
@@ -45,7 +58,7 @@ function HeaderMenu({ items, placement }) {
     setAnchorEl(null);
   };
 
-  const handleListKeyDown = event => {
+  const handleListKeyDown = (event: KeyboardEvent) => {
     if (event.key === "Tab") {
       event.preventDefault();
       setAnchorEl(null);
@@ -62,11 +75,7 @@ function HeaderMenu({ items, placement }) {
         aria-haspopup="true"
         onClick={handleMenuToggle}
       >
-        {isMenuOpen ? (
-          <FontAwesomeIcon icon={faXmark} size="xs" />
-        ) : (
-          <FontAwesomeIcon icon={faBars} size="xs" />
-        )}
+        <FontAwesomeIcon icon={isMenuOpen ? faXmark : faBars} size="xs" />
       </IconButton>
 
       <Popper
@@ -84,7 +93,7 @@ function HeaderMenu({ items, placement }) {
             <Paper>
               <ClickAwayListener onClickAway={handleMenuClose}>
                 <MenuList onKeyDown={handleListKeyDown}>
-                  {items.map((item, i) => {
+                  {items.map((item: HeaderMenuItem) => {
                     if (item.showOnlyPartner) {
                       return (
                         <PrivateWrapper key={v1()}>
@@ -93,6 +102,7 @@ function HeaderMenu({ items, placement }) {
                               external={item.external}
                               to={item.url}
                               className={classes.menuLink}
+                              footer={false}
                             >
                               {item.name}
                             </Link>
@@ -107,7 +117,12 @@ function HeaderMenu({ items, placement }) {
                         dense
                         className={classes.menuItem}
                       >
-                        <Link external={item.external} to={item.url} className={classes.menuLink}>
+                        <Link
+                          external={item.external}
+                          to={item.url}
+                          className={classes.menuLink}
+                          footer={false}
+                        >
                           {item.name}
                         </Link>
                       </MenuItem>


### PR DESCRIPTION
## Description

Migrate the HeaderMenu component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Applications were built locally. Component was manually inspected in the UI.

**Condition:** Menu closed
![image](https://github.com/user-attachments/assets/af760ade-c068-4d9e-8e84-7b231b01b2c4)

**Condition:** Menu opened
![image](https://github.com/user-attachments/assets/62dbea13-9ba0-4fa9-98d4-28b53a295b89)

## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
