### PR TITLE
[Platform] Use batching for variants widget on credible sets page

### DIFF
--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -1,12 +1,19 @@
-import { useQuery } from "@apollo/client";
 import { Box, Chip } from "@mui/material";
-import { Link, SectionItem, ScientificNotation, DisplayVariantId, OtTable } from "ui";
-import { naLabel } from "../../constants";
+import {
+  Link,
+  SectionItem,
+  ScientificNotation,
+  DisplayVariantId,
+  OtTable,
+  useBatchQuery,
+} from "ui";
+import { naLabel, initialResponse, table5HChunkSize } from "../../constants";
 import { definition } from ".";
 import Description from "./Description";
 import VARIANTS_QUERY from "./VariantsQuery.gql";
 import { mantissaExponentComparator, variantComparator } from "../../utils/comparators";
 import { identifiersOrgLink } from "../../utils/global";
+import { useEffect, useState } from "react";
 
 type getColumnsType = {
   leadVariantId: string;
@@ -148,9 +155,9 @@ function getColumns({ leadVariantId, leadReferenceAllele, leadAlternateAllele }:
         const mostSevereConsequence = variant?.mostSevereConsequence
         if (!mostSevereConsequence) return naLabel;
         const displayElement = (
-            <Link external to={identifiersOrgLink("SO", mostSevereConsequence.id.slice(3))}>
-              {formatVariantConsequenceLabel(mostSevereConsequence.label)}
-            </Link>
+          <Link external to={identifiersOrgLink("SO", mostSevereConsequence.id.slice(3))}>
+            {formatVariantConsequenceLabel(mostSevereConsequence.label)}
+          </Link>
         );
         return displayElement;
       },
@@ -180,9 +187,24 @@ function Body({
     studyLocusId: studyLocusId,
   };
 
-  const request = useQuery(VARIANTS_QUERY, {
-    variables,
+  const [request, setRequest] = useState<responseType>(initialResponse);
+
+  const getData = useBatchQuery({
+    query: VARIANTS_QUERY,
+    variables: {
+      studyLocusId,
+      size: table5HChunkSize,
+      index: 0,
+    },
+    dataPath: "data.credibleSet.locus",
+    size: table5HChunkSize,
   });
+
+  useEffect(() => {
+    getData().then(r => {
+      setRequest(r);
+    });
+  }, []);
 
   const columns = getColumns({
     leadVariantId,
@@ -195,6 +217,8 @@ function Body({
       definition={definition}
       entity={entity}
       request={request}
+      showContentLoading
+      loadingMessage="Loading data. This may take some time..."
       renderDescription={() => <Description />}
       renderBody={() => {
         return (

--- a/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
+++ b/packages/sections/src/credibleSet/Variants/VariantsQuery.gql
@@ -1,7 +1,7 @@
-query VariantsQuery($studyLocusId: String!) {
+query VariantsQuery($studyLocusId: String!, $size: Int!, $index: Int!) {
   credibleSet(studyLocusId: $studyLocusId) {
     studyLocusId
-    locus {
+    locus(page: { size: $size, index: $index }) {
       count
       rows {
         logBF


### PR DESCRIPTION
## Description

Use batching for variants widget on credible sets page.

**Issue:** [#3611](https://github.com/opentargets/issues/issues/3611)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on credible set page.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
