### PR TITLE
[Platform]: Use toPrecision for posterior probabilities

### DIFF
--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -166,9 +166,9 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       },
       sortable: true,
       renderCell: ({ locus }) =>
-        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toPrecision(3) : naLabel,
       exportValue: ({ locus }) =>
-        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability : naLabel,
     },
     {
       id: "finemappingMethod",

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -169,9 +169,9 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
         </>
       ),
       renderCell: ({ locus }) =>
-        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toPrecision(3) : naLabel,
       exportValue: ({ locus }) =>
-        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability.toFixed(3) : naLabel,
+        locus.rows.length > 0 ? locus?.rows[0]?.posteriorProbability : naLabel,
     },
     {
       id: "confidence",


### PR DESCRIPTION
## Description

Use `toPrecision` for posterior probs in credible sets widgets on variant page - these variants are not the leads so can have tiny probs after all.

**Issue:** [#3666](https://github.com/opentargets/issues/issues/3666)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on variant page

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
