### PR TITLE
[Platform]: Set plot-wide fontSize to affect crosshair for DepmapPlot

### DIFF
--- a/packages/sections/src/target/DepMap/DepmapPlot.jsx
+++ b/packages/sections/src/target/DepMap/DepmapPlot.jsx
@@ -67,6 +67,7 @@ function DepmapPlot({ data, width }) {
       marginLeft: 200,
       style: {
         background: "transparent",
+        fontSize: "12px",
       },
       x: {
         type: "symlog",
@@ -129,11 +130,9 @@ function DepmapPlot({ data, width }) {
           fillOpacity: 0.5,
         }),
         Plot.axisY({
-          fontSize: 12,
           label: "Tissue name",
         }),
         Plot.axisX({
-          fontSize: 12,
           label: "Gene Effect",
         }),
         Plot.crosshair(data, { x: "geneEffect", y: "tissueName" }),


### PR DESCRIPTION
# [Platform]: Set plot-wide fontSize so crosshair is also adjusted

## Description

Crosshairs in the depmap plot are not in font size 12 like the axes and the crosshairs do not have a fontsize option so I set the fontSize for the whole plot to also affect the crosshairs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A locally with yarn

## Checklist:

- [x] My changes generate no new warnings
