### PR TITLE
[Platform]: Fix credible set size in PheWas plot tooltip

### DIFF
--- a/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
@@ -354,7 +354,7 @@ function tooltipContent(data) {
         </Box>
       </HTMLTooltipRow>
       <HTMLTooltipRow label="Credible set size" data={data} labelWidth={labelWidth}>
-        {data.locus?.count ?? naLabel}
+        {data.locusSize?.count ?? naLabel}
       </HTMLTooltipRow>
     </HTMLTooltipTable>
   );


### PR DESCRIPTION

## Description

Fix credible set size in PheWas plot tooltip

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

## How Has This Been Tested?

Checked PheWas plot

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
