### PR TITLE
[Platform]: add create GWAS credible sets to AotF and base widget

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/static_datasets/dataSourcesAssoc.js
+++ b/apps/platform/src/components/AssociationsToolkit/static_datasets/dataSourcesAssoc.js
@@ -1,5 +1,16 @@
 const dataSources = [
   {
+    id: "gwas_credible_sets",
+    sectionId: "gwasCredibleSets",
+    label: "GWAS credible sets",
+    aggregation: "Genetic association",
+    aggregationId: "genetic_association",
+    weight: 1,
+    isPrivate: false,
+    docsLink: "https://platform-docs.opentargets.org/evidence#open-targets-genetics",
+    required: false,
+  },
+  {
     id: "ot_genetics_portal",
     sectionId: "otGenetics",
     label: "OT Genetics",

--- a/apps/platform/src/sections/evidenceSections.js
+++ b/apps/platform/src/sections/evidenceSections.js
@@ -27,6 +27,7 @@ const evidenceSections = new Map([
   ["ot_crispr_validation", lazy(() => import("sections/src/evidence/OTValidation/Body"))],
   ["uniprot_literature", lazy(() => import("sections/src/evidence/UniProtLiterature/Body"))],
   ["uniprot_variants", lazy(() => import("sections/src/evidence/UniProtVariants/Body"))],
+  ["gwas_credible_sets", lazy(() => import("sections/src/evidence/GWASCredibleSets/Body"))],
 ]);
 
 export default evidenceSections;

--- a/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
@@ -1,0 +1,276 @@
+import { useQuery } from "@apollo/client";
+import { Typography } from "@mui/material";
+import {
+  SectionItem,
+  Link,
+  PublicationsDrawer,
+  LabelChip,
+  OtTable,
+  ScientificNotation,
+  DirectionOfEffectTooltip,
+  DirectionOfEffectIcon,
+} from "ui";
+
+import {
+  defaultRowsPerPageOptions,
+  naLabel,
+  sectionsBaseSizeQuery,
+  studySourceMap,
+  variantConsequenceSource,
+} from "../../constants";
+import { definition } from ".";
+import Description from "./Description";
+import { dataTypesMap } from "../../dataTypes";
+import OPEN_TARGETS_GENETICS_QUERY from "./sectionQuery.gql";
+import { otgStudyUrl, otgVariantUrl } from "../../utils/urls";
+import { identifiersOrgLink, sentenceCase } from "../../utils/global";
+
+function getColumns(label) {
+  return [
+    {
+      id: "disease",
+      label: "Disease/phenotype",
+      renderCell: ({ disease }) => <Link to={`/disease/${disease.id}`}>{disease.name}</Link>,
+      filterValue: ({ disease }) => disease.name,
+    },
+    {
+      id: "diseaseFromSource",
+      label: "Reported disease/phenotype",
+      renderCell: ({ diseaseFromSource, studyId }) => {
+        const parsedDiseaseFromSource = diseaseFromSource.replace(/['"]+/g, "");
+        return (
+          <Link external to={otgStudyUrl(studyId)}>
+            {diseaseFromSource ? parsedDiseaseFromSource : studyId}
+          </Link>
+        );
+      },
+    },
+    {
+      id: "literature",
+      label: "Publication",
+      renderCell: ({ literature, publicationYear, publicationFirstAuthor }) => {
+        if (!literature) return naLabel;
+        return (
+          <PublicationsDrawer
+            entries={[{ name: literature[0] }]}
+            customLabel={`${publicationFirstAuthor} et al, ${publicationYear}`}
+            symbol={label.symbol}
+            name={label.name}
+          />
+        );
+      },
+      filterValue: ({ literature, publicationYear, publicationFirstAuthor }) =>
+        `${literature} ${publicationYear} ${publicationFirstAuthor}`,
+    },
+    {
+      id: "studySource",
+      label: "Study source",
+      renderCell: ({ projectId }) => {
+        if (!projectId) return naLabel;
+        if (Object.keys(studySourceMap).indexOf(projectId) < 0) return naLabel;
+        return studySourceMap[projectId];
+      },
+      filterValue: ({ projectId }) => {
+        if (!projectId) return naLabel;
+        if (Object.keys(studySourceMap).indexOf(projectId) < 0) return naLabel;
+        return studySourceMap[projectId];
+      },
+    },
+    {
+      id: "variantId",
+      label: "Variant ID (RSID)",
+      renderCell: ({ variantId, variantRsId }) => (
+        <>
+          {variantId ? (
+            <Link external to={otgVariantUrl(variantId)}>
+              {variantId}
+            </Link>
+          ) : (
+            naLabel
+          )}
+          {variantRsId ? (
+            <Typography variant="caption">
+              {" "}
+              (
+              <Link
+                external
+                to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+              >
+                {variantRsId}
+              </Link>
+              )
+            </Typography>
+          ) : null}
+        </>
+      ),
+      filterValue: ({ variantId, variantRsId }) => `${variantId} ${variantRsId}`,
+    },
+    {
+      id: "variantConsequence",
+      label: "Variant Consequence",
+      renderCell: ({
+        variantFunctionalConsequence,
+        variantFunctionalConsequenceFromQtlId,
+        variantId,
+      }) => {
+        const pvparams = variantId?.split("_") || [];
+        return (
+          <div style={{ display: "flex", gap: "5px" }}>
+            {variantFunctionalConsequence && (
+              <LabelChip
+                label={variantConsequenceSource.VEP.label}
+                value={sentenceCase(variantFunctionalConsequence.label)}
+                tooltip={variantConsequenceSource.VEP.tooltip}
+                to={identifiersOrgLink("SO", variantFunctionalConsequence.id.slice(3))}
+              />
+            )}
+            {variantFunctionalConsequenceFromQtlId && (
+              <LabelChip
+                label={variantConsequenceSource.QTL.label}
+                value={sentenceCase(variantFunctionalConsequenceFromQtlId.label)}
+                to={identifiersOrgLink("SO", variantFunctionalConsequenceFromQtlId.id.slice(3))}
+                tooltip={variantConsequenceSource.QTL.tooltip}
+              />
+            )}
+            {(variantFunctionalConsequence.id === "SO:0001583" ||
+              variantFunctionalConsequence.id === "SO:0001587") && (
+              <LabelChip
+                label={variantConsequenceSource.ProtVar.label}
+                to={`https://www.ebi.ac.uk/ProtVar/query?chromosome=${pvparams[0]}&genomic_position=${pvparams[1]}&reference_allele=${pvparams[2]}&alternative_allele=${pvparams[3]}`}
+                tooltip={variantConsequenceSource.ProtVar.tooltip}
+              />
+            )}
+          </div>
+        );
+      },
+    },
+    {
+      id: "directionOfVariantEffect",
+      label: (
+        <DirectionOfEffectTooltip docsUrl="https://platform-docs.opentargets.org/evidence#open-targets-genetics"></DirectionOfEffectTooltip>
+      ),
+      renderCell: ({ variantEffect, directionOnTrait }) => {
+        return (
+          <DirectionOfEffectIcon
+            variantEffect={variantEffect}
+            directionOnTrait={directionOnTrait}
+          />
+        );
+      },
+
+      // TODO: find a way to access getTooltipText function from DirectionOfEffectIcon.tsx
+      filterValue: ({ variantEffect, directionOnTrait }) => {},
+    },
+    {
+      id: "pValueMantissa",
+      label: (
+        <>
+          Association <i>p</i>-value
+        </>
+      ),
+      numeric: true,
+      sortable: true,
+      renderCell: ({ pValueMantissa, pValueExponent }) => (
+        <ScientificNotation number={[pValueMantissa, pValueExponent]} />
+      ),
+      comparator: (a, b) =>
+        a.pValueMantissa * 10 ** a.pValueExponent - b.pValueMantissa * 10 ** b.pValueExponent,
+    },
+    {
+      id: "studySampleSize",
+      label: "Sample size",
+      numeric: true,
+      sortable: true,
+      renderCell: ({ studySampleSize }) =>
+        studySampleSize ? parseInt(studySampleSize, 10).toLocaleString() : naLabel,
+    },
+    {
+      id: "oddsRatio",
+      label: "Odds Ratio (CI 95%)",
+      numeric: true,
+      renderCell: ({
+        oddsRatio,
+        oddsRatioConfidenceIntervalLower,
+        oddsRatioConfidenceIntervalUpper,
+      }) => {
+        const ci =
+          oddsRatioConfidenceIntervalLower && oddsRatioConfidenceIntervalUpper
+            ? `(${parseFloat(oddsRatioConfidenceIntervalLower.toFixed(3))}, ${parseFloat(
+                oddsRatioConfidenceIntervalUpper.toFixed(3)
+              )})`
+            : "";
+        return oddsRatio ? `${parseFloat(oddsRatio.toFixed(3))} ${ci}` : naLabel;
+      },
+    },
+    {
+      id: "betaConfidenceInterval",
+      label: "Beta (CI 95%)",
+      numeric: true,
+      renderCell: ({ beta, betaConfidenceIntervalLower, betaConfidenceIntervalUpper }) => {
+        const ci =
+          betaConfidenceIntervalLower && betaConfidenceIntervalUpper
+            ? `(${parseFloat(betaConfidenceIntervalLower.toFixed(3))}, ${parseFloat(
+                betaConfidenceIntervalUpper.toFixed(3)
+              )})`
+            : "";
+        return beta ? `${parseFloat(beta.toFixed(3))} ${ci}` : naLabel;
+      },
+    },
+    {
+      id: "resourceScore",
+      label: "L2G score",
+      tooltip: (
+        <>
+          Causal inference score - see{" "}
+          <Link
+            external
+            to="https://platform-docs.opentargets.org/evidence#open-targets-genetics-portal"
+          >
+            our documentation
+          </Link>{" "}
+          for more information.
+        </>
+      ),
+      numeric: true,
+      sortable: true,
+      renderCell: ({ resourceScore }) => parseFloat(resourceScore?.toFixed(5)),
+    },
+  ];
+}
+
+function Body({ id, label, entity }) {
+  const { ensgId, efoId } = id;
+  const variables = { ensemblId: ensgId, efoId, size: sectionsBaseSizeQuery };
+
+  const columns = getColumns(label);
+
+  const request = useQuery(OPEN_TARGETS_GENETICS_QUERY, {
+    variables,
+  });
+
+  return (
+    <SectionItem
+      definition={definition}
+      chipText={dataTypesMap.genetic_association}
+      request={request}
+      entity={entity}
+      renderDescription={() => <Description symbol={label.symbol} name={label.name} />}
+      renderBody={() => (
+        <OtTable
+          columns={columns}
+          dataDownloader
+          dataDownloaderFileStem={`otgenetics-${ensgId}-${efoId}`}
+          order="desc"
+          rows={request.data?.disease.openTargetsGenetics.rows}
+          showGlobalFilter
+          sortBy="resourceScore"
+          query={OPEN_TARGETS_GENETICS_QUERY.loc.source.body}
+          variables={variables}
+          loading={request.loading}
+        />
+      )}
+    />
+  );
+}
+
+export default Body;

--- a/packages/sections/src/evidence/GWASCredibleSets/Description.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Description.jsx
@@ -1,0 +1,16 @@
+import { Link } from "ui";
+import config from "../../config";
+
+function Description({ symbol, name }) {
+  return (
+    <>
+      Genome-wide associated loci prioritisating <strong>{symbol}</strong> as likely causal gene for{" "}
+      <strong>{name}</strong>. Source:{" "}
+      <Link to={config.geneticsPortalUrl} external>
+        Open Targets Genetics
+      </Link>
+    </>
+  );
+}
+
+export default Description;

--- a/packages/sections/src/evidence/GWASCredibleSets/GWASCredibleSetsSummary.gql
+++ b/packages/sections/src/evidence/GWASCredibleSets/GWASCredibleSetsSummary.gql
@@ -1,0 +1,10 @@
+fragment GWASCredibleSetsSummaryFragment on Disease {
+  openTargetsGenetics: evidences(
+    ensemblIds: [$ensgId]
+    enableIndirect: true
+    datasourceIds: ["gwas_credible_sets"]
+    size: 0
+  ) {
+    count
+  }
+}

--- a/packages/sections/src/evidence/GWASCredibleSets/Summary.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Summary.jsx
@@ -1,0 +1,28 @@
+import { SummaryItem, usePlatformApi } from "ui";
+
+import { definition } from ".";
+import { dataTypesMap } from "../../dataTypes";
+import GWAS_CREDIBLE_SETS_SUMMARY_FRAGMENT from "./GWASCredibleSetsSummary.gql";
+
+function Summary() {
+  const request = usePlatformApi(GWAS_CREDIBLE_SETS_SUMMARY_FRAGMENT);
+
+  return (
+    <SummaryItem
+      definition={definition}
+      request={request}
+      renderSummary={data =>
+        `${data.openTargetsGenetics.count} entr${
+          data.openTargetsGenetics.count === 1 ? "y" : "ies"
+        }`
+      }
+      subText={dataTypesMap.genetic_association}
+    />
+  );
+}
+
+Summary.fragments = {
+  OpenTargetsGeneticsSummaryFragment: GWAS_CREDIBLE_SETS_SUMMARY_FRAGMENT,
+};
+
+export default Summary;

--- a/packages/sections/src/evidence/GWASCredibleSets/index.js
+++ b/packages/sections/src/evidence/GWASCredibleSets/index.js
@@ -1,0 +1,10 @@
+import { isPrivateEvidenceSection } from "../../utils/partnerPreviewUtils";
+
+const id = "gwas_credible_sets";
+export const definition = {
+  id,
+  name: "GWAS credible sets",
+  shortName: "GC",
+  hasData: data => data.openTargetsGenetics.count > 0,
+  isPrivate: isPrivateEvidenceSection(id),
+};

--- a/packages/sections/src/evidence/GWASCredibleSets/sectionQuery.gql
+++ b/packages/sections/src/evidence/GWASCredibleSets/sectionQuery.gql
@@ -1,0 +1,52 @@
+query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
+  target(ensemblId: $ensemblId) {
+    approvedSymbol
+  }
+  disease(efoId: $efoId) {
+    id
+    name
+    openTargetsGenetics: evidences(
+      ensemblIds: [$ensemblId]
+      enableIndirect: true
+      datasourceIds: ["ot_genetics_portal"]
+      size: $size
+    ) {
+      count
+      rows {
+        id
+        disease {
+          id
+          name
+        }
+        variantEffect
+        directionOnTrait
+        diseaseFromSource
+        studyId
+        studySampleSize
+        variantId
+        variantRsId
+        literature
+        publicationYear
+        publicationFirstAuthor
+        pValueExponent
+        pValueMantissa
+        oddsRatio
+        oddsRatioConfidenceIntervalLower
+        oddsRatioConfidenceIntervalUpper
+        beta
+        betaConfidenceIntervalLower
+        betaConfidenceIntervalUpper
+        variantFunctionalConsequence {
+          id
+          label
+        }
+        variantFunctionalConsequenceFromQtlId {
+          id
+          label
+        }
+        resourceScore
+        projectId
+      }
+    }
+  }
+}


### PR DESCRIPTION
# [Platform]: add create GWAS credible sets to AotF and base widget

## Description

**Issue:** (link)
**Deploy preview:** (link)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
- Check AotF

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x]  I have made corresponding changes to the documentation
