### PR TITLE
fix:credible set listing all variants instead of only lead

### DIFF
--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -152,7 +152,6 @@ function Body({
 }: BodyProps) {
   const variables = {
     studyLocusId: studyLocusId,
-    variantIds: [leadVariantId],
   };
 
   const request = useQuery(VARIANTS_QUERY, {

--- a/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
+++ b/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
@@ -12,10 +12,6 @@ query VariantsQuery($studyLocusId: String!) {
           position
           referenceAllele
           alternateAllele
-          mostSevereConsequence {
-            id
-            label
-          }
         }
         pValueMantissa
         pValueExponent

--- a/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
+++ b/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
@@ -1,7 +1,7 @@
-query VariantsQuery($studyLocusId: String!, $variantIds: [String!]!) {
+query VariantsQuery($studyLocusId: String!) {
   credibleSet(studyLocusId: $studyLocusId) {
     studyLocusId
-    locus(variantIds: $variantIds) {
+    locus {
       count
       rows {
         logBF
@@ -12,6 +12,10 @@ query VariantsQuery($studyLocusId: String!, $variantIds: [String!]!) {
           position
           referenceAllele
           alternateAllele
+          mostSevereConsequence {
+            id
+            label
+          }
         }
         pValueMantissa
         pValueExponent


### PR DESCRIPTION
This widget accidentally only listed the lead variant instead of all variants in the credible set.
GraphQL query needed to be adjusted:

Dev:
![Screenshot 2024-11-22 at 16 02 10](https://github.com/user-attachments/assets/89497fb5-ac83-40d8-a629-db35db1a1de8)

This PR:
![Screenshot 2024-11-22 at 14 59 54](https://github.com/user-attachments/assets/3115719e-6d9f-4f66-a51e-38349f44e0e1)
