### PR TITLE
[Platform]: Add uniprot widget to variant page

### DIFF
--- a/apps/platform/src/pages/VariantPage/Profile.tsx
+++ b/apps/platform/src/pages/VariantPage/Profile.tsx
@@ -12,7 +12,7 @@ import PharmacogenomicsSummary from "sections/src/variant/Pharmacogenomics/Summa
 import InSilicoPredictorsSummary from "sections/src/variant/InSilicoPredictors/Summary";
 import VariantEffectPredictorSummary from "sections/src/variant/VariantEffectPredictor/Summary";
 import EVASummary from "sections/src/variant/EVA/Summary";
-// import UniProtVariantsSummary from "sections/src/variant/UniProtVariants/Summary";
+import UniProtVariantsSummary from "sections/src/variant/UniProtVariants/Summary";
 import GWASCredibleSetsSummary from "sections/src/variant/GWASCredibleSets/Summary";
 import QTLCredibleSetsSummary from "sections/src/variant/QTLCredibleSets/Summary";
 
@@ -28,7 +28,7 @@ const VariantEffectPredictorSection = lazy(
   () => import("sections/src/variant/VariantEffectPredictor/Body")
 );
 const EVASection = lazy(() => import("sections/src/variant/EVA/Body"));
-// const UniProtVariantsSection = lazy(() => import("sections/src/variant/UniProtVariants/Body"));
+const UniProtVariantsSection = lazy(() => import("sections/src/variant/UniProtVariants/Body"));
 const GWASCredibleSetsSection = lazy(
   () => import("sections/src/variant/GWASCredibleSets/Body")
 );
@@ -41,7 +41,7 @@ const summaries = [
   InSilicoPredictorsSummary,
   VariantEffectPredictorSummary,
   EVASummary,
-  // UniProtVariantsSummary,
+  UniProtVariantsSummary,
   GWASCredibleSetsSummary,
   QTLCredibleSetsSummary,
 ];
@@ -82,7 +82,7 @@ function Profile({ varId }: ProfileProps) {
         <InSilicoPredictorsSummary />
         <VariantEffectPredictorSummary />
         <EVASummary />
-        {/* <UniProtVariantsSummary /> */}
+        <UniProtVariantsSummary />
         <GWASCredibleSetsSummary />
         <QTLCredibleSetsSummary />
       </SummaryContainer>
@@ -98,16 +98,16 @@ function Profile({ varId }: ProfileProps) {
           <VariantEffectPredictorSection id={varId} entity={VARIANT} />
         </Suspense>
         <Suspense fallback={<SectionLoader />}>
-          <EVASection id={varId} label='NO-LABEL!' entity={VARIANT} />
+          <EVASection id={varId} entity={VARIANT} />
         </Suspense>
-        {/* <Suspense fallback={<SectionLoader />}>
-          <UniProtVariantsSection id={varId} label='NO-LABEL!' entity={VARIANT} />
-        </Suspense> */}
+        <Suspense fallback={<SectionLoader />}>
+          <UniProtVariantsSection id={varId} entity={VARIANT} />
+        </Suspense>
         <Suspense fallback={<SectionLoader />}>
           <GWASCredibleSetsSection id={varId} entity={VARIANT} />
         </Suspense>
         <Suspense fallback={<SectionLoader />}>
-          <QTLCredibleSetsSection id={varId} label='NO-LABEL!' entity={VARIANT} />
+          <QTLCredibleSetsSection id={varId} entity={VARIANT} />
         </Suspense>
       </SectionContainer>
     </PlatformApiProvider>

--- a/apps/platform/src/pages/VariantPage/Profile.tsx
+++ b/apps/platform/src/pages/VariantPage/Profile.tsx
@@ -28,7 +28,9 @@ const VariantEffectPredictorSection = lazy(
   () => import("sections/src/variant/VariantEffectPredictor/Body")
 );
 const EVASection = lazy(() => import("sections/src/variant/EVA/Body"));
-const UniProtVariantsSection = lazy(() => import("sections/src/variant/UniProtVariants/Body"));
+const UniProtVariantsSection = lazy(
+  () => import("sections/src/variant/UniProtVariants/Body")
+);
 const GWASCredibleSetsSection = lazy(
   () => import("sections/src/variant/GWASCredibleSets/Body")
 );

--- a/packages/sections/src/variant/EVA/EVASummaryFragment.gql
+++ b/packages/sections/src/variant/EVA/EVASummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment EVASummaryFragment on Variant {
-  evidences(datasourceIds: ["eva"]){
+  evaEvidences: evidences(datasourceIds: ["eva"]){
     count
   }
 }

--- a/packages/sections/src/variant/EVA/Summary.tsx
+++ b/packages/sections/src/variant/EVA/Summary.tsx
@@ -1,7 +1,7 @@
 import { SummaryItem, usePlatformApi } from "ui";
 
 import { definition } from ".";
-import EVA_SUMMARY from "./EVASummaryFragement.gql";
+import EVA_SUMMARY from "./EVASummaryFragment.gql";
 
 function Summary() {
   const request = usePlatformApi(EVA_SUMMARY);

--- a/packages/sections/src/variant/EVA/index.ts
+++ b/packages/sections/src/variant/EVA/index.ts
@@ -3,5 +3,8 @@ export const definition = {
   id,
   name: "ClinVar",
   shortName: "CV",
-  hasData: ({ evidences }) => evidences.count > 0,
+  hasData: data => {
+    return  data?.evaEvidences?.count > 0 ||  // summary
+            data?.evidences?.count > 0;       // section
+  },
 };

--- a/packages/sections/src/variant/UniProtVariants/Body.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Body.tsx
@@ -5,7 +5,7 @@ import { definition } from ".";
 import Description from "./Description";
 import { epmcUrl } from "../../utils/urls";
 import { defaultRowsPerPageOptions, naLabel } from "../../constants";
-import UNIPROT_VARIANTS_QUERY from "./UniprotVariantsQuery.gql";
+import UNIPROT_VARIANTS_QUERY from "./UniProtVariantsQuery.gql";
 
 const columns = [
   {

--- a/packages/sections/src/variant/UniProtVariants/Body.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Body.tsx
@@ -1,28 +1,25 @@
-// import { useQuery } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import { Typography } from "@mui/material";
 import { Link, SectionItem, Tooltip, PublicationsDrawer, DataTable } from "ui";
-import { definition } from "../../variant/UniProtVariants";
-import Description from "../../variant/UniProtVariants/Description";
+import { definition } from ".";
+import Description from "./Description";
 import { epmcUrl } from "../../utils/urls";
-import { defaultRowsPerPageOptions, sectionsBaseSizeQuery,
-} from "../../constants";
-// import UNIPROT_VARIANTS_QUERY from "./UniprotVariantsQuery.gql";
+import { defaultRowsPerPageOptions, naLabel } from "../../constants";
+import UNIPROT_VARIANTS_QUERY from "./UniprotVariantsQuery.gql";
 
-function getColumns(label: string) {
-  return [
-    {
-      id: "disease.name",
-      label: "Disease/phenotype",
-      renderCell: ({
-            "disease.id": disease_id,
-            "disease.name": disease_name,
-            diseaseFromSource
-          }) => (
-        <Tooltip
+const columns = [
+  {
+    id: "diseases",
+    label: "Disease/phenotype",
+    renderCell: ({ disease, diseaseFromSource }) => {
+      if (!disease) return naLabel;
+      const displayElement = <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      if (diseaseFromSource) {
+        return <Tooltip
           title={
             <>
               <Typography variant="subtitle2" display="block" align="center">
-                Reported disease or phenotype:
+                Reported disease or phenotype
               </Typography>
               <Typography variant="caption" display="block" align="center">
                 {diseaseFromSource}
@@ -31,77 +28,76 @@ function getColumns(label: string) {
           }
           showHelpIcon
         >
-          <Link to={`/disease/${disease_id}`}>{disease_name}</Link>
+          {displayElement}
         </Tooltip>
-      ),
+      }
+      return displayElement;
     },
-    {
-      id: "confidence",
-      label: "Confidence",
-    },
-    {
-      label: "Literature",
-      renderCell: ({ literature }) => {
-        const literatureList =
-          literature?.reduce((acc, id) => {
-            if (id !== "NA") {
-              acc.push({
-                name: id,
-                url: epmcUrl(id),
-                group: "literature",
-              });
-            }
-            return acc;
-          }, []) || [];
+  },
+  {
+    id: "confidence",
+    label: "Confidence",
+  },
+  {
+    id: "literature",
+    label: "Literature",
+    renderCell: ({ literature }) => {
+      const literatureList =
+        literature?.reduce((acc, id) => {
+          if (id !== "NA") {
+            acc.push({
+              name: id,
+              url: epmcUrl(id),
+              group: "literature",
+            });
+          }
+          return acc;
+        }, []) || [];
 
-        return (
-          <PublicationsDrawer entries={literatureList} symbol={label.symbol} name={label.name} />
-        );
-      },
+      return (
+        <PublicationsDrawer entries={literatureList} />
+      );
     },
-  ];
-}
+  },
+];
 
 type BodyProps = {
   id: string,
-  label: string,
   entity: string,
 };
 
+export function Body({ id, entity }: BodyProps) {
+  const variables = {
+    variantId: id,
+  };
 
-export function Body({ id, label, entity }) {
-
-  // const variables = {
-  //   ensemblId: ensgId,
-  //   efoId,
-  //   size: sectionsBaseSizeQuery,
-  // };
-
-  const columns = getColumns(label);
-
-  // const request = useQuery(UNIPROT_VARIANTS_QUERY, {
-  //   variables,
-  // });
-  const request = mockQuery();
+  const request = useQuery(UNIPROT_VARIANTS_QUERY, {
+    variables,
+  });
 
   return (
     <SectionItem
       definition={definition}
       request={request}
       entity={entity}
-      renderDescription={data => <Description variantId={id} data={data} />}
-      renderBody={() => {
-        // const { rows } = disease.uniprotVariantsSummary;
-        const rows = request.data.variant.uniProtVariants;      
+      renderDescription={({ variant }) => (
+        <Description
+          variantId={variant.id}
+          referenceAllele={variant.referenceAllele}
+          alternateAllele={variant.alternateAllele}
+          evidences={variant.evidences}
+        />
+      )}
+      renderBody={({ variant }) => { 
         return (
           <DataTable
-            columns={columns}
-            rows={rows}
             dataDownloader
             showGlobalFilter
+            columns={columns}
+            rows={variant.evidences.rows}
             rowsPerPageOptions={defaultRowsPerPageOptions}
-            // query={UNIPROT_VARIANTS_QUERY.loc.source.body}
-            // variables={variables}
+            query={UNIPROT_VARIANTS_QUERY.loc.source.body}
+            variables={variables}
           />
         );
       }}
@@ -110,167 +106,3 @@ export function Body({ id, label, entity }) {
 }
 
 export default Body;
-
-function mockQuery() {
-  return {
-    loading: false,
-    error: undefined,
-    data: JSON.parse(`
-{ 
-  "variant": {
-    "uniProtVariants": [
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Mitochondrial DNA depletion syndrome 4A",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "Orphanet_726",
-        "disease.name": "Alpers syndrome"
-      },
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Mitochondrial DNA depletion syndrome 4A",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "MONDO_0008758",
-        "disease.name": "mitochondrial DNA depletion syndrome 4a"
-      },
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Sensory ataxic neuropathy dysarthria and ophthalmoparesis",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "MONDO_0011835",
-        "disease.name": "sensory ataxic neuropathy, dysarthria, and ophthalmoparesis"
-      },
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Spinocerebellar ataxia with epilepsy",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "Orphanet_70595",
-        "disease.name": "Sensory ataxic neuropathy - dysarthria - ophthalmoparesis"
-      },
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Sensory ataxic neuropathy dysarthria and ophthalmoparesis",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "Orphanet_70595",
-        "disease.name": "Sensory ataxic neuropathy - dysarthria - ophthalmoparesis"
-      },
-      {
-        "variantId": "15_89327201_C_T",
-        "confidence": "high",
-        "diseaseFromSource": "Spinocerebellar ataxia with epilepsy",
-        "literature": [
-          "16639411",
-          "15917273",
-          "15477547",
-          "14635118",
-          "15824347",
-          "11431686",
-          "15122711",
-          "26942291",
-          "12565911",
-          "18828154",
-          "14694057",
-          "15689359",
-          "12707443"
-        ],
-        "targetFromSourceId": "P54098",
-        "target.id": "ENSG00000140521",
-        "target.approvedSymbol": "POLG",
-        "disease.id": "MONDO_0011835",
-        "disease.name": "sensory ataxic neuropathy, dysarthria, and ophthalmoparesis"
-      }
-    ]
-  }
-}`),
-  };
-}

--- a/packages/sections/src/variant/UniProtVariants/Body.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Body.tsx
@@ -13,7 +13,9 @@ const columns = [
     label: "Disease/phenotype",
     renderCell: ({ disease, diseaseFromSource }) => {
       if (!disease) return naLabel;
-      const displayElement = <Link to={`/disease/${disease.id}`}>{disease.name}</Link>
+      const displayElement = <Link to={`/disease/${disease.id}`}>
+        {disease.name}
+      </Link>;
       if (diseaseFromSource) {
         return <Tooltip
           title={
@@ -33,6 +35,8 @@ const columns = [
       }
       return displayElement;
     },
+    exportValue: ({ disease }) => disease?.name,
+    filterValue: ({ disease }) => disease?.name,
   },
   {
     id: "confidence",
@@ -53,11 +57,11 @@ const columns = [
           }
           return acc;
         }, []) || [];
-
       return (
         <PublicationsDrawer entries={literatureList} />
       );
     },
+    filterValue: false,
   },
 ];
 

--- a/packages/sections/src/variant/UniProtVariants/Description.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Description.tsx
@@ -1,16 +1,33 @@
-import { Link } from "ui";
+import { Link, DisplayVariantId } from "ui";
 import { identifiersOrgLink } from "../../utils/global";
 
 type DescriptionProps = {
   variantId: string;
-  data: any;
+  referenceAllele: string;
+  alternateAllele: string;
+  evidences: any;
 };
 
-function Description({ variantId, data }: DescriptionProps) {
-  const { targetFromSourceId } = data.variant.uniProtVariants[0];
+function Description({
+      variantId,
+      referenceAllele,
+      alternateAllele,
+      evidences,
+    }: DescriptionProps) {
+  
+  const { targetFromSourceId } = evidences.rows[0];
+  
   return (
     <>
-      Literature-based curation associating <strong>{variantId}</strong>{" "} to a disease/phenotype. Source:{" "}
+      Literature-based curation associating{" "}
+      <strong>
+        <DisplayVariantId
+          variantId={variantId}
+          referenceAllele={referenceAllele}
+          alternateAllele={alternateAllele}
+        />
+      </strong>
+      {" "} to a disease/phenotype. Source:{" "}
       <Link external to={identifiersOrgLink("uniprot", targetFromSourceId)}>
         UniProt ({targetFromSourceId})
       </Link>

--- a/packages/sections/src/variant/UniProtVariants/Description.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Description.tsx
@@ -27,7 +27,7 @@ function Description({
           alternateAllele={alternateAllele}
         />
       </strong>
-      {" "} to a disease/phenotype. Source:{" "}
+      {" "}to a disease/phenotype. Source:{" "}
       <Link external to={identifiersOrgLink("uniprot", targetFromSourceId)}>
         UniProt ({targetFromSourceId})
       </Link>

--- a/packages/sections/src/variant/UniProtVariants/Summary.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Summary.tsx
@@ -1,7 +1,7 @@
 import { SummaryItem, usePlatformApi } from "ui";
 
 import { definition } from ".";
-import UNIPROT_VARIANTS_SUMMARY from "./UniprotVariantsSummaryFragment.gql";
+import UNIPROT_VARIANTS_SUMMARY from "./UniProtVariantsSummaryFragment.gql";
 
 function Summary() {
   const request = usePlatformApi(UNIPROT_VARIANTS_SUMMARY);

--- a/packages/sections/src/variant/UniProtVariants/Summary.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Summary.tsx
@@ -1,35 +1,18 @@
 import { SummaryItem, usePlatformApi } from "ui";
 
 import { definition } from ".";
-import { dataTypesMap } from "../../dataTypes";
-// import UNIPROT_VARIANTS_SUMMARY from "./UniprotVariantsSummaryQuery.gql";
+import UNIPROT_VARIANTS_SUMMARY from "./UniprotVariantsSummaryFragment.gql";
 
 function Summary() {
+  const request = usePlatformApi(UNIPROT_VARIANTS_SUMMARY);
 
-  // !! USE PLACEHOLDER REQUEST FOR NOW !!
-  // const request = usePlatformApi(UNIPROT_VARIANTS_SUMMARY);
-  const request = {
-    loading: false,
-    error: undefined,
-    data: true,  // data is not actually used by summary - only cares if there is data
-  };
-  
   return (
-    <SummaryItem
-      definition={definition}
-      request={request}
-      renderSummary={() => {}}  // !! renderSummary PROP NOT USED ANYMORE ANYWAY?
-      // renderSummary={({ uniprotVariantsSummary }) => {
-      //   const { count } = uniprotVariantsSummary;
-      //   return `${count} ${count === 1 ? "entry" : "entries"}`;
-      // }}
-    />
+    <SummaryItem definition={definition} request={request} />
   );
 }
 
-// !!!!!!!!!!!!!
-// Summary.fragments = {
-//   UniprotVariantsSummary: UNIPROT_VARIANTS_SUMMARY,
-// };
+Summary.fragments = {
+  UniProtVariantsSummaryFragment: UNIPROT_VARIANTS_SUMMARY,
+};
 
 export default Summary;

--- a/packages/sections/src/variant/UniProtVariants/UniProtVariantsQuery.gql
+++ b/packages/sections/src/variant/UniProtVariants/UniProtVariantsQuery.gql
@@ -1,0 +1,20 @@
+query UniProtVariantsQuery($variantId: String!) {
+  variant(variantId: $variantId) {
+    id
+    referenceAllele
+    alternateAllele
+    evidences(datasourceIds: ["uniprot_variants"]) {
+      count
+      rows {
+        targetFromSourceId
+        confidence
+        diseaseFromSource
+        disease {
+          id
+          name
+        }
+        literature
+      }
+    }
+  }
+}

--- a/packages/sections/src/variant/UniProtVariants/UniProtVariantsSummaryFragment.gql
+++ b/packages/sections/src/variant/UniProtVariants/UniProtVariantsSummaryFragment.gql
@@ -1,0 +1,5 @@
+fragment UniProtVariantsSummaryFragment on Variant {
+  uniProtEvidences: evidences(datasourceIds: ["uniprot_variants"]){
+    count
+  }
+}

--- a/packages/sections/src/variant/UniProtVariants/index.ts
+++ b/packages/sections/src/variant/UniProtVariants/index.ts
@@ -1,11 +1,10 @@
-// import { isPrivateEvidenceSection } from "../../utils/partnerPreviewUtils";
-
 const id = "uniprot_variants";
 export const definition = {
   id,
   name: "UniProt variants",
   shortName: "UV",
-  // !! UPDATE HERE ONCE HAVE PROPER DATA
-  hasData: data => true,  // data.uniprotVariantsSummary.count > 0,
-  isPrivate: false,  // isPrivateEvidenceSection(id),
+  hasData: data => {
+    return  data?.uniProtEvidences?.count > 0 ||  // summary
+            data?.evidences?.count > 0;           // section
+  },
 };


### PR DESCRIPTION
## Description

Add uniprot widget to variant page.

**Issue:** [#3318](https://github.com/opentargets/issues/issues/3318)
**Deploy preview:** https://deploy-preview-507--ot-platform.netlify.app/variant/17_63945614_C_T

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
