### PR TITLE
[Platform] Add links from credible sets widgets to credible set page

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -13,6 +13,15 @@ import GWAS_CREDIBLE_SETS_QUERY from "./GWASCredibleSetsQuery.gql";
 
 const columns = [
   {
+    id: "view",
+    label: "Details",
+    renderCell: ({ studyLocusId }) => (
+      <Link to={`../credible-set/${studyLocusId}`}>view</Link>
+    ),
+    filterValue: false,
+    exportValue: false,
+  },
+  {
     id: "leadVariant",
     label: "Lead Variant",
     renderCell: ({ variant }) => {

--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -2,6 +2,7 @@ query GWASCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
     credibleSets(page: { size: 2000, index: 0 }) {
+      studyLocusId
       variant {
         id
         referenceAllele

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -13,6 +13,15 @@ import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
 
 const columns = [
   {
+    id: "view",
+    label: "Details",
+    renderCell: ({ studyLocusId }) => (
+      <Link to={`../credible-set/${studyLocusId}`}>view</Link>
+    ),
+    filterValue: false,
+    exportValue: false,
+  },
+  {
     id: "leadVariant",
     label: "Lead Variant",
     renderCell: ({ variant }) => {

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -2,6 +2,7 @@ query QTLCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
     credibleSets(page: { size: 2000, index: 0 }) {
+      studyLocusId
       variant {
         id
         referenceAllele

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -29,6 +29,15 @@ function getColumns({
 
   return [
     {
+      id: "view",
+      label: "Details",
+      renderCell: ({ studyLocusId }) => (
+        <Link to={`../credible-set/${studyLocusId}`}>view</Link>
+      ),
+      filterValue: false,
+      exportValue: false,
+    },
+    {
       id: "leadVariant",
       label: "Lead Variant",
       renderCell: ({ variant }) => {

--- a/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -4,6 +4,7 @@ query GWASCredibleSetsQuery($variantId: String!) {
     referenceAllele
     alternateAllele
     credibleSets(studyTypes: [gwas], page: { size: 2000, index: 0 }) {
+      studyLocusId
       variant {
         id
         referenceAllele

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -28,6 +28,15 @@ function getColumns({
 
   return [
     {
+      id: "view",
+      label: "Details",
+      renderCell: ({ studyLocusId }) => (
+        <Link to={`../credible-set/${studyLocusId}`}>view</Link>
+      ),
+      filterValue: false,
+      exportValue: false,
+    },
+    {
       id: "leadVariant",
       label: "Lead Variant",
       renderCell: ({ variant }) => {

--- a/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -7,6 +7,7 @@ query QTLCredibleSetsQuery($variantId: String!) {
         studyTypes: [sqtl, pqtl, eqtl, tuqtl],
         page: { size: 2000, index: 0 }
       ) {
+      studyLocusId
       variant {
         id
         referenceAllele


### PR DESCRIPTION
## Description

Add links from credible sets widgets to credible set page.

**Issue:** [#3436](https://github.com/opentargets/issues/issues/3436)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
