### PR TITLE
fix: handle null study locus id in colocalisation widgets

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Body.tsx
@@ -14,15 +14,14 @@ const columns = [
   {
     id: "otherStudyLocus.studyLocusId",
     label: "Navigate",
-    renderCell: ({ otherStudyLocus }) => (
-      <Box sx={{ display: "flex" }}>
+    renderCell: ({ otherStudyLocus }) => {
+      if (!otherStudyLocus?.variant) return naLabel;
+      return (<Box sx={{ display: "flex" }}>
         <Link to={`./${otherStudyLocus.studyLocusId}`}>
           <FontAwesomeIcon icon={faArrowRightToBracket} />
         </Link>
-      </Box>
-    ),
-    filterValue: false,
-    exportValue: false,
+      </Box>)
+    },
   },
   {
     id: "otherStudyLocus.study.studyId",

--- a/packages/sections/src/credibleSet/GWASMolQTL/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASMolQTL/Body.tsx
@@ -14,14 +14,14 @@ const columns = [
   {
     id: "otherStudyLocus.studyLocusId",
     label: "Navigate",
-    renderCell: ({ otherStudyLocus }) => (
-      <Box sx={{ display: "flex" }}>
+    renderCell: ({ otherStudyLocus }) => {
+      if (!otherStudyLocus?.variant) return naLabel;
+      return(<Box sx={{ display: "flex" }}>
         <Link to={`./${otherStudyLocus.studyLocusId}`}>
           <FontAwesomeIcon icon={faArrowRightToBracket} />
         </Link>
-      </Box>
-    ),
-    filterValue: false,
+      </Box>)
+    },
   },
   {
     id: "otherStudyLocus.study.studyId",


### PR DESCRIPTION
It's not an expected situation, but it prevents the UI crashing given the current issues with the API responses