### PR TITLE
[Platform]: fix credible set size in credible set widgets

### DIFF
--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -218,16 +218,16 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
     {
       id: "credibleSetSize",
       label: "Credible set size",
-      comparator: (a, b) => a.locus?.count - b.locus?.count,
+      comparator: (a, b) => a.locusSize?.count - b.locusSize?.count,
       sortable: true,
       numeric: true,
       filterValue: false,
-      renderCell: ({ locus }) => {
-        return typeof locus?.count === "number"
-          ? locus.count.toLocaleString()
+      renderCell: ({ locusSize }) => {
+        return typeof locusSize?.count === "number"
+          ? locusSize.count.toLocaleString()
           : naLabel;
       },
-      exportValue: ({ locus }) => locus?.count,
+      exportValue: ({ locusSize }) => locusSize?.count,
     },
   ];
 }

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -159,9 +159,9 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       },
       sortable: true,
       renderCell: ({ locus }) =>
-        locus.count > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
       exportValue: ({ locus }) =>
-        locus.count > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
     },
     {
       id: "finemappingMethod",

--- a/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/GWASCredibleSets/GWASCredibleSetsQuery.gql
@@ -32,10 +32,12 @@ query GWASCredibleSetsQuery($variantId: String!, $size: Int!, $index: Int!) {
           }
         }
         locus(variantIds: [$variantId]) {
-          count
           rows {
             posteriorProbability
           }
+        }
+        locusSize: locus {
+          count
         }
         l2GPredictions(page: { size: 1, index: 1 }) {
           rows {

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -169,9 +169,9 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
         </>
       ),
       renderCell: ({ locus }) =>
-        locus.count > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
       exportValue: ({ locus }) =>
-        locus.count > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
     },
     {
       id: "confidence",

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -197,15 +197,15 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       id: "credibleSetSize",
       label: "Credible set size",
       numeric: true,
-      comparator: (a, b) => a.locus?.count - b.locus?.count,
+      comparator: (a, b) => a.locusSize?.count - b.locusSize?.count,
       sortable: true,
       filterValue: false,
-      renderCell: ({ locus }) => {
-        return typeof locus?.count === "number"
-          ? locus.count.toLocaleString()
+      renderCell: ({ locusSize }) => {
+        return typeof locusSize?.count === "number"
+          ? locusSize.count.toLocaleString()
           : naLabel;
       },
-      exportValue: ({ locus }) => locus?.count,
+      exportValue: ({ locusSize }) => locusSize?.count,
     },
   ];
 }

--- a/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/variant/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -37,10 +37,12 @@ query QTLCredibleSetsQuery($variantId: String!, $size: Int!, $index: Int!) {
           }
         }
         locus(variantIds: [$variantId]) {
-          count
           rows {
             posteriorProbability
           }
+        }
+        locusSize: locus {
+          count
         }
       }
     }


### PR DESCRIPTION
Credible set size and posterior probabilities could not work in the same "locus" query.

This adds another "locus" query aliased