### PR TITLE
[Platform]: Handle missing biosample in molQTL credible sets widget on variant page

### DIFF
--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -102,7 +102,7 @@ function getColumns({
       id: "study.biosample.biosampleId",
       label: "Affected tissue/cell",
       renderCell: ({ study }) => {
-        const { biosampleId } = study?.biosample; 
+        const biosampleId = study?.biosample?.biosampleId;
         if (!biosampleId) return naLabel;
         return <Link external to={`https://www.ebi.ac.uk/ols4/search?q=${biosampleId}&ontology=uberon`}>
           {biosampleId}


### PR DESCRIPTION
## Description

Handle missing biosample in molQTL credible sets widget on variant page.

**Issue:**
**Deploy preview:**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
