### PR TITLE
[Platform] Limit minimum p-value in Manhattan plots

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -22,7 +22,7 @@ import { ScientificNotation } from "ui";
 import { naLabel } from "../../constants";
 
 export default function ManhattanPlot({ loading, data }) {
-  
+
   const plotHeight = 390;
   const theme = useTheme();
   const background = theme.palette.background.paper;
@@ -36,8 +36,8 @@ export default function ManhattanPlot({ loading, data }) {
   // eslint-disable-next-line
   data = data.filter(d => {
     return d.pValueMantissa != null &&
-           d.pValueExponent != null &&
-           d.variant != null;
+      d.pValueExponent != null &&
+      d.variant != null;
   });
   if (data.length === 0) return null;
 
@@ -53,7 +53,7 @@ export default function ManhattanPlot({ loading, data }) {
     const x = genomePositions[row.variant.id];
     return x < genomeLength / 2 ? 'left' : 'right';
   }
-  
+
   function yAnchor(row) {
     const y = pValue(row);
     return Math.log10(y) > Math.log10(pValueMin) / 2 ? 'bottom' : 'top';
@@ -87,7 +87,7 @@ export default function ManhattanPlot({ loading, data }) {
           format={(_, i, __, tickData) => tickData[i].chromosome}
           padding={5}
         />
-        <XGrid 
+        <XGrid
           values={tickData => tickData.map(chromo => chromo.end)}
           stroke="#cecece"
           strokeDasharray="3 4"
@@ -208,17 +208,17 @@ function Tooltip({ data }) {
             {data.beta?.toFixed(3) ?? naLabel}
           </TooltipRow>
           <TooltipRow label="Finemapping">
-          {data.finemappingMethod ?? naLabel}
+            {data.finemappingMethod ?? naLabel}
           </TooltipRow>
           {data.l2Gpredictions?.[0].target
             ? <TooltipRow label="Top L2G">
-                <Link to={`/target/${data.l2Gpredictions?.[0].target.id}`}>
-                  {data.l2Gpredictions?.[0].target.approvedSymbol}
-                </Link>
-              </TooltipRow>
+              <Link to={`/target/${data.l2Gpredictions?.[0].target.id}`}>
+                {data.l2Gpredictions?.[0].target.approvedSymbol}
+              </Link>
+            </TooltipRow>
             : <TooltipRow label="Top L2G">
-                {naLabel}
-              </TooltipRow>
+              {naLabel}
+            </TooltipRow>
           }
           <TooltipRow label="L2G score">
             {data.l2Gpredictions?.[0].score.toFixed(3)}
@@ -241,7 +241,7 @@ function TooltipRow({ children, label }) {
         </Typography>
       </td>
       <td>
-        <Typography variant="body2"  style={{ lineHeight: 1.35 }}>
+        <Typography variant="body2" style={{ lineHeight: 1.35 }}>
           {children}
         </Typography>
       </td>
@@ -250,40 +250,43 @@ function TooltipRow({ children, label }) {
 }
 
 function pValue(row) {
-  return row.pValueMantissa * 10 ** row.pValueExponent;
+  return Math.max(
+    row.pValueMantissa * 10 ** row.pValueExponent,
+    Number.MIN_VALUE
+  );
 }
 
 // from: https://www.ncbi.nlm.nih.gov/grc/human/data
 // (first tab: "Chromosome lengths")
 const chromosomeInfo = [
-  { chromosome: '1',  length: 248956422 },
-  { chromosome: '2',	length: 242193529 },
-  { chromosome: '3',	length: 198295559 },
-  { chromosome: '4',	length: 190214555 },
-  { chromosome: '5',	length: 181538259 },
-  { chromosome: '6',	length: 170805979 },
-  { chromosome: '7',	length: 159345973 },
-  { chromosome: '8',	length: 145138636 },
-  { chromosome: '9',  length: 138394717 },
-  { chromosome: '10',	length: 133797422 },
-  { chromosome: '11',	length: 135086622 },
-  { chromosome: '12',	length: 133275309 },
-  { chromosome: '13',	length: 114364328 },
-  { chromosome: '14',	length: 107043718 },
-  { chromosome: '15',	length: 101991189 },
-  { chromosome: '16',	length: 90338345  },
-  { chromosome: '17',	length: 83257441  },
-  { chromosome: '18',	length: 80373285  },
-  { chromosome: '19',	length: 58617616  },
-  { chromosome: '20',	length: 64444167  },
-  { chromosome: '21',	length: 46709983  },
-  { chromosome: '22',	length: 50818468  },
-  { chromosome: 'X',	length: 156040895 },
-  { chromosome: 'Y',  length: 57227415  },
+  { chromosome: '1', length: 248956422 },
+  { chromosome: '2', length: 242193529 },
+  { chromosome: '3', length: 198295559 },
+  { chromosome: '4', length: 190214555 },
+  { chromosome: '5', length: 181538259 },
+  { chromosome: '6', length: 170805979 },
+  { chromosome: '7', length: 159345973 },
+  { chromosome: '8', length: 145138636 },
+  { chromosome: '9', length: 138394717 },
+  { chromosome: '10', length: 133797422 },
+  { chromosome: '11', length: 135086622 },
+  { chromosome: '12', length: 133275309 },
+  { chromosome: '13', length: 114364328 },
+  { chromosome: '14', length: 107043718 },
+  { chromosome: '15', length: 101991189 },
+  { chromosome: '16', length: 90338345 },
+  { chromosome: '17', length: 83257441 },
+  { chromosome: '18', length: 80373285 },
+  { chromosome: '19', length: 58617616 },
+  { chromosome: '20', length: 64444167 },
+  { chromosome: '21', length: 46709983 },
+  { chromosome: '22', length: 50818468 },
+  { chromosome: 'X', length: 156040895 },
+  { chromosome: 'Y', length: 57227415 },
 ];
 
 chromosomeInfo.forEach((chromo, i) => {
-  chromo.start = chromosomeInfo[i-1]?.end ?? 0;
+  chromo.start = chromosomeInfo[i - 1]?.end ?? 0;
   chromo.end = chromo.start + chromo.length;
   chromo.midpoint = (chromo.start + chromo.end) / 2;
 });
@@ -291,7 +294,7 @@ chromosomeInfo.forEach((chromo, i) => {
 const genomeLength = chromosomeInfo.at(-1).end;
 
 const chromosomeInfoMap = new Map(
-  chromosomeInfo.map(obj => [ obj.chromosome, obj ])
+  chromosomeInfo.map(obj => [obj.chromosome, obj])
 );
 
 function cumulativePosition({ chromosome, position }) {

--- a/packages/ui/src/components/Plot/components/marks/Circle.jsx
+++ b/packages/ui/src/components/Plot/components/marks/Circle.jsx
@@ -1,12 +1,12 @@
 import Mark from "./Mark";
 
 export default function Circle({
-      data,
-      dataFrom,
-      missing = 'throw',
-      hover,
-      ...accessors
-    }) {
+  data,
+  dataFrom,
+  missing = 'throw',
+  hover,
+  ...accessors
+}) {
 
   const markChannels = [
     'x',
@@ -25,7 +25,7 @@ export default function Circle({
   ];
 
   const tagName = 'circle';
-  
+
   function createAttrs(row) {
     const attrs = {
       cx: row.x + row.dx,
@@ -42,7 +42,7 @@ export default function Circle({
     if (row.pointerEvents) attrs.pointerEvents = row.pointerEvents;
     return attrs;
   }
-  
+
   return <Mark {...{
     data,
     dataFrom,

--- a/packages/ui/src/components/Plot/components/marks/StandardMark.jsx
+++ b/packages/ui/src/components/Plot/components/marks/StandardMark.jsx
@@ -13,15 +13,15 @@ import { rowValues } from "../../util/rowValues";
 import DynamicTag from "../util/DynamicTag";
 
 export default memo(function StandardMark({
-      data,
-      missing,
-      hover,
-      accessors,
-      markChannels,
-      tagName,
-      createAttrs,
-      createContent,
-    }) {
+  data,
+  missing,
+  hover,
+  accessors,
+  markChannels,
+  tagName,
+  createAttrs,
+  createContent,
+}) {
 
   const visUpdateSelection = useVisUpdateSelection();
   const visClearSelection = useVisClearSelection();
@@ -33,7 +33,7 @@ export default memo(function StandardMark({
   if (!plot) {
     throw Error("mark components must appear inside a Plot component");
   }
-  
+
   const frame = useFrame();
   const ops = fromFrameOrPlot(['data', 'scales', 'mapX', 'mapY'], frame, plot);
   const { scales, mapX, mapY } = ops;
@@ -68,7 +68,7 @@ export default memo(function StandardMark({
 
     if (row != null) {
       const attrs = createAttrs(row);
-      
+
       if (hover) {
         attrs.onMouseEnter = () => visUpdateSelection('hover', [d]);
         if (hover !== 'stay') {

--- a/packages/ui/src/components/Plot/util/processAccessors.js
+++ b/packages/ui/src/components/Plot/util/processAccessors.js
@@ -6,17 +6,17 @@ import { scaleValue } from "./scaleValue";
 const autoScaleChannels = new Set(['x', 'xx', 'width', 'y', 'yy', 'height']);
 
 export function processAccessors({
-      markChannels,
-      accessors,
-      scales,
-      mapX,
-      mapY,
-    }) {
+  markChannels,
+  accessors,
+  scales,
+  mapX,
+  mapY,
+}) {
 
-  const newAccessors = new Map();    
+  const newAccessors = new Map();
 
   for (const channel of markChannels) {
-    
+
     const acc = accessors[channel];
 
     // channel omitted - use default value or ignore channel
@@ -25,11 +25,11 @@ export function processAccessors({
       if (value != null) {
         newAccessors.set(channel, value);
       }
-    
-    // constant channel  
+
+      // constant channel  
     } else if (typeof acc === 'object' ||
-               typeof acc === 'number' ||
-               typeof acc === 'string') {
+      typeof acc === 'number' ||
+      typeof acc === 'string') {
       let input, output;
       if (typeof acc === 'object') {
         ({ input, output } = acc);
@@ -41,9 +41,9 @@ export function processAccessors({
         if (!scaleChannels.has(channel)) {
           throw Error(`cannot use an 'input constant' for ${channel} channel`);
         }
-        value = scaleValue({ input, channel, scales, mapX, mapY});
+        value = scaleValue({ input, channel, scales, mapX, mapY });
       }
-      noInfiniteOrNaN(value);
+      noInfiniteOrNaN(value, channel);
       if (value == null) {
         value = channelDefaults[channel];
       }
@@ -51,12 +51,12 @@ export function processAccessors({
         newAccessors.set(channel, value);
       }
 
-    // dynamic channel
+      // dynamic channel`
     } else if (typeof acc === 'function') {
       newAccessors.set(channel, acc);
 
-    // invalid accessor
-    } else {  
+      // invalid accessor
+    } else {
       throw Error(`invalid accessor (channel: ${channel})`);
     }
 

--- a/packages/ui/src/components/Plot/util/rowValues.js
+++ b/packages/ui/src/components/Plot/util/rowValues.js
@@ -2,14 +2,14 @@ import { scaleValue } from "./scaleValue";
 import { noInfiniteOrNaN } from "./assert";
 
 export function rowValues({
-      rowIndex,
-      rowData,
-      missing,
-      finalAccessors,
-      scales,
-      mapX,
-      mapY,
-    }) {
+  rowIndex,
+  rowData,
+  missing,
+  finalAccessors,
+  scales,
+  mapX,
+  mapY,
+}) {
 
   const values = {};
 


### PR DESCRIPTION
## Description

Limit p-values in Manhattan plot to JavaScript's `Number.MIN_VALUE`.

**Issue:** [#3502](https://github.com/opentargets/issues/issues/3502)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on study page.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
