### PR TITLE
[Platform]: Batch load studies and use updated study api on disease page

### DIFF
--- a/apps/platform/src/pages/DiseasePage/Profile.jsx
+++ b/apps/platform/src/pages/DiseasePage/Profile.jsx
@@ -47,8 +47,8 @@ const DISEASE_PROFILE_QUERY = gql`
       ...DiseaseProfileHeaderFragment
       ...DiseaseProfileSummaryFragment
     }
-    gwasStudy(diseaseIds: [$efoId], page: { size: 1, index: 0}) {
-      studyId
+    studies(diseaseIds: [$efoId], page: { size: 1, index: 0}) {
+      count
     }
   }
   ${ProfileHeader.fragments.profileHeader}

--- a/packages/sections/src/disease/GWASStudies/Body.tsx
+++ b/packages/sections/src/disease/GWASStudies/Body.tsx
@@ -145,6 +145,8 @@ function Body({ id: efoId, label: diseaseName }: BodyProps) {
       definition={definition}
       entity="studies"
       pageEntity="disease"
+      showContentLoading
+      loadingMessage="Loading data. This may take some time..."
       request={request}
       renderDescription={() => <Description name={diseaseName} />}
       renderBody={() => (

--- a/packages/sections/src/disease/GWASStudies/GWASStudiesQuery.gql
+++ b/packages/sections/src/disease/GWASStudies/GWASStudiesQuery.gql
@@ -1,17 +1,20 @@
-query GWASStudiesQuery($diseaseIds: [String!]!, $size: Int!) {
-  gwasStudy(diseaseIds: $diseaseIds, page: { size: $size, index: 0 }) {
-    studyId
-    projectId
-    traitFromSource
-    publicationFirstAuthor
-    publicationDate
-    publicationJournal
-    nSamples
-    cohorts
-    pubmedId
-    ldPopulationStructure {
-      ldPopulation
-      relativeSampleSize
+query GWASStudiesQuery($diseaseIds: [String!]!, $size: Int!, $index: Int!) {
+  studies(diseaseIds: $diseaseIds, page: { size: $size, index: $index }) {
+    count
+    rows {
+      id
+      projectId
+      traitFromSource
+      publicationFirstAuthor
+      publicationDate
+      publicationJournal
+      nSamples
+      cohorts
+      pubmedId
+      ldPopulationStructure {
+        ldPopulation
+        relativeSampleSize
+      }
     }
   }
 }

--- a/packages/sections/src/disease/GWASStudies/index.ts
+++ b/packages/sections/src/disease/GWASStudies/index.ts
@@ -2,7 +2,7 @@ export const definition = {
   id: "GWASStudies",
   name: "GWAS Studies",
   shortName: "GS",
-  hasData: data => (console.log(data),
+  hasData: data => (
     data?.studies?.count > 0 ||  // summary
     data?.count > 0              // section
   ),

--- a/packages/sections/src/disease/GWASStudies/index.ts
+++ b/packages/sections/src/disease/GWASStudies/index.ts
@@ -2,8 +2,8 @@ export const definition = {
   id: "GWASStudies",
   name: "GWAS Studies",
   shortName: "GS",
-  hasData: data => (
-    data?.gwasStudy?.length > 0 ||  // summary
-    data?.length > 0                // section - argument is data.gwasStudy
+  hasData: data => (console.log(data),
+    data?.studies?.count > 0 ||  // summary
+    data?.count > 0              // section
   ),
 };


### PR DESCRIPTION
## Description

Batch load studies and use updated study api on disease page:

**Issue:** [#3611](https://github.com/opentargets/issues/issues/3611)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on disease page - e.g. `disease/EFO_0004346`

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
