### PR TITLE
refactor: rename gwas credible set datasource

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/static_datasets/dataSourcesAssoc.js
+++ b/apps/platform/src/components/AssociationsToolkit/static_datasets/dataSourcesAssoc.js
@@ -2,7 +2,7 @@ const dataSources = [
   {
     id: "gwas_credible_sets",
     sectionId: "gwasCredibleSets",
-    label: "GWAS credible sets",
+    label: "GWAS associations",
     aggregation: "Genetic association",
     aggregationId: "genetic_association",
     weight: 1,

--- a/packages/sections/src/evidence/GWASCredibleSets/index.js
+++ b/packages/sections/src/evidence/GWASCredibleSets/index.js
@@ -3,8 +3,8 @@ import { isPrivateEvidenceSection } from "../../utils/partnerPreviewUtils";
 const id = "gwas_credible_sets";
 export const definition = {
   id,
-  name: "GWAS credible sets",
-  shortName: "GC",
+  name: "GWAS associations",
+  shortName: "GW",
   hasData: data => data.gwasCredibleSets.count > 0,
   isPrivate: isPrivateEvidenceSection(id),
 };


### PR DESCRIPTION
After some feedback from David H and discussion with @buniello, we want to rename the widget name for the more accessible `GWAS associations`