### PR TITLE
[Platform]: Use page parameter in credible sets queries

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -1,7 +1,7 @@
 query GWASCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
-    credibleSets {
+    credibleSets(page: { size: 2000, index: 0 }) {
       variant {
         id
         referenceAllele

--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment GWASCredibleSetsSummaryFragment on Gwas {
-  gwasCredibleSets: credibleSets {
+  gwasCredibleSets: credibleSets(page: { size: 1, index: 0 }) {
     beta
   }
 }

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -1,7 +1,7 @@
 query QTLCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
-    credibleSets {
+    credibleSets(page: { size: 2000, index: 0 }) {
       variant {
         id
         referenceAllele

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment QTLCredibleSetsSummaryFragment on Gwas {
-  qtlCredibleSets: credibleSets {
+  qtlCredibleSets: credibleSets(page: { size: 1, index: 0 }) {
     beta
   }
 }

--- a/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -3,7 +3,7 @@ query GWASCredibleSetsQuery($variantId: String!) {
     id
     referenceAllele
     alternateAllele
-    credibleSets(studyTypes: [gwas]) {
+    credibleSets(studyTypes: [gwas], page: { size: 2000, index: 0 }) {
       variant {
         id
         referenceAllele

--- a/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
@@ -1,5 +1,8 @@
 fragment GWASCredibleSetsSummaryFragment on Variant {
-  gwasCredibleSets: credibleSets(studyTypes: [gwas]) {
+  gwasCredibleSets: credibleSets(
+      studyTypes: [gwas],
+      page: { size: 1, index: 0 }
+    ) {
     studyLocusId
   }
 }

--- a/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -1,9 +1,12 @@
-query GWCredibleSetsQuery($variantId: String!) {
+query QTLCredibleSetsQuery($variantId: String!) {
   variant(variantId: $variantId) {
     id
     referenceAllele
     alternateAllele
-    credibleSets(studyTypes: [sqtl, pqtl, eqtl, tuqtl]) {
+    credibleSets(
+        studyTypes: [sqtl, pqtl, eqtl, tuqtl],
+        page: { size: 2000, index: 0 }
+      ) {
       variant {
         id
         referenceAllele

--- a/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,5 +1,8 @@
 fragment QTLCredibleSetsSummaryFragment on Variant {
-  qtlCredibleSets: credibleSets(studyTypes: [sqtl, pqtl, eqtl, tuqtl]) {
+  qtlCredibleSets: credibleSets(
+      studyTypes: [sqtl, pqtl, eqtl, tuqtl],
+      page: { size: 1, index: 0 }
+    ) {
     studyLocusId
   }
 }


### PR DESCRIPTION
## Description

Use page parameter in credible sets queries.

Allows us to see all credible sets in all (or almost all) cases for now though widgets will likely be changed to server side pagination in future.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
