### PR TITLE
[Platform]: Accurate sorting when very small p-values

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Body.tsx
@@ -10,7 +10,10 @@ import { naLabel, defaultRowsPerPageOptions } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import GWAS_COLOC_QUERY from "./GWASColocQuery.gql";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 import { getStudyCategory } from "../../utils/getStudyCategory";
 
 const columns = [
@@ -88,9 +91,12 @@ const columns = [
   {
     id: "pValue",
     label: "P-Value",
-    comparator: ({ otherStudyLocus: a }, { otherStudyLocus: b }) =>
-      a?.pValueMantissa * 10 ** a?.pValueExponent -
-        b?.pValueMantissa * 10 ** b?.pValueExponent,
+    comparator: (a, b) => mantissaExponentComparator(
+      a?.pValueMantissa,
+      a?.pValueExponent,
+      b?.pValueMantissa,
+      b?.pValueExponent,
+    ),
     sortable: true,
     filterValue: false,
     renderCell: ({ otherStudyLocus }) => {

--- a/packages/sections/src/credibleSet/GWASColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Body.tsx
@@ -91,11 +91,13 @@ const columns = [
   {
     id: "pValue",
     label: "P-Value",
-    comparator: (a, b) => mantissaExponentComparator(
-      a?.pValueMantissa,
-      a?.pValueExponent,
-      b?.pValueMantissa,
-      b?.pValueExponent,
+    comparator: ({ otherStudyLocus: a }, { otherStudyLocus: b }) => (
+      mantissaExponentComparator(
+        a?.pValueMantissa,
+        a?.pValueExponent,
+        b?.pValueMantissa,
+        b?.pValueExponent,
+      )
     ),
     sortable: true,
     filterValue: false,

--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -11,7 +11,10 @@ import { naLabel, defaultRowsPerPageOptions } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import VARIANTS_QUERY from "./VariantsQuery.gql";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 
 type getColumnsType = {
   leadVariantId: string;
@@ -58,9 +61,12 @@ function getColumns({
     {
       id: "pValue",
       label: "P-value",
-      comparator: (a, b) =>
-        a?.pValueMantissa * 10 ** a?.pValueExponent -
-          b?.pValueMantissa * 10 ** b?.pValueExponent,
+      comparator: (a, b) => mantissaExponentComparator(
+        a?.pValueMantissa,
+        a?.pValueExponent,
+        b?.pValueMantissa,
+        b?.pValueExponent,
+      ),
       sortable: true,
       filterValue: false,
       renderCell: ({ pValueMantissa, pValueExponent }) => {

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -10,7 +10,10 @@ import { naLabel, defaultRowsPerPageOptions } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import GWAS_CREDIBLE_SETS_QUERY from "./GWASCredibleSetsQuery.gql";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 
 const columns = [
   {
@@ -47,9 +50,12 @@ const columns = [
   {
     id: "pValue",
     label: "P-value",
-    comparator: (a, b) =>
-      a?.pValueMantissa * 10 ** a?.pValueExponent -
-        b?.pValueMantissa * 10 ** b?.pValueExponent,
+    comparator: (a, b) => mantissaExponentComparator(
+      a?.pValueMantissa,
+      a?.pValueExponent,
+      b?.pValueMantissa,
+      b?.pValueExponent,
+    ),
     sortable: true,
     filterValue: false,
     renderCell: ({ pValueMantissa, pValueExponent }) => {

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -10,7 +10,10 @@ import { naLabel, defaultRowsPerPageOptions } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 
 const columns = [
   {
@@ -47,9 +50,12 @@ const columns = [
   {
     id: "pValue",
     label: "P-value",
-    comparator: (a, b) =>
-      a?.pValueMantissa * 10 ** a?.pValueExponent -
-        b?.pValueMantissa * 10 ** b?.pValueExponent,
+    comparator: (a, b) => mantissaExponentComparator(
+      a?.pValueMantissa,
+      a?.pValueExponent,
+      b?.pValueMantissa,
+      b?.pValueExponent,
+    ),
     sortable: true,
     filterValue: false,
     renderCell: ({ pValueMantissa, pValueExponent }) => {

--- a/packages/sections/src/utils/comparators.ts
+++ b/packages/sections/src/utils/comparators.ts
@@ -76,3 +76,8 @@ export function variantComparator(
   
   return 0;
 }
+
+export function mantissaExponentComparator(m1, e1, m2, e2) {
+  if (e1 === e2) return m1 - m2;
+  return e1 - e2;
+}

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -12,7 +12,10 @@ import { definition } from ".";
 import Description from "./Description";
 import GWAS_CREDIBLE_SETS_QUERY from "./GWASCredibleSetsQuery.gql";
 import { Fragment } from "react/jsx-runtime";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 
 type getColumnsType = {
   id: string;
@@ -107,9 +110,12 @@ function getColumns({
     {
       id: "pValue",
       label: "P-value",
-      comparator: (a, b) =>
-        a?.pValueMantissa * 10 ** a?.pValueExponent -
-          b?.pValueMantissa * 10 ** b?.pValueExponent,
+      comparator: (a, b) => mantissaExponentComparator(
+        a?.pValueMantissa,
+        a?.pValueExponent,
+        b?.pValueMantissa,
+        b?.pValueExponent,
+      ),
       sortable: true,
       filterValue: false,
       renderCell: ({ pValueMantissa, pValueExponent }) => {

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -11,7 +11,10 @@ import { naLabel, defaultRowsPerPageOptions } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
-import { variantComparator } from "../../utils/comparators";
+import {
+  mantissaExponentComparator,
+  variantComparator
+} from "../../utils/comparators";
 
 type getColumnsType = {
   id: string;
@@ -117,9 +120,12 @@ function getColumns({
     {
       id: "pValue",
       label: "P-value",
-      comparator: (a, b) =>
-        a?.pValueMantissa * 10 ** a?.pValueExponent -
-          b?.pValueMantissa * 10 ** b?.pValueExponent,
+      comparator: (a, b) => mantissaExponentComparator(
+        a?.pValueMantissa,
+        a?.pValueExponent,
+        b?.pValueMantissa,
+        b?.pValueExponent,
+      ),
       sortable: true,
       filterValue: false,
       renderCell: ({ pValueMantissa, pValueExponent }) => {


### PR DESCRIPTION
## Description

Use dedicated comparator for p-values in genetics widgets (supplied as mantissa and exponent) so get correct results even when values are very small. 

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)
**Deploy preview:** https://deploy-preview-500--ot-platform.netlify.app/variant/12_21178615_T_C

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
