### PR TITLE
[Platform]: Use l2Gpredictions instead of strongestLocus2Gene in study page

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -74,28 +74,29 @@ const columns = [
     label: "Finemapping method",
   },
   {
-    id: "topL2G",
+    id: "TopL2G",
     label: "Top L2G",
     tooltip: "Top gene prioritised by our locus-to-gene model",
-    filterValue: ({ strongestLocus2gene }) => strongestLocus2gene?.target.approvedSymbol,
-    renderCell: ({ strongestLocus2gene }) => {
-      if (!strongestLocus2gene?.target) return naLabel;
-      const { target } = strongestLocus2gene;
+    filterValue: ({ l2Gpredictions }) => l2Gpredictions?.[0]?.target.approvedSymbol,
+    renderCell: ({ l2Gpredictions }) => {
+      const { target } = l2Gpredictions?.[0];
+      if (!target) return naLabel;
       return <Link to={`/target/${target.id}`}>{target.approvedSymbol}</Link>;
     },
-    exportValue: ({ strongestLocus2gene }) => strongestLocus2gene?.target.approvedSymbol,
+    exportValue: ({ l2Gpredictions }) => l2Gpredictions?.[0]?.target.approvedSymbol,
   },
   {
     id: "l2gScore",
     label: "L2G score",
-    comparator: (rowA, rowB) => rowA?.strongestLocus2gene?.score - rowB?.strongestLocus2gene?.score,
+    comparator: (rowA, rowB) => rowA?.l2Gpredictions?.[0]?.score - rowB?.l2Gpredictions?.[0]?.score,
     sortable: true,
     filterValue: false,
-    renderCell: ({ strongestLocus2gene }) => {
-      if (typeof strongestLocus2gene?.score !== "number") return naLabel;
-      return strongestLocus2gene.score.toFixed(3);
+    renderCell: ({ l2Gpredictions }) => {
+      const { score } = l2Gpredictions?.[0];
+      if (typeof score !== "number") return naLabel;
+      return score.toFixed(3);
     },
-    exportValue: ({ strongestLocus2gene }) => strongestLocus2gene?.score,
+    exportValue: ({ l2Gpredictions }) => l2Gpredictions?.[0]?.score,
   },
   {
     id: "credibleSetSize",

--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -17,8 +17,8 @@ query GWASCredibleSetsQuery($studyId: String!) {
         is95CredibleSet
       }
       finemappingMethod
-      strongestLocus2gene {
-        target {
+      l2Gpredictions(size: 1) {
+        target{
           id
           approvedSymbol
         }


### PR DESCRIPTION
## Description

Use first entry of `l2Gpredictions` for top L2G (instead of `strongestLocus2Gene`) in GWAS credible sets widget on study page.

**Issue:** [#3616](https://github.com/opentargets/issues/issues/3616)
**Deploy preview:**

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
