### PR TITLE
[Platform] Missing data fixes in Manhattan plot tooltip

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -210,10 +210,10 @@ function Tooltip({ data }) {
           <TooltipRow label="Finemapping">
             {data.finemappingMethod ?? naLabel}
           </TooltipRow>
-          {data.l2Gpredictions?.[0].target
+          {data.l2Gpredictions?.[0]?.target
             ? <TooltipRow label="Top L2G">
-              <Link to={`/target/${data.l2Gpredictions?.[0].target.id}`}>
-                {data.l2Gpredictions?.[0].target.approvedSymbol}
+              <Link to={`/target/${data.l2Gpredictions[0].target.id}`}>
+                {data.l2Gpredictions[0].target.approvedSymbol}
               </Link>
             </TooltipRow>
             : <TooltipRow label="Top L2G">
@@ -221,7 +221,10 @@ function Tooltip({ data }) {
             </TooltipRow>
           }
           <TooltipRow label="L2G score">
-            {data.l2Gpredictions?.[0].score.toFixed(3)}
+            {data.l2Gpredictions?.[0]?.score != null
+              ? data.l2Gpredictions[0].score.toFixed(3)
+              : naLabel
+            }
           </TooltipRow>
           <TooltipRow label="Credible set size">
             {data.locus?.length ?? naLabel}


### PR DESCRIPTION
## Description

Plot was not correctly handling missing L2G in tooltip.

**Issue:** [#3502](https://github.com/opentargets/issues/issues/3502)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on study page.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
