### PR TITLE
[Platform]: Update study page to reflect API changes

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -108,11 +108,11 @@ const columns = [
   {
     id: "credibleSetSize",
     label: "Credible set size",
-    comparator: (a, b) => a.locus?.length - b.locus?.length,
+    comparator: (a, b) => a.locus?.count - b.locus?.count,
     sortable: true,
     filterValue: false,
-    renderCell: ({ locus }) => locus?.length ?? naLabel,
-    exportValue: ({ locus }) => locus?.length,
+    renderCell: ({ locus }) => locus?.count ?? naLabel,
+    exportValue: ({ locus }) => locus?.count,
   },
 ];
 
@@ -140,7 +140,7 @@ function Body({ id, entity }: BodyProps) {
         <>
           <ManhattanPlot
             loading={request.loading}
-            data={request.data?.gwasStudy[0].credibleSets}
+            data={request.data?.gwasStudy[0].credibleSets.rows}
           />
           <OtTable
             dataDownloader
@@ -148,7 +148,7 @@ function Body({ id, entity }: BodyProps) {
             sortBy="pValue"
             loading={request.loading}
             columns={columns}
-            rows={request.data?.gwasStudy[0].credibleSets}
+            rows={request.data?.gwasStudy[0].credibleSets.rows}
             query={GWAS_CREDIBLE_SETS_QUERY.loc.source.body}
             variables={variables}
           />

--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -2,27 +2,30 @@ query GWASCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
     credibleSets(page: { size: 2000, index: 0 }) {
-      studyLocusId
-      variant {
-        id
-        chromosome
-        position
-        referenceAllele
-        alternateAllele
-      }
-      pValueMantissa
-      pValueExponent
-      beta
-      locus {
-        is95CredibleSet
-      }
-      finemappingMethod
-      l2Gpredictions(size: 1) {
-        target{
+      count
+      rows {
+        studyLocusId
+        variant {
           id
-          approvedSymbol
+          chromosome
+          position
+          referenceAllele
+          alternateAllele
         }
-        score
+        pValueMantissa
+        pValueExponent
+        beta
+        locus {
+          count
+        }
+        finemappingMethod
+        l2Gpredictions(size: 1) {
+          target{
+            id
+            approvedSymbol
+          }
+          score
+        }
       }
     }
   }

--- a/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/study/GWASCredibleSets/GWASCredibleSetsSummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment GWASCredibleSetsSummaryFragment on Gwas {
   gwasCredibleSets: credibleSets(page: { size: 1, index: 0 }) {
-    beta
+    count
   }
 }

--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -224,7 +224,7 @@ function Tooltip({ data }) {
             {data.l2Gpredictions?.[0].score.toFixed(3)}
           </TooltipRow>
           <TooltipRow label="Credible set size">
-            {data.locus?.length ?? naLabel}
+            {data.locus?.count ?? naLabel}
           </TooltipRow>
         </tbody>
       </table>

--- a/packages/sections/src/study/GWASCredibleSets/index.ts
+++ b/packages/sections/src/study/GWASCredibleSets/index.ts
@@ -3,6 +3,6 @@ export const definition = {
   id,
   name: "GWAS Credible Sets",
   shortName: "GW",
-  hasData: data => data?.[0]?.gwasCredibleSets?.length > 0 ||
-                   data?.[0]?.credibleSets?.length > 0,
+  hasData: data => data?.[0]?.gwasCredibleSets?.count > 0 ||
+    data?.[0]?.credibleSets?.count > 0,
 };

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -75,11 +75,11 @@ const columns = [
   {
     id: "credibleSetSize",
     label: "Credible set size",
-    comparator: (a, b) => a.locus?.length - b.locus?.length,
+    comparator: (a, b) => a.locus?.count - b.locus?.count,
     sortable: true,
     filterValue: false,
-    renderCell: ({ locus }) => locus?.length ?? naLabel,
-    exportValue: ({ locus }) => locus?.length,
+    renderCell: ({ locus }) => locus?.count ?? naLabel,
+    exportValue: ({ locus }) => locus?.count,
   },
 ];
 
@@ -110,7 +110,7 @@ function Body({ id, entity }: BodyProps) {
           sortBy="pValue"
           columns={columns}
           loading={request.loading}
-          rows={request.data?.gwasStudy[0].credibleSets}
+          rows={request.data?.gwasStudy[0].credibleSets.rows}
           query={QTL_CREDIBLE_SETS_QUERY.loc.source.body}
           variables={variables}
         />

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -2,21 +2,24 @@ query QTLCredibleSetsQuery($studyId: String!) {
   gwasStudy(studyId: $studyId) {
     studyId
     credibleSets(page: { size: 2000, index: 0 }) {
-      studyLocusId
-      variant {
-        id
-        chromosome
-        position
-        referenceAllele
-        alternateAllele
+      count
+      rows {
+        studyLocusId
+        variant {
+          id
+          chromosome
+          position
+          referenceAllele
+          alternateAllele
+        }
+        pValueMantissa
+        pValueExponent
+        beta
+        locus {
+          count
+        }
+        finemappingMethod
       }
-      pValueMantissa
-      pValueExponent
-      beta
-      locus {
-        is95CredibleSet
-      }
-      finemappingMethod
     }
   }
 }

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,5 +1,5 @@
 fragment QTLCredibleSetsSummaryFragment on Gwas {
   qtlCredibleSets: credibleSets(page: { size: 1, index: 0 }) {
-    beta
+    count
   }
 }

--- a/packages/sections/src/study/QTLCredibleSets/index.ts
+++ b/packages/sections/src/study/QTLCredibleSets/index.ts
@@ -3,6 +3,6 @@ export const definition = {
   id,
   name: "molQTL Credible Sets",
   shortName: "QT",
-  hasData: data => data?.[0]?.qtlCredibleSets?.length > 0 ||
-                   data?.[0]?.credibleSets?.length > 0,
+  hasData: data => data?.[0]?.qtlCredibleSets?.count > 0 ||
+    data?.[0]?.credibleSets?.count > 0,
 };


### PR DESCRIPTION
## Description

Update study page to use `count` and `rows` for `CredibleSets` and `Loci` in the API.

**Issue:** (link)
**Deploy preview:** https://deploy-preview-546--ot-platform.netlify.app/study/GCST008338

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked study page, example study IDs:

- GWAS credible sets: GCST008338
- molQTL credible sets: Cytoimmgen_ge_combined_CD4_Memory_UNS_16H_ENSG00000232300

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
