### PR TITLE
[Platform]: add/harmonise l2g score tooltips

### DIFF
--- a/packages/sections/src/credibleSet/Locus2Gene/Body.tsx
+++ b/packages/sections/src/credibleSet/Locus2Gene/Body.tsx
@@ -26,8 +26,7 @@ const columns = [
     id: "score",
     label: "L2G score",
     sortable: true,
-    tooltip:
-      "Overall evidence linking a gene to this credible set using all features. Score range [0,1]",
+    tooltip: "Machine learning prediction linking a gene to a credible set using all features. Score range [0,1].",
     renderCell: ({ score }) => {
       if (!score) return naLabel;
       return (

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -118,6 +118,7 @@ const columns = [
     label: "L2G score",
     comparator: (rowA, rowB) => rowA?.l2Gpredictions[0]?.score - rowB?.l2Gpredictions[0]?.score,
     sortable: true,
+    tooltip: "Machine learning prediction linking a gene to a credible set using all features. Score range [0,1].",
     renderCell: ({ l2Gpredictions }) => {
       const score = l2Gpredictions?.[0]?.score;
       if (typeof score !== "number") return naLabel;

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -196,6 +196,7 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       label: "L2G score",
       comparator: (rowA, rowB) => rowA?.l2Gpredictions[0]?.score - rowB?.l2Gpredictions[0]?.score,
       sortable: true,
+      tooltip: "Machine learning prediction linking a gene to a credible set using all features. Score range [0,1].",
       renderCell: ({ l2Gpredictions }) => {
         if (!l2Gpredictions[0]?.score) return naLabel;
         return (


### PR DESCRIPTION
## Description

Add/harmonise l2g score tooltips in profile pages - leave tooltip in evidence as is.

**Issue:** [#3629](ithub.com/opentargets/issues/issues/3629)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked profile pages

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
