### PR TITLE
[Platform]: Add loading message to GWAS credible sets widget on study page

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -162,6 +162,8 @@ function Body({ id, entity }: BodyProps) {
       definition={definition}
       entity={entity}
       request={request}
+      showContentLoading
+      loadingMessage="Loading data. This may take some time..."
       renderDescription={() => <Description studyId={request.data?.gwasStudy[0].studyId} />}
       renderBody={() => (
         <>

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -8,6 +8,7 @@ import {
   ClinvarStars,
   OtScoreLinearBar,
   useBatchQuery,
+  SummaryLoader,
 } from "ui";
 import { Box, Chip } from "@mui/material";
 import { clinvarStarMap, initialResponse, naLabel, table5HChunkSize } from "../../constants";
@@ -271,6 +272,7 @@ function Body({ id, entity }: BodyProps) {
         );
       }}
       renderBody={() => {
+        if (request.loading) return <SummaryLoader />;
         return (
           <>
             <OtTable

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -8,7 +8,6 @@ import {
   ClinvarStars,
   OtScoreLinearBar,
   useBatchQuery,
-  SummaryLoader,
 } from "ui";
 import { Box, Chip } from "@mui/material";
 import { credsetConfidenceMap, initialResponse, naLabel, table5HChunkSize } from "../../constants";
@@ -257,6 +256,8 @@ function Body({ id, entity }: BodyProps) {
       definition={definition}
       entity={entity}
       request={request}
+      showContentLoading
+      loadingMessage="Loading data. This may take some time..."
       renderDescription={() => (
         <Description
           variantId={request.data?.variant.id}
@@ -274,7 +275,6 @@ function Body({ id, entity }: BodyProps) {
         );
       }}
       renderBody={() => {
-        if (request.loading) return <SummaryLoader />;
         return (
           <>
             <OtTable

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -239,6 +239,8 @@ function Body({ id, entity }: BodyProps): ReactNode {
       definition={definition}
       entity={entity}
       request={request}
+      showContentLoading
+      loadingMessage="Loading data. This may take some time..."
       renderDescription={() => (
         <Description
           variantId={request.data?.variant?.id}

--- a/packages/ui/src/components/PublicationsDrawer/SummaryLoader.jsx
+++ b/packages/ui/src/components/PublicationsDrawer/SummaryLoader.jsx
@@ -16,13 +16,13 @@ const LoadingContainer = styled("div")({
   textAlign: "center",
 });
 
-function SummaryLoader() {
+function SummaryLoader({ message = 'Summarising. This may take some time...' }) {
   return (
     <LoadingContainer>
       <StyledContainer>
         <CircularProgress color="inherit" />
       </StyledContainer>
-      Summarising. This may take some time...
+      {message}
     </LoadingContainer>
   );
 }

--- a/packages/ui/src/components/Section/SectionItem.tsx
+++ b/packages/ui/src/components/Section/SectionItem.tsx
@@ -10,6 +10,7 @@ import PartnerLockIcon from "../PartnerLockIcon";
 import SectionViewToggle from "./SectionViewToggle";
 import { ReactNode, useState } from "react";
 import { VIEW } from "../../constants";
+import { SummaryLoader } from "../PublicationsDrawer";
 
 type definitionType = {
   id: string;
@@ -32,6 +33,7 @@ type SectionItemProps = {
   showEmptySection: boolean;
   // check use
   showContentLoading: boolean;
+  loadingMessage: string;
   defaultView: string;
 };
 
@@ -44,6 +46,7 @@ function SectionItem({
   entity,
   showEmptySection = false,
   showContentLoading = false,
+  loadingMessage,
   renderChart,
   defaultView = VIEW.table,
 }: SectionItemProps): ReactNode {
@@ -110,7 +113,18 @@ function SectionItem({
                 <>
                   {error && <SectionError error={error} />}
                   {showContentLoading && loading && (
-                    <Skeleton sx={{ height: 390 }} variant="rectangular" />
+                    loadingMessage
+                      ? <Box
+                        width="100%"
+                        height={390}
+                        bgcolor={theme => theme.palette.grey[100]}
+                        display="flex"
+                        flexDirection="column"
+                        justifyContent="center"
+                      >
+                        <SummaryLoader message={loadingMessage} />
+                      </Box>
+                      : <Skeleton sx={{ height: 390 }} variant="rectangular" />
                   )}
                   {hasData && selectedView === VIEW.table && renderBody()}
                   {hasData && selectedView === VIEW.chart && renderChart()}


### PR DESCRIPTION
## Description

Add loading message to GWAS credible sets widget on study page.

Note: builds on PR [#566](https://github.com/opentargets/ot-ui-apps/pull/566)

Note: molQTL widget does not need batching or loading message.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on study page

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
