### PR TITLE
[Platform]: Replace unsafe destructuring assignments on study page

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -93,7 +93,7 @@ const columns = [
     tooltip: "Top gene prioritised by our locus-to-gene model",
     filterValue: ({ l2Gpredictions }) => l2Gpredictions?.[0]?.target.approvedSymbol,
     renderCell: ({ l2Gpredictions }) => {
-      const { target } = l2Gpredictions?.[0];
+      const target = l2Gpredictions?.[0]?.target;
       if (!target) return naLabel;
       return <Link to={`/target/${target.id}`}>{target.approvedSymbol}</Link>;
     },
@@ -106,7 +106,7 @@ const columns = [
     sortable: true,
     filterValue: false,
     renderCell: ({ l2Gpredictions }) => {
-      const { score } = l2Gpredictions?.[0];
+      const score = l2Gpredictions?.[0]?.score;
       if (typeof score !== "number") return naLabel;
       return score.toFixed(3);
     },


### PR DESCRIPTION
## Description

GWAS credible sets widget was failing when no L2G target or score.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on study page

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
