### PR TITLE
[Platform]: Remove buggy formatting in DepMap tooltip

### DIFF
--- a/packages/sections/src/target/DepMap/DepmapPlot.jsx
+++ b/packages/sections/src/target/DepMap/DepmapPlot.jsx
@@ -119,7 +119,7 @@ function DepmapPlot({ data, width }) {
             textPadding: 10,
             format: {
               fill: false,
-              cellLineName: d => d + "\n\n",
+              cellLineName: true,
               diseaseFromSource: true,
               x: false,
               y: false,


### PR DESCRIPTION
# [Platform]: Remove buggy formatting in DepMap tooltip

## Description

In firefox the tooltip of the depmap plot is rendered like this:
![image](https://github.com/user-attachments/assets/f41111ef-0aa9-46c1-9cc5-7d0d362e03d7)

While in chrome the two linebreaks did not affect the front-end at all:
![image](https://github.com/user-attachments/assets/c079328a-fd9a-4c32-a3d6-ad60404f61b0)

Therefore I just removed the linebreaks so it fixed the tooltip in firefox and kept the tooltip the same as it was in chrome.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A tested locally in yarn

## Checklist:

- [x] My changes generate no new warnings
