### PR TITLE
[Platform]: Allow greater precision in allele frequency plot

### DIFF
--- a/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
@@ -113,7 +113,23 @@ const populationLabels = {
   remaining_adj: 'Other',
 };
 
+// magnitude of a number: its index in standard form
+function magnitude(v) {
+  const sf = v.toExponential();
+  return sf.slice(sf.indexOf('e'));
+}
+
 function AlleleFrequencyPlot({ data }) {
+
+  let orderOfMag = -2;
+  for (const { alleleFrequency } of data) {
+    if (alleleFrequency > 0) {
+      orderOfMag = Math.min(
+        orderOfMag,
+        Math.floor(Math.log10(alleleFrequency))
+      )
+    }
+  }
   
   // sort rows alphabetically on population label - but put "other" last
   const rows = data.map(({ populationName, alleleFrequency }) => ({
@@ -125,13 +141,13 @@ function AlleleFrequencyPlot({ data }) {
   return(
     <Box display="flex" flexDirection="column" gap={0.25}>
       {rows.map(row => (
-        <BarGroup dataRow={row} key={row.label}/>
+        <BarGroup dataRow={row} key={row.label} dps={-orderOfMag + 1}/>
       ))}
     </Box>
   );
 }
 
-function BarGroup({ dataRow: { label, alleleFrequency } }) {
+function BarGroup({ dataRow: { label, alleleFrequency }, dps }) {
   return (
     <Box display="flex" gap={1} alignItems="center" width="100%">
       <Typography width={170} fontSize="13.5px" variant="body2" textAlign="right">
@@ -151,8 +167,8 @@ function BarGroup({ dataRow: { label, alleleFrequency } }) {
           }}
         />
       </Box>
-      <Typography width={40} fontSize="12px" variant="body2" lineHeight={0.8}>
-        {alleleFrequency.toFixed(3)}
+      <Typography fontSize="12px" variant="body2" lineHeight={0.8}>
+        { alleleFrequency === 0 ? 0 : alleleFrequency.toFixed(dps) }
       </Typography>
     </Box>
   );

--- a/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/VariantPage/ProfileHeader.tsx
@@ -113,24 +113,20 @@ const populationLabels = {
   remaining_adj: 'Other',
 };
 
-// magnitude of a number: its index in standard form
-function magnitude(v) {
-  const sf = v.toExponential();
-  return sf.slice(sf.indexOf('e'));
-}
 
 function AlleleFrequencyPlot({ data }) {
 
   let orderOfMag = -2;
   for (const { alleleFrequency } of data) {
-    if (alleleFrequency > 0) {
+    if (alleleFrequency > 0 && alleleFrequency < 1) {
       orderOfMag = Math.min(
         orderOfMag,
         Math.floor(Math.log10(alleleFrequency))
       )
     }
   }
-  
+  const dps = Math.min(6, -orderOfMag + 1);
+
   // sort rows alphabetically on population label - but put "other" last
   const rows = data.map(({ populationName, alleleFrequency }) => ({
     label: populationLabels[populationName],
@@ -141,7 +137,7 @@ function AlleleFrequencyPlot({ data }) {
   return(
     <Box display="flex" flexDirection="column" gap={0.25}>
       {rows.map(row => (
-        <BarGroup dataRow={row} key={row.label} dps={-orderOfMag + 1}/>
+        <BarGroup dataRow={row} key={row.label} dps={dps}/>
       ))}
     </Box>
   );
@@ -167,7 +163,7 @@ function BarGroup({ dataRow: { label, alleleFrequency }, dps }) {
           }}
         />
       </Box>
-      <Typography fontSize="12px" variant="body2" lineHeight={0.8}>
+      <Typography width="60px" fontSize="12px" variant="body2" lineHeight={0.8}>
         { alleleFrequency === 0 ? 0 : alleleFrequency.toFixed(dps) }
       </Typography>
     </Box>


### PR DESCRIPTION
## Description

Allow greater precision in allele frequency plot at top of variant page.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)
**Deploy preview:** https://deploy-preview-480--ot-platform.netlify.app/variant/11_64600382_G_A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
