### PR TITLE
[Platform]: Update open targets links in widget descriptions

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/Description.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Description.tsx
@@ -4,7 +4,7 @@ function Description() {
   return (
     <>
       Colocalisation metrics for overlapping credible sets from GWAS studies. Source:{" "}
-      <Link to="../" >
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
         Open Targets
       </Link>
     </>

--- a/packages/sections/src/credibleSet/Locus2Gene/Description.tsx
+++ b/packages/sections/src/credibleSet/Locus2Gene/Description.tsx
@@ -5,7 +5,9 @@ function Description(): ReactElement {
   return (
     <>
       Gene assignment based on machine-learning prioritisation of credible set features. Source:{" "}
-      <Link to="../">Open Targets</Link>
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
+        Open Targets
+      </Link>
     </>
   );
 }

--- a/packages/sections/src/credibleSet/MolQTLColoc/Description.tsx
+++ b/packages/sections/src/credibleSet/MolQTLColoc/Description.tsx
@@ -4,7 +4,7 @@ function Description() {
   return (
     <>
       Colocalisation metrics for overlapping credible sets from molecular QTL studies. Source:{" "}
-      <Link to="../" >
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
         Open Targets
       </Link>
     </>

--- a/packages/sections/src/credibleSet/Variants/Description.tsx
+++ b/packages/sections/src/credibleSet/Variants/Description.tsx
@@ -4,7 +4,7 @@ function Description() {
   return (
     <>
       Set of variants with 95% probability of containing the causal variant. Source:{" "}
-      <Link to="../" >
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
         Open Targets
       </Link>
     </>

--- a/packages/sections/src/evidence/GWASCredibleSets/Description.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Description.jsx
@@ -6,8 +6,8 @@ function Description({ symbol, name }) {
     <>
       95% GWAS credible sets prioritisating <strong>{symbol}</strong> as likely causal gene for{" "}
       <strong>{name}</strong>. Source:{" "}
-      <Link to={config.geneticsPortalUrl} external>
-        Open Targets Genetics
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
+        Open Targets
       </Link>
     </>
   );

--- a/packages/sections/src/study/GWASCredibleSets/Description.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Description.tsx
@@ -9,7 +9,7 @@ function Description({ studyId }: DescriptionProps) {
     <>
       95% GWAS credible sets associated with study {" "}
       <strong>{studyId}</strong>. Source{" "}
-      <Link to="../" >
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
         Open Targets
       </Link>
     </>

--- a/packages/sections/src/study/QTLCredibleSets/Description.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Description.tsx
@@ -12,6 +12,10 @@ function Description({ studyId }: DescriptionProps) {
       <Link external to="https://www.ebi.ac.uk/eqtl/" >
         eQTL Catalog
       </Link>
+      ,{" "}
+      <Link external to="https://www.synapse.org/Synapse:syn51364943/wiki/622119" >
+        UKB-PPP
+      </Link>
     </>
   );
 }

--- a/packages/sections/src/variant/GWASCredibleSets/Description.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Description.tsx
@@ -18,7 +18,7 @@ function Description({ variantId, referenceAllele, alternateAllele }: Descriptio
         />
       </strong>
       . Source{" "}
-      <Link to="../" >
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
         Open Targets
       </Link>
     </>

--- a/packages/sections/src/variant/QTLCredibleSets/Description.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Description.tsx
@@ -22,7 +22,10 @@ function Description({
           alternateAllele={alternateAllele}
         />
       </strong>
-      . Source <Link to="/">Open Targets</Link>
+      . Source{" "}
+      <Link to="https://home.opentargets.org/merged-product-documentation" external>
+        Open Targets
+      </Link>
     </>
   );
 }


### PR DESCRIPTION
## Description

Update open targets links in widget descriptions to point to merged product docs rather than homepage.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked relevant pages

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
