### PR TITLE
[Platform]: feat add project id to study and credible set metadata when QTL studies

### DIFF
--- a/apps/platform/src/pages/CredibleSetPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/CredibleSetPage/ProfileHeader.tsx
@@ -221,6 +221,11 @@ function ProfileHeader() {
         )}
         {study?.studyType !== "gwas" && (
           <>
+            {study?.projectId && (
+              <Field loading={loading} title="Project">
+                {study?.projectId?.replace(/_/gi, " ")}
+              </Field>
+            )}
             {target?.id && (
               <Field loading={loading} title="Affected gene">
                 <Link to={`../target/${target.id}`}>{target.approvedSymbol}</Link>

--- a/apps/platform/src/pages/StudyPage/StudyProfileHeader.gql
+++ b/apps/platform/src/pages/StudyPage/StudyProfileHeader.gql
@@ -5,6 +5,7 @@ fragment StudyProfileHeaderFragment on Gwas {
   publicationJournal
   pubmedId
   traitFromSource
+  projectId
   backgroundTraits {
     id
     name

--- a/apps/platform/src/pages/StudyPage/StudyProfileHeader.tsx
+++ b/apps/platform/src/pages/StudyPage/StudyProfileHeader.tsx
@@ -33,6 +33,7 @@ function ProfileHeader() {
     traitFromSource,
     backgroundTraits,
     diseases,
+    projectId,
     target,
     nCases,
     nControls,
@@ -80,6 +81,11 @@ function ProfileHeader() {
         )}
         {studyType !== "gwas" && (  // QTL
           <>
+            {projectId && (
+              <Field loading={loading} title="Project">
+                {projectId?.replace(/_/gi, " ")}
+              </Field>
+            )}
             {target?.id && (
               <Field loading={loading} title="Affected gene">
                 <Link to={`../target/${target.id}`}>{target.approvedSymbol}</Link>


### PR DESCRIPTION
Adds project ID in credible set and study metadata only for QTL studies

This information was missing and can help understand where the QTL study is coming from