### PR TITLE
[Platform] Take other required datasources into account in aggregationClick

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/context/aotfReducer.ts
+++ b/apps/platform/src/components/AssociationsToolkit/context/aotfReducer.ts
@@ -114,7 +114,10 @@ export function aotfReducer(state: State = initialState, action: Action): State 
 
       const isAllActive = state.dataSourceControls
         .filter(el => el.aggregation === aggregation)
-        .every(el => el.required === true);
+        .every(el => el.required);
+      const isAnyOtherActive = state.dataSourceControls
+        .filter(el => el.aggregation !== aggregation)
+        .some(el => el.required);
       const dataSourceControls = state.dataSourceControls.map(col => {
         if (col.aggregation === aggregation) {
           return {
@@ -127,7 +130,7 @@ export function aotfReducer(state: State = initialState, action: Action): State 
       return {
         ...state,
         dataSourceControls,
-        modifiedSourcesDataControls: !isAllActive,
+        modifiedSourcesDataControls: !isAllActive || isAnyOtherActive,
         pagination: DEFAULT_TABLE_PAGINATION_STATE,
       };
     }


### PR DESCRIPTION
# [Platform]: Take other required datasources into account in aggregationClick

## Description

`modifiedSourcesDataControls` was turned off when unclicking an aggregation on the associations page while other datasources might still be required.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A: ran it locally in yarn

## Checklist:

- [x] My changes generate no new warnings
