### PR TITLE
[Platform]: Include variant id in credible sets tooltips

### DIFF
--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -13,7 +13,19 @@ import Description from "./Description";
 import GWAS_CREDIBLE_SETS_QUERY from "./GWASCredibleSetsQuery.gql";
 import { Fragment } from "react/jsx-runtime";
 
-function getColumns(id: string, posteriorProbabilities: any) {
+type getColumnsType = {
+  id: string;
+  referenceAllele: string;
+  alternateAllele: string;
+  posteriorProbabilities: any;
+};
+
+function getColumns({
+      id,
+      referenceAllele,
+      alternateAllele,
+      posteriorProbabilities
+    }: getColumnsType) {
 
   return [
     {
@@ -105,7 +117,16 @@ function getColumns(id: string, posteriorProbabilities: any) {
     {
       id: "posteriorProbability",
       label: "Posterior Probability",
-      tooltip: "Probability the fixed page variant is in the credible set.",
+      tooltip: <>
+        Probability the fixed page variant (
+        <DisplayVariantId
+          variantId={id}
+          referenceAllele={referenceAllele}
+          alternateAllele={alternateAllele}
+          expand={false}
+        />
+        ) is in the credible set.
+      </>,
       comparator: (rowA, rowB) => (
         posteriorProbabilities.get(rowA.locus) -
           posteriorProbabilities.get(rowB.locus)
@@ -117,7 +138,16 @@ function getColumns(id: string, posteriorProbabilities: any) {
     {
       id: "ldr2",
       label: "LD (r²)",
-      tooltip: "Linkage disequilibrium with the queried variant",
+      tooltip: <>
+        Linkage disequilibrium with the fixed page variant (
+        <DisplayVariantId
+          variantId={id}
+          referenceAllele={referenceAllele}
+          alternateAllele={alternateAllele}
+          expand={false}
+        />
+        ).
+      </>,
       renderCell: ({ locus }) => {
         const r2 = locus?.find(obj => obj.variant?.id === id)?.r2Overall;
         if (typeof r2 !== "number") return naLabel;
@@ -211,7 +241,12 @@ function Body({ id, entity }: BodyProps) {
           <DataTable
             dataDownloader
             sortBy="pValue"
-            columns={getColumns(id, posteriorProbabilities)}
+            columns={getColumns({
+              id,
+              referenceAllele: variant.referenceAllele,
+              alternateAllele: variant.alternateAllele,
+              posteriorProbabilities,
+            })}
             rows={variant.credibleSets}
             rowsPerPageOptions={defaultRowsPerPageOptions}
             query={GWAS_CREDIBLE_SETS_QUERY.loc.source.body}

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -81,7 +81,7 @@ function getColumns({
     },
     {
       id: "study.studyid",
-      label: "Study",
+      label: "Study ID",
       renderCell: ({ study }) => {
         if (!study) return naLabel;
         return <Link to={`../study/${study.studyId}`}>{study.studyId}</Link>

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -53,7 +53,7 @@ function getColumns({
     },
     {
       id: "study.studyid",
-      label: "Study",
+      label: "Study ID",
       renderCell: ({ study }) => {
         if (!study) return naLabel;
         return <Link to={`../study/${study.studyId}`}>{study.studyId}</Link>

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -12,7 +12,19 @@ import { definition } from ".";
 import Description from "./Description";
 import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
 
-function getColumns(id: string, posteriorProbabilities: any) {
+type getColumnsType = {
+  id: string;
+  referenceAllele: string;
+  alternateAllele: string;
+  posteriorProbabilities: any;
+};
+
+function getColumns({
+      id,
+      referenceAllele,
+      alternateAllele,
+      posteriorProbabilities
+    }: getColumnsType) {
 
   return [
     {
@@ -116,7 +128,16 @@ function getColumns(id: string, posteriorProbabilities: any) {
     {
       id: "posteriorProbability",
       label: "Posterior Probability",
-      tooltip: "Probability the fixed page variant is in the credible set.",
+      tooltip: <>
+        Probability the fixed page variant (
+        <DisplayVariantId
+          variantId={id}
+          referenceAllele={referenceAllele}
+          alternateAllele={alternateAllele}
+          expand={false}
+        />
+        ) is in the credible set.
+      </>,
       comparator: (rowA, rowB) => (
         posteriorProbabilities.get(rowA.locus) -
           posteriorProbabilities.get(rowB.locus)
@@ -185,7 +206,12 @@ function Body({ id, entity }: BodyProps) {
           <DataTable
             dataDownloader
             sortBy="pValue"
-            columns={getColumns(id, posteriorProbabilities)}
+            columns={getColumns({
+              id,
+              referenceAllele: variant.referenceAllele,
+              alternateAllele: variant.alternateAllele,
+              posteriorProbabilities,
+            })}
             rows={variant.credibleSets}
             rowsPerPageOptions={defaultRowsPerPageOptions}
             query={QTL_CREDIBLE_SETS_QUERY.loc.source.body}


### PR DESCRIPTION
## Description

Include variant id in column header tooltips for posterior probabilities and r^2 in variant page credible sets widgets.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked in dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
