### PR TITLE
fix: old genetics use variant object in query

### DIFF
--- a/packages/sections/src/evidence/OTGenetics/sectionQuery.gql
+++ b/packages/sections/src/evidence/OTGenetics/sectionQuery.gql
@@ -23,7 +23,9 @@ query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!
         diseaseFromSource
         studyId
         studySampleSize
-        variantId
+        variant {
+          id
+        }
         variantRsId
         literature
         publicationYear


### PR DESCRIPTION
Query was crashing due to recent updates in API. 