### PR TITLE
[Platform]: feat variant id and amino acid consequence in uniprot widget

### DIFF
--- a/packages/sections/src/evidence/UniProtVariants/Body.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Body.jsx
@@ -63,7 +63,7 @@ function getColumns(label) {
     },
     {
       id: "aminoAcidConsequence",
-      label: "Amino acid consequence",
+      label: "Amino acid",
       renderCell: ({ variant }) => {
         if (!variant) return naLabel;
         const aaConsequences = variant.transcriptConsequences?.filter(d => d.aminoAcidChange != null).map(d => d.aminoAcidChange);

--- a/packages/sections/src/evidence/UniProtVariants/Body.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Body.jsx
@@ -62,6 +62,18 @@ function getColumns(label) {
       },
     },
     {
+      id: "variantRsId",
+      label: "rsID",
+      renderCell: ({ variantRsId }) => (
+        <Link
+          external
+          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
+        >
+          {variantRsId}
+        </Link>
+      ),
+    },
+    {
       id: "aminoAcidConsequence",
       label: "Amino acid",
       renderCell: ({ variant }) => {

--- a/packages/sections/src/evidence/UniProtVariants/Body.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Body.jsx
@@ -57,24 +57,22 @@ function getColumns(label) {
       filterValue: ({ variant: v }) =>
         `${v?.chromosome}_${v?.position}_${v?.referenceAllele}_${v?.alternateAllele}`,
       renderCell: ({ variant }) => {
-        if (variant.id) return <Link to={`/variant/${variant.id}`}>{variant.id}</Link>;
+        if (variant) return <Link to={`/variant/${variant.id}`}>{variant.id}</Link>;
         return naLabel;
       },
-      exportValue: ({ variant }) => variant?.id,
     },
-
     {
       id: "aminoAcidConsequence",
       label: "Amino acid consequence",
-      renderCell: ({ variant: { transcriptConsequences } }) => {
-        if (!transcriptConsequences) return naLabel;
-        const aaConsequences = transcriptConsequences?.filter(d => d.aminoAcidChange != null).map(d => d.aminoAcidChange);
+      renderCell: ({ variant }) => {
+        if (!variant) return naLabel;
+        const aaConsequences = variant.transcriptConsequences?.filter(d => d.aminoAcidChange != null).map(d => d.aminoAcidChange);
         if (aaConsequences?.length) {
           return aaConsequences.join(", ");
         }
         return naLabel;
-      },
-    },
+      }
+    },        
     {
       id: "variantConsequence",
       label: "Variant Consequence",

--- a/packages/sections/src/evidence/UniProtVariants/Body.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Body.jsx
@@ -8,10 +8,12 @@ import Description from "./Description";
 import { epmcUrl } from "../../utils/urls";
 import { dataTypesMap } from "../../dataTypes";
 import { identifiersOrgLink } from "../../utils/global";
+import { variantComparator } from "../../utils/comparators";
 import {
   defaultRowsPerPageOptions,
   variantConsequenceSource,
   sectionsBaseSizeQuery,
+  naLabel,
 } from "../../constants";
 import UNIPROT_VARIANTS_QUERY from "./UniprotVariantsQuery.gql";
 
@@ -48,16 +50,30 @@ function getColumns(label) {
       ),
     },
     {
-      id: "variantRsId",
+      id: "variantId",
       label: "Variant",
-      renderCell: ({ variantRsId }) => (
-        <Link
-          external
-          to={`http://www.ensembl.org/Homo_sapiens/Variation/Explore?v=${variantRsId}`}
-        >
-          {variantRsId}
-        </Link>
-      ),
+      comparator: variantComparator,
+      sortable: true,
+      filterValue: ({ variant: v }) =>
+        `${v?.chromosome}_${v?.position}_${v?.referenceAllele}_${v?.alternateAllele}`,
+      renderCell: ({ variant }) => {
+        if (variant.id) return <Link to={`/variant/${variant.id}`}>{variant.id}</Link>;
+        return naLabel;
+      },
+      exportValue: ({ variant }) => variant?.id,
+    },
+
+    {
+      id: "aminoAcidConsequence",
+      label: "Amino acid consequence",
+      renderCell: ({ variant: { transcriptConsequences } }) => {
+        if (!transcriptConsequences) return naLabel;
+        const aaConsequences = transcriptConsequences?.filter(d => d.aminoAcidChange != null).map(d => d.aminoAcidChange);
+        if (aaConsequences?.length) {
+          return aaConsequences.join(", ");
+        }
+        return naLabel;
+      },
     },
     {
       id: "variantConsequence",

--- a/packages/sections/src/evidence/UniProtVariants/UniprotVariantsQuery.gql
+++ b/packages/sections/src/evidence/UniProtVariants/UniprotVariantsQuery.gql
@@ -18,6 +18,16 @@ query UniprotVariantsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
         }
         diseaseFromSource
         targetFromSourceId
+        variant {
+          id
+          chromosome
+          position
+          referenceAllele
+          alternateAllele
+          transcriptConsequences {
+            aminoAcidChange
+          }
+        }
         variantRsId
         confidence
         literature


### PR DESCRIPTION
Based on suggestion from @DSuveges, adding variant ID with link to variant page in uniprot widget

Sorting by variant works, but I didn't implement sorting by amino acid consequence
With some help from @carcruz we also included the aminoacid consequence in a diifferent column