### PR TITLE
[Platform] Increase max rows in coloc widget

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/GWASColocQuery.gql
+++ b/packages/sections/src/credibleSet/GWASColoc/GWASColocQuery.gql
@@ -1,6 +1,6 @@
 query GWASColocQuery($studyLocusIds: [String!]!) {
   credibleSets(studyLocusIds: $studyLocusIds) {
-    colocalisation(studyTypes: [gwas]) {
+    colocalisation(studyTypes: [gwas], page: { size: 250, index: 0 }) {
       otherStudyLocus {
         studyLocusId
         study {

--- a/packages/sections/src/credibleSet/GWASColoc/GWASColocSummaryFragment.gql
+++ b/packages/sections/src/credibleSet/GWASColoc/GWASColocSummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment GWASColocSummaryFragment on credibleSet {
-  colocalisation(studyTypes: [gwas]) {
+  colocalisation(studyTypes: [gwas], page: { size: 1, index: 0 }) {
     colocalisationMethod
   }
 }


### PR DESCRIPTION
## Description

Increase max rows in coloc widget from 25 to 250.

Note: this table will be server paginated in future since it will often have a very large number of rows.

**Issue:** [#3510](https://github.com/opentargets/issues/issues/3510)
**Deploy preview:** https://deploy-preview-502--ot-platform.netlify.app/credible-set/-8771774904770677429

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
