### PR TITLE
[Platform]: fix variant id displayed in old genetics widget

### DIFF
--- a/packages/sections/src/evidence/OTGenetics/Body.jsx
+++ b/packages/sections/src/evidence/OTGenetics/Body.jsx
@@ -79,11 +79,11 @@ function getColumns(label) {
     {
       id: "variantId",
       label: "Variant (RSID)",
-      renderCell: ({ variantId, variantRsId }) => (
+      renderCell: ({ variant, variantRsId }) => (
         <>
-          {variantId ? (
-            <Link external to={otgVariantUrl(variantId)}>
-              {variantId}
+          {variant ? (
+            <Link external to={otgVariantUrl(variant.id)}>
+              {variant.id}
             </Link>
           ) : (
             naLabel


### PR DESCRIPTION
At the moment it was displayed as N/A all the time.

Now it will show the variant ID. There is a corner case in which the variant ID from old genetics is not used in our new variant index. In this case, I confirmed the variant ID will display the N/A.