### PR TITLE
[Platform]: disable column hiding

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Body.tsx
@@ -20,6 +20,7 @@ const columns = [
   {
     id: "otherStudyLocus.studyLocusId",
     label: "Navigate",
+    enableHiding: false,
     renderCell: ({ otherStudyLocus }) => {
       if (!otherStudyLocus?.variant) return naLabel;
       return <Navigate to={`./${otherStudyLocus.studyLocusId}`} />;

--- a/packages/sections/src/credibleSet/Locus2Gene/Body.tsx
+++ b/packages/sections/src/credibleSet/Locus2Gene/Body.tsx
@@ -17,6 +17,7 @@ const columns = [
   {
     id: "gene",
     label: "Gene",
+    enableHiding: false,
     renderCell: ({ target }) => {
       if (!target) return naLabel;
       return <Link to={`../target/${target?.id}`}>{target?.approvedSymbol}</Link>;

--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -30,6 +30,7 @@ function getColumns({ leadVariantId, leadReferenceAllele, leadAlternateAllele }:
     {
       id: "variant.id",
       label: "Variant",
+      enableHiding: false,
       comparator: variantComparator(d => d?.variant),
       sortable: true,
       filterValue: ({ variant: v }) =>

--- a/packages/sections/src/disease/GWASStudies/Body.tsx
+++ b/packages/sections/src/disease/GWASStudies/Body.tsx
@@ -13,6 +13,7 @@ const columns = [
   {
     id: "id",
     label: "Study",
+    enableHiding: false,
     renderCell: ({ id }) => <Link to={`/study/${id}`}>{id}</Link>,
   },
   {

--- a/packages/sections/src/disease/OTProjects/Body.jsx
+++ b/packages/sections/src/disease/OTProjects/Body.jsx
@@ -24,6 +24,7 @@ const getColumns = classes => [
   {
     id: "otarCode",
     label: "Project Code",
+    enableHiding: false,
     renderCell: ({ otarCode }) => (
       <Link external to={`http://home.opentargets.org/${otarCode}`}>
         {otarCode}

--- a/packages/sections/src/disease/Phenotypes/Body.jsx
+++ b/packages/sections/src/disease/Phenotypes/Body.jsx
@@ -34,6 +34,7 @@ const columns = [
   {
     id: "phenotypeHPO",
     label: "Phenotype",
+    enableHiding: false,
     renderCell: ({ phenotypeEFO, phenotypeHPO }) => {
       let content;
       if (phenotypeEFO && phenotypeEFO.id) {
@@ -56,6 +57,7 @@ const columns = [
   {
     id: "phenotypeHDOid",
     label: "Phenotype ID",
+    enableHiding: false,
     renderCell: ({ phenotypeHPO }) => {
       const id = phenotypeHPO?.id.replace("_", ":");
       return (

--- a/packages/sections/src/drug/DrugWarnings/Body.jsx
+++ b/packages/sections/src/drug/DrugWarnings/Body.jsx
@@ -29,6 +29,7 @@ const columns = [
   {
     id: "toxicityClass",
     label: "ChEMBL warning class",
+    enableHiding: false,
     renderCell: ({ toxicityClass, efoIdForWarningClass, description }) => {
       if (efoIdForWarningClass)
         return (

--- a/packages/sections/src/drug/Indications/Body.jsx
+++ b/packages/sections/src/drug/Indications/Body.jsx
@@ -14,6 +14,7 @@ const columns = [
   {
     id: "indication",
     label: "Indication",
+    enableHiding: false,
     propertyPath: "disease.name",
     renderCell: d => <Link to={`/disease/${d.disease.id}`}>{d.disease.name}</Link>,
     width: "38%",

--- a/packages/sections/src/drug/MechanismsOfAction/Body.jsx
+++ b/packages/sections/src/drug/MechanismsOfAction/Body.jsx
@@ -12,6 +12,7 @@ const columns = [
   {
     id: "mechanismOfAction",
     label: "Mechanism of Action",
+    enableHiding: false,
   },
   {
     id: "targetName",

--- a/packages/sections/src/drug/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/drug/Pharmacogenomics/Body.jsx
@@ -87,6 +87,7 @@ function Body({ id: chemblId, label: name, entity }) {
     {
       id: "variantRsId",
       label: "rsID",
+      enableHiding: false,
       renderCell: ({ variantRsId }) =>
         variantRsId ? (
           <Link

--- a/packages/sections/src/evidence/CRISPR/Body.jsx
+++ b/packages/sections/src/evidence/CRISPR/Body.jsx
@@ -13,6 +13,7 @@ const columns = [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease }) => (
       <Link component={RouterLink} to={`/disease/${disease.id}`}>
         {disease.name}
@@ -21,6 +22,7 @@ const columns = [
   },
   {
     label: "Reported disease/phenotype",
+    enableHiding: false,
     renderCell: ({ diseaseCellLines, diseaseFromSource }) => {
       if (!diseaseCellLines) return naLabel;
 

--- a/packages/sections/src/evidence/CRISPRScreen/Body.jsx
+++ b/packages/sections/src/evidence/CRISPRScreen/Body.jsx
@@ -35,6 +35,7 @@ const getColumns = label => [
   {
     id: "studyId",
     label: "Study Identifier",
+    enableHiding: false,
     renderCell: row => (
       <Link external to={`https://crisprbrain.org/simple-screen/?screen=${row.studyId}`}>
         {row.studyId}

--- a/packages/sections/src/evidence/CancerBiomarkers/Body.jsx
+++ b/packages/sections/src/evidence/CancerBiomarkers/Body.jsx
@@ -36,6 +36,7 @@ const getColumns = label => [
   {
     id: "biomarkerName",
     label: "Biomarker",
+    enableHiding: false,
     renderCell: ({ biomarkerName, biomarkers }) => (
       <BiomarkersDrawer biomarkerName={biomarkerName} biomarkers={biomarkers} />
     ),

--- a/packages/sections/src/evidence/CancerGeneCensus/Body.jsx
+++ b/packages/sections/src/evidence/CancerGeneCensus/Body.jsx
@@ -26,12 +26,14 @@ const getColumns = label => [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease }) => <Link to={`/disease/${disease.id}`}>{disease.name}</Link>,
   },
   {
     id: "mutationType",
     propertyPath: "mutatedSamples.functionalConsequence",
     label: "Mutation type",
+    enableHiding: false,
     renderCell: ({ mutatedSamples }) => {
       if (!mutatedSamples) return naLabel;
       const sortedMutatedSamples = mutatedSamples

--- a/packages/sections/src/evidence/Chembl/Body.jsx
+++ b/packages/sections/src/evidence/Chembl/Body.jsx
@@ -79,6 +79,7 @@ function getColumns(classes) {
     {
       id: "disease.name",
       label: "Disease/phenotype",
+      enableHiding: false,
       renderCell: ({ disease, cohortPhenotypes }) => {
         let displayElement = naLabel;
         if (disease) displayElement = <Link to={`/disease/${disease.id}`}>{disease.name}</Link>;
@@ -153,6 +154,7 @@ function getColumns(classes) {
     {
       id: "drug.name",
       label: "Drug",
+      enableHiding: false,
       renderCell: ({ drug }) => <Link to={`/drug/${drug.id}`}>{drug.name}</Link>,
     },
     {

--- a/packages/sections/src/evidence/ClinGen/Body.jsx
+++ b/packages/sections/src/evidence/ClinGen/Body.jsx
@@ -12,6 +12,7 @@ const columns = [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => (
       <Tooltip
         title={

--- a/packages/sections/src/evidence/ExpressionAtlas/Body.jsx
+++ b/packages/sections/src/evidence/ExpressionAtlas/Body.jsx
@@ -37,6 +37,7 @@ const columns = [
   {
     id: "studyId",
     label: "Experiment ID",
+    enableHiding: false,
     renderCell: ({ studyId }) => (
       <Link external to={`http://www.ebi.ac.uk/gxa/experiments/${studyId}`}>
         {studyId}

--- a/packages/sections/src/evidence/Gene2Phenotype/Body.jsx
+++ b/packages/sections/src/evidence/Gene2Phenotype/Body.jsx
@@ -26,6 +26,7 @@ const getColumns = label => [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => (
       <Tooltip
         title={
@@ -96,6 +97,7 @@ const getColumns = label => [
   {
     id: "studyId",
     label: "Panel",
+    enableHiding: false,
     renderCell: ({ studyId, target: { approvedSymbol } }) => (
       <Link external to={g2pUrl(studyId, approvedSymbol)}>
         {studyId}

--- a/packages/sections/src/evidence/GenomicsEngland/Body.jsx
+++ b/packages/sections/src/evidence/GenomicsEngland/Body.jsx
@@ -6,7 +6,7 @@ import { v1 } from "uuid";
 import { Tooltip, SectionItem, Link, PublicationsDrawer, OtTable } from "ui";
 
 import { definition } from ".";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 import Description from "./Description";
 import { epmcUrl } from "../../utils/urls";
 import { sentenceCase } from "../../utils/global";
@@ -49,6 +49,7 @@ const getColumns = label => [
   {
     id: "disease",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource, cohortPhenotypes }) => (
       <Tooltip
         title={
@@ -102,6 +103,7 @@ const getColumns = label => [
   {
     id: "studyOverview",
     label: "Genomics England Panel",
+    enableHiding: false,
     renderCell: ({ studyOverview, studyId, target: { approvedSymbol } }) =>
       studyOverview && studyId && approvedSymbol ? (
         <Link external to={geUrl(studyId, approvedSymbol)}>

--- a/packages/sections/src/evidence/Impc/Body.jsx
+++ b/packages/sections/src/evidence/Impc/Body.jsx
@@ -100,6 +100,7 @@ const columns = [
   {
     id: "literature",
     label: "Mouse model allelic composition",
+    enableHiding: false,
     renderCell: ({
       biologicalModelAllelicComposition,
       biologicalModelGeneticBackground,

--- a/packages/sections/src/evidence/IntOgen/Body.jsx
+++ b/packages/sections/src/evidence/IntOgen/Body.jsx
@@ -116,6 +116,7 @@ const columns = [
   {
     id: "cohortShortName",
     label: "Cohort Information",
+    enableHiding: false,
     renderCell: ({ cohortId, cohortShortName, cohortDescription, target: { approvedSymbol } }) =>
       cohortShortName && cohortDescription ? (
         <>

--- a/packages/sections/src/evidence/OTCRISPR/Body.jsx
+++ b/packages/sections/src/evidence/OTCRISPR/Body.jsx
@@ -5,7 +5,7 @@ import { SectionItem, Link, Tooltip, OtTable, TooltipStyledLabel } from "ui";
 import { definition } from ".";
 import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 
 import CRISPR_QUERY from "./OTCrisprQuery.gql";
 
@@ -34,6 +34,7 @@ const getColumns = () => [
   {
     id: "contrast",
     label: "Contrast / Study overview",
+    enableHiding: false,
     renderCell: row => {
       if (row.contrast && row.studyOverview) {
         return (

--- a/packages/sections/src/evidence/OTEncore/Body.jsx
+++ b/packages/sections/src/evidence/OTEncore/Body.jsx
@@ -16,7 +16,7 @@ import {
 import { definition } from ".";
 import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
-import { defaultRowsPerPageOptions, sectionsBaseSizeQuery } from "../../constants";
+import { sectionsBaseSizeQuery } from "../../constants";
 
 import ENCORE_QUERY from "./OTEncoreQuery.gql";
 
@@ -49,6 +49,7 @@ const getColumns = classes => [
   {
     id: "interactingTargetFromSourceId",
     label: "Anchor gene",
+    enableHiding: false,
     sortable: true,
   },
   {

--- a/packages/sections/src/evidence/OTValidation/Body.jsx
+++ b/packages/sections/src/evidence/OTValidation/Body.jsx
@@ -10,7 +10,7 @@ import { v1 } from "uuid";
 import { definition } from ".";
 import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 import VALIDATION_QUERY from "./OTValidationQuery.gql";
 
 const useStyles = makeStyles(theme => ({
@@ -70,6 +70,7 @@ const getColumns = classes => [
   {
     id: "biomarkerList",
     label: "Cell line biomarkers",
+    enableHiding: false,
     renderCell: row => (
       <ChipList
         small

--- a/packages/sections/src/evidence/Orphanet/Body.jsx
+++ b/packages/sections/src/evidence/Orphanet/Body.jsx
@@ -11,7 +11,7 @@ import {
 } from "ui";
 
 import { definition } from ".";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 import { epmcUrl } from "../../utils/urls";
 import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
@@ -23,6 +23,7 @@ const getColumns = label => [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => (
       <Tooltip
         title={
@@ -55,6 +56,7 @@ const getColumns = label => [
   {
     id: "variantFunctionalConsequence",
     label: "Functional consequence",
+    enableHiding: false,
     renderCell: ({ variantFunctionalConsequence }) =>
       variantFunctionalConsequence ? (
         <Link

--- a/packages/sections/src/evidence/Progeny/Body.jsx
+++ b/packages/sections/src/evidence/Progeny/Body.jsx
@@ -7,7 +7,7 @@ import Description from "./Description";
 import PROGENY_QUERY from "./sectionQuery.gql";
 import { dataTypesMap } from "../../dataTypes";
 import { sentenceCase } from "../../utils/global";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 
 const reactomeUrl = id => `https://identifiers.org/reactome:${id}`;
 
@@ -15,6 +15,7 @@ const columns = [
   {
     id: "disease",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => (
       <Tooltip
         title={
@@ -37,6 +38,7 @@ const columns = [
   {
     id: "pathwayName",
     label: "Significant pathway",
+    enableHiding: false,
     renderCell: ({ pathways }) =>
       pathways?.length >= 1 ? (
         <Link external to={reactomeUrl(pathways[0].id)}>

--- a/packages/sections/src/evidence/Reactome/Body.jsx
+++ b/packages/sections/src/evidence/Reactome/Body.jsx
@@ -69,6 +69,7 @@ const getColumns = label => [
   {
     id: "reactionId",
     label: "Reaction",
+    enableHiding: false,
     renderCell: ({ reactionName, reactionId }) => (
       <Link external to={`https://identifiers.org/reactome/${reactionId}`}>
         <EllsWrapper>{reactionName}</EllsWrapper>

--- a/packages/sections/src/evidence/SlapEnrich/Body.jsx
+++ b/packages/sections/src/evidence/SlapEnrich/Body.jsx
@@ -7,7 +7,7 @@ import Description from "./Description";
 import { dataTypesMap } from "../../dataTypes";
 import SLAPENRICH_QUERY from "./sectionQuery.gql";
 import { sentenceCase } from "../../utils/global";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 
 const reactomeUrl = id => `https://identifiers.org/reactome:${id}`;
 
@@ -37,6 +37,7 @@ const columns = [
   {
     id: "pathwayName",
     label: "Significant pathway",
+    enableHiding: false,
     renderCell: ({ pathways }) =>
       pathways?.length >= 1 ? (
         <Link external to={reactomeUrl(pathways[0].id)}>

--- a/packages/sections/src/evidence/SysBio/Body.jsx
+++ b/packages/sections/src/evidence/SysBio/Body.jsx
@@ -6,7 +6,7 @@ import Description from "./Description";
 import { epmcUrl } from "../../utils/urls";
 import SYSBIO_QUERY from "./sectionQuery.gql";
 import { dataTypesMap } from "../../dataTypes";
-import { defaultRowsPerPageOptions, naLabel, sectionsBaseSizeQuery } from "../../constants";
+import { naLabel, sectionsBaseSizeQuery } from "../../constants";
 
 const getColumns = label => [
   {
@@ -18,6 +18,7 @@ const getColumns = label => [
   {
     id: "pathwayName",
     label: "Gene set",
+    enableHiding: false,
     renderCell: ({ pathways, studyOverview }) => {
       if (pathways && pathways.length >= 1 && studyOverview) {
         return (

--- a/packages/sections/src/evidence/UniProtLiterature/Body.jsx
+++ b/packages/sections/src/evidence/UniProtLiterature/Body.jsx
@@ -14,6 +14,7 @@ const getcolumns = label => [
   {
     id: "disease.name",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => (
       <Tooltip
         title={
@@ -35,6 +36,7 @@ const getcolumns = label => [
   {
     id: "targetFromSourceId",
     label: "Reported protein",
+    enableHiding: false,
     renderCell: ({ targetFromSourceId }) => (
       <Link external to={identifiersOrgLink("uniprot", targetFromSourceId)}>
         {targetFromSourceId}

--- a/packages/sections/src/evidence/UniProtVariants/Body.jsx
+++ b/packages/sections/src/evidence/UniProtVariants/Body.jsx
@@ -28,6 +28,7 @@ function getColumns(label) {
     {
       id: "disease.name",
       label: "Disease/phenotype",
+      enableHiding: false,
       renderCell: ({ disease, diseaseFromSource }) => (
         <Tooltip
           title={
@@ -58,6 +59,7 @@ function getColumns(label) {
     {
       id: "variantId",
       label: "Variant",
+      enableHiding: false,
       sortable: true,
       comparator: nullishComparator(variantComparator(), d => d?.variant),
       filterValue: ({ variant: v }) =>

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -27,11 +27,13 @@ const columns = [
   {
     id: "studyLocusId",
     label: "Navigate",
+    enableHiding: false,
     renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
   },
   {
     id: "leadVariant",
     label: "Lead variant",
+    enableHiding: false,
     comparator: variantComparator(d => d?.variant),
     sortable: true,
     filterValue: ({ variant: v }) =>

--- a/packages/sections/src/study/SharedTraitStudies/Body.tsx
+++ b/packages/sections/src/study/SharedTraitStudies/Body.tsx
@@ -15,6 +15,7 @@ function getColumns(diseaseIds: string[]) {
     {
       id: "studyId",
       label: "Study",
+      enableHiding: false,
       renderCell: ({ id }) => <Link to={`./${id}`}>{id}</Link>,
       exportValue: ({ id }) => id,
     },

--- a/packages/sections/src/target/CancerHallmarks/Body.jsx
+++ b/packages/sections/src/target/CancerHallmarks/Body.jsx
@@ -13,6 +13,7 @@ const columns = [
   {
     id: "label",
     label: "Hallmark",
+    enableHiding: false,
     renderCell: row => row.label,
     exportLabel: "Hallmark",
   },

--- a/packages/sections/src/target/ChemicalProbes/Body.jsx
+++ b/packages/sections/src/target/ChemicalProbes/Body.jsx
@@ -23,6 +23,7 @@ const columns = [
   {
     id: "id",
     label: "Probe ID",
+    enableHiding: false,
     renderCell: row => {
       // link to drug page if drugid is available; also add tooltip with control if available
       const c = row.drugId ? (

--- a/packages/sections/src/target/ComparativeGenomics/Body.jsx
+++ b/packages/sections/src/target/ComparativeGenomics/Body.jsx
@@ -71,6 +71,7 @@ function getColumns(classes) {
     {
       id: "speciesName",
       label: "Species",
+      enableHiding: false,
       renderCell: ({ speciesId, speciesName }) => {
         const SpeciesIcon = speciesIcons[speciesId];
         return (
@@ -113,6 +114,7 @@ function getColumns(classes) {
     {
       id: "targetGeneSymbol",
       label: "Homologue",
+      enableHiding: false,
       renderCell: ({ targetGeneId, targetGeneSymbol }) => (
         <Link external to={identifiersOrgLink("ensembl", targetGeneId)}>
           {targetGeneSymbol || targetGeneId}

--- a/packages/sections/src/target/GeneOntology/Body.jsx
+++ b/packages/sections/src/target/GeneOntology/Body.jsx
@@ -88,6 +88,7 @@ const columns = [
   {
     id: "goTerm",
     label: "GO term",
+    enableHiding: false,
     renderCell: ({ term }) =>
       term ? (
         <Link external to={`https://identifiers.org/${term.id}`}>

--- a/packages/sections/src/target/GeneticConstraint/Body.jsx
+++ b/packages/sections/src/target/GeneticConstraint/Body.jsx
@@ -69,6 +69,7 @@ function getColumns(ensemblId, symbol) {
     {
       id: "constraintType",
       label: "Category",
+      enableHiding: false,
       renderCell: ({ constraintType }) => constraintTypeMap[constraintType],
     },
     {

--- a/packages/sections/src/target/MousePhenotypes/Body.jsx
+++ b/packages/sections/src/target/MousePhenotypes/Body.jsx
@@ -10,6 +10,7 @@ const columns = [
   {
     id: "targetInModel",
     label: "Mouse gene",
+    enableHiding: false,
     renderCell: ({ targetInModel, targetInModelMgiId }) => (
       <Link external to={`https://identifiers.org/${targetInModelMgiId}`}>
         {targetInModel}
@@ -54,6 +55,7 @@ const columns = [
   {
     id: "allelicComposition",
     label: "Allelic composition",
+    enableHiding: false,
     renderCell: ({ biologicalModels }) => (
       <AllelicCompositionDrawer biologicalModels={biologicalModels} />
     ),

--- a/packages/sections/src/target/Pathways/Body.jsx
+++ b/packages/sections/src/target/Pathways/Body.jsx
@@ -15,6 +15,7 @@ function getColumns(symbol) {
     {
       id: "pathway",
       label: "Pathway",
+      enableHiding: false,
       renderCell: ({ pathwayId, pathway }) => (
         <Link external to={identifiersOrgLink("reactome", pathwayId)}>
           {pathway}

--- a/packages/sections/src/target/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/target/Pharmacogenomics/Body.jsx
@@ -67,6 +67,7 @@ function getColumns(classes) {
     {
       id: "variantRsId",
       label: "rsID",
+      enableHiding: false,
       renderCell: ({ variantRsId }) =>
         variantRsId ? (
           <Link

--- a/packages/sections/src/target/Safety/Body.jsx
+++ b/packages/sections/src/target/Safety/Body.jsx
@@ -43,6 +43,7 @@ function getColumns(classes) {
     {
       id: "event",
       label: "Safety event",
+      enableHiding: false,
       renderCell: ({ event, eventId }) =>
         eventId ? <Link to={`/disease/${eventId}`}>{event ?? naLabel}</Link> : event ?? naLabel,
     },

--- a/packages/sections/src/variant/EVA/Body.tsx
+++ b/packages/sections/src/variant/EVA/Body.tsx
@@ -58,6 +58,7 @@ const columns = [
   {
     id: "studyId",
     label: "ClinVar ID",
+    enableHiding: false,
     renderCell: ({ studyId }) => {
       if (!studyId) return naLabel;
       return (

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -37,11 +37,13 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
     {
       id: "studyLocusId",
       label: "Navigate",
+      enableHiding: false,
       renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
     },
     {
       id: "leadVariant",
       label: "Lead variant",
+      enableHiding: false,
       comparator: variantComparator(d => d?.variant),
       sortable: true,
       filterValue: ({ variant: v }) =>

--- a/packages/sections/src/variant/InSilicoPredictors/Body.tsx
+++ b/packages/sections/src/variant/InSilicoPredictors/Body.tsx
@@ -13,6 +13,7 @@ const columns = [
   {
     id: "method",
     label: "Method",
+    enableHiding: false,
   },
   {
     id: "assessment",

--- a/packages/sections/src/variant/Pharmacogenomics/Body.tsx
+++ b/packages/sections/src/variant/Pharmacogenomics/Body.tsx
@@ -71,6 +71,7 @@ function Body({ id, entity }: BodyProps) {
     {
       id: "genotypeId",
       label: "Genotype ID",
+      enableHiding: false,
       tooltip: (
         <>
           VCF-style(chr_pos_ref_allele1,allele2). See{" "}

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -29,11 +29,13 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
     {
       id: "studyLocusId",
       label: "Navigate",
+      enableHiding: false,
       renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
     },
     {
       id: "leadVariant",
       label: "Lead variant",
+      enableHiding: false,
       comparator: variantComparator(d => d.variant),
       sortable: true,
       filterValue: ({ variant: v }) =>

--- a/packages/sections/src/variant/UniProtVariants/Body.tsx
+++ b/packages/sections/src/variant/UniProtVariants/Body.tsx
@@ -11,6 +11,7 @@ const columns = [
   {
     id: "diseases",
     label: "Disease/phenotype",
+    enableHiding: false,
     renderCell: ({ disease, diseaseFromSource }) => {
       if (!disease) return naLabel;
       const displayElement = <Link to={`/disease/${disease.id}`}>{disease.name}</Link>;
@@ -45,6 +46,7 @@ const columns = [
   {
     id: "literature",
     label: "Literature",
+    enableHiding: false,
     renderCell: ({ literature }) => {
       const literatureList =
         literature?.reduce((acc, id) => {

--- a/packages/sections/src/variant/VariantEffectPredictor/Body.tsx
+++ b/packages/sections/src/variant/VariantEffectPredictor/Body.tsx
@@ -21,6 +21,7 @@ const columns = [
     id: "target.approvedSymbol",
     label: "Gene",
     sortable: true,
+    enableHiding: false,
     renderCell: ({ target, transcriptId, uniprotAccessions }) => {
       if (!target) return naLabel;
       let displayElement = <Link to={`../target/${target.id}`}>{target.approvedSymbol}</Link>;
@@ -91,6 +92,7 @@ const columns = [
   {
     id: "variantConsequences.label",
     label: "Predicted consequence",
+    enableHiding: false,
     renderCell: ({ variantConsequences, aminoAcidChange, codons }) => {
       if (!variantConsequences?.length) return naLabel;
       let displayElement = variantConsequences.map(({ id, label }, i, arr) => (


### PR DESCRIPTION
# [Platform]: disable column hiding

## Description

Columns that define unique rows in each widget. The point is that we will not allow to hide these columns in the UI.

**Issue:** https://github.com/opentargets/issues/issues/3633
**Deploy preview:** https://deploy-preview-625--ot-platform-partner.netlify.app/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A
- Test B

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
