### PR TITLE
[Platform]: study search ui label change

### DIFF
--- a/apps/platform/src/components/Search/SearchQuery.gql
+++ b/apps/platform/src/components/Search/SearchQuery.gql
@@ -24,6 +24,7 @@ query SearchQuery($queryString: String!) {
           nSamples
           publicationDate
           publicationFirstAuthor
+          publicationJournal
           # studyType
           credibleSets {
             credibleSetsCount: count

--- a/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
+++ b/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
@@ -26,7 +26,14 @@ query SearchPageQuery($queryString: String!, $index: Int!, $entityNames: [String
           nSamples
           publicationDate
           publicationFirstAuthor
+          publicationJournal
           studyType
+          biosample {
+            biosampleName
+          }
+          target {
+            approvedSymbol
+          }
           credibleSets {
             credibleSetsCount: count
           }

--- a/apps/platform/src/pages/SearchPage/StudyResult.jsx
+++ b/apps/platform/src/pages/SearchPage/StudyResult.jsx
@@ -23,7 +23,7 @@ function StudyResult({ data, highlights }) {
 
   return (
     <div className={classes.container}>
-      <Link to={`/variant/${data.id}`} className={classes.subtitle}>
+      <Link to={`/study/${data.id}`} className={classes.subtitle}>
         <FontAwesomeIcon icon={faChartBar} className={classes.icon} /> <>{data.traitFromSource}</>
       </Link>
       <Typography className={classes.subtitle} variant="subtitle1">
@@ -31,16 +31,24 @@ function StudyResult({ data, highlights }) {
           <Box sx={{ display: "flex", flexDirection: "column" }}>
             <Box sx={{ display: "flex", flexDirection: "row", gap: 1 }}>
               <div>Credible sets count: {data.credibleSets.credibleSetsCount}</div>
-              <div> • N Study: {data.nSamples}</div>
+              <div> • Sample size: {data.nSamples.toLocaleString()}</div>
             </Box>
             <Box sx={{ display: "flex", flexDirection: "row", gap: 1 }}>
               <div>
                 {" "}
-                {data.publicationFirstAuthor &&
-                  `Publication author: ${data.publicationFirstAuthor}`}
+                {data.publicationFirstAuthor && (
+                  <>
+                    {data.publicationFirstAuthor} <i>et al.</i> {data.publicationJournal} (
+                    {data.publicationDate?.slice(0, 4)})
+                  </>
+                )}
               </div>
-              <div> {data.publicationDate && ` •  Publication date: ${data.publicationDate}`}</div>
             </Box>
+            <div>
+              {data.target?.approvedSymbol && `Affected gene: ${data.target.approvedSymbol}  • `}
+              {data.biosample?.biosampleName &&
+                `Affected cell/tissue: ${data.biosample.biosampleName}`}
+            </div>
             <div>Study Type: {data.studyType}</div>
           </Box>
         )}

--- a/packages/ui/src/components/GlobalSearch/GlobalSearchListItem.jsx
+++ b/packages/ui/src/components/GlobalSearch/GlobalSearchListItem.jsx
@@ -215,7 +215,16 @@ function TopHitListItem({ item, onItemClick }) {
         ) : (
           <>
             <Box sx={{ fontWeight: "500", letterSpacing: 1 }}>
-              <Typography variant="subtitle1">{item.symbol && item.name}</Typography>
+              <Typography variant="subtitle1">
+                {item.symbol && item.name}
+
+                {item.publicationFirstAuthor && (
+                  <>
+                    {item.publicationFirstAuthor} <i>et al.</i> {item.publicationJournal} (
+                    {item.publicationDate?.slice(0, 4)})
+                  </>
+                )}
+              </Typography>
             </Box>
             <JustifyBetween>
               <Box sx={{ fontWeight: "light", fontStyle: "oblique" }}>
@@ -226,11 +235,11 @@ function TopHitListItem({ item, onItemClick }) {
                   {item.credibleSetsCount > -1 && (
                     <>Credible sets count: {item.credibleSetsCount}</>
                   )}
-                  {item.nSamples && <> • N Study: {item.nSamples}</>}
+                  {item.nSamples && <> • Sample size: {item.nSamples.toLocaleString()}</>}
                 </Typography>
                 <Typography variant="caption">
-                  {item.publicationFirstAuthor && <>{item.publicationFirstAuthor}</>}
-                  {item.publicationDate && <>({item.publicationDate})</>}
+                  {/* {item.publicationFirstAuthor && <>{item.publicationFirstAuthor}</>}
+                  {item.publicationDate && <>({item.publicationDate})</>} */}
                 </Typography>
               </Box>
               {item.hasSumstats && (
@@ -350,7 +359,7 @@ function GlobalSearchListItem({ item, isTopHit = false, onItemClick }) {
       <JustifyBetween>
         <Typography variant="caption">
           {item.credibleSetsCount > -1 && <>Credible sets count: {item.credibleSetsCount}</>}
-          {item.nSamples && <> • N Study: {item.nSamples}</>}
+          {item.nSamples && <> • Sample size: {item.nSamples.toLocaleString()}</>}
           {getVariantRsIds()}
         </Typography>
 


### PR DESCRIPTION
# [Platform]: study search ui label change

## Description

- [x] N Study -> Sample size
- [x] Publication to follow the same pattern as on the study profile page 
- [x] Pretty the numbers
- [x] for QTLs study, need to add gene & affected tissue
- [ ] order of entity types in quick search results [Targets, Diseases, Study, Drugs]
- [x] remove "Publication" label
- [x] Study search results page links lead to variant

**Issue:** https://github.com/opentargets/issues/issues/3561#issuecomment-2637302023
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A
- Test B

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
