### PR TITLE
[Platform]: Homepage study suggestions

### DIFF
--- a/apps/platform/src/pages/HomePage/HomePage.jsx
+++ b/apps/platform/src/pages/HomePage/HomePage.jsx
@@ -16,6 +16,7 @@ import {
   faDna,
   faPrescriptionBottleMedical,
   faMapPin,
+  faChartBar,
 } from "@fortawesome/free-solid-svg-icons";
 import {
   appTitle,
@@ -205,67 +206,74 @@ function HomePage({ suggestions }) {
             gap={1.5}
             sx={{ mt: 4 }}
           >
-            <Link to={`/target/${suggestions[0].id}/associations`}>
+            <Link asyncTooltip to={`/target/${suggestions[0].id}/associations`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faDna} />}
                 label={suggestions[0].name}
               />
             </Link>
-            <Link to={`/target/${suggestions[1].id}/associations`}>
+            <Link asyncTooltip to={`/target/${suggestions[1].id}/associations`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faDna} />}
                 label={suggestions[1].name}
               />
             </Link>
-            <Link to={`/disease/${suggestions[2].id}/associations`}>
+            <Link asyncTooltip to={`/disease/${suggestions[2].id}/associations`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faStethoscope} />}
                 label={suggestions[2].name}
               />
             </Link>
-            <Link to={`/disease/${suggestions[3].id}/associations`}>
+            <Link asyncTooltip to={`/disease/${suggestions[3].id}/associations`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faStethoscope} />}
                 label={suggestions[3].name}
               />
             </Link>
-            <Link to={`/drug/${suggestions[4].id}`}>
+            <Link asyncTooltip to={`/drug/${suggestions[4].id}`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faPrescriptionBottleMedical} />}
                 label={suggestions[4].name}
               />
             </Link>
-            <Link to={`/drug/${suggestions[5].id}`}>
+            <Link asyncTooltip to={`/drug/${suggestions[5].id}`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faPrescriptionBottleMedical} />}
                 label={suggestions[5].name}
               />
             </Link>
-            <Link to={`/variant/${suggestions[6].id}`}>
+            <Link asyncTooltip to={`/variant/${suggestions[6].id}`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faMapPin} />}
                 label={suggestions[6].name}
               />
             </Link>
-            <Link to={`/variant/${suggestions[7].id}`}>
+            <Link asyncTooltip to={`/variant/${suggestions[7].id}`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
                 icon={<FontAwesomeIcon icon={faMapPin} />}
                 label={suggestions[7].name}
               />
             </Link>
-            <Link to={`/variant/${suggestions[8].id}`}>
+            <Link asyncTooltip to={`/study/${suggestions[8].id}`}>
               <StyledChip
                 sx={{ pl: 1, borderRadius: 2 }}
-                icon={<FontAwesomeIcon icon={faMapPin} />}
+                icon={<FontAwesomeIcon icon={faChartBar} />}
                 label={suggestions[8].name}
+              />
+            </Link>
+            <Link asyncTooltip to={`/study/${suggestions[9].id}`}>
+              <StyledChip
+                sx={{ pl: 1, borderRadius: 2 }}
+                icon={<FontAwesomeIcon icon={faChartBar} />}
+                label={suggestions[9].name}
               />
             </Link>
           </Grid>

--- a/apps/platform/src/pages/HomePage/searchExamples.ts
+++ b/apps/platform/src/pages/HomePage/searchExamples.ts
@@ -1,4 +1,4 @@
-type Entity = "disease" | "drug" | "target" | "variant";
+type Entity = "disease" | "drug" | "target" | "variant" | "study";
 
 type Suggestion = {
   type: string;
@@ -12,6 +12,7 @@ type Examples = {
   diseases: Suggestion[];
   drugs: Suggestion[];
   variants: Suggestion[];
+  studies: Suggestion[];
 };
 
 export const pppSearchExamples: Examples = {
@@ -49,6 +50,15 @@ export const pppSearchExamples: Examples = {
     { type: "suggestion", entity: "variant", name: "11_64600382_G_A", id: "11_64600382_G_A" },
     { type: "suggestion", entity: "variant", name: "12_6333477_C_T", id: "12_6333477_C_T" },
     { type: "suggestion", entity: "variant", name: "17_43093010_G_A", id: "17_43093010_G_A" },
+  ],
+  studies: [
+    { type: "suggestion", entity: "study", name: "GCST90012877", id: "GCST90012877" },
+    { type: "suggestion", entity: "study", name: "GCST90308590", id: "GCST90308590" },
+    { type: "suggestion", entity: "study", name: "GCST004131", id: "GCST004131" },
+    { type: "suggestion", entity: "study", name: "GCST90295916", id: "GCST90295916" },
+    { type: "suggestion", entity: "study", name: "GCST90018784", id: "GCST90018784" },
+    { type: "suggestion", entity: "study", name: "GCST90204201", id: "GCST90204201" },
+    { type: "suggestion", entity: "study", name: "GCST90239655", id: "GCST90239655" },
   ],
 };
 

--- a/apps/platform/src/pages/HomePage/searchExamples.ts
+++ b/apps/platform/src/pages/HomePage/searchExamples.ts
@@ -1,13 +1,13 @@
 type Entity = "disease" | "drug" | "target" | "variant" | "study";
 
-type Suggestion = {
+export type Suggestion = {
   type: string;
   entity: Entity;
   name: string;
   id: string;
 };
 
-type Examples = {
+export type Examples = {
   targets: Suggestion[];
   diseases: Suggestion[];
   drugs: Suggestion[];
@@ -15,7 +15,7 @@ type Examples = {
   studies: Suggestion[];
 };
 
-export const pppSearchExamples: Examples = {
+export const searchExamples: Examples = {
   targets: [
     { type: "suggestion", entity: "target", name: "PCSK9", id: "ENSG00000169174" },
     { type: "suggestion", entity: "target", name: "WRN", id: "ENSG00000165392" },
@@ -59,78 +59,5 @@ export const pppSearchExamples: Examples = {
     { type: "suggestion", entity: "study", name: "GCST90018784", id: "GCST90018784" },
     { type: "suggestion", entity: "study", name: "GCST90204201", id: "GCST90204201" },
     { type: "suggestion", entity: "study", name: "GCST90239655", id: "GCST90239655" },
-  ],
-};
-
-export const searchExamples: Examples = {
-  targets: [
-    { type: "suggestion", entity: "target", name: "PCSK9", id: "ENSG00000169174" },
-    { type: "suggestion", entity: "target", name: "IL13", id: "ENSG00000169194" },
-    { type: "suggestion", entity: "target", name: "TSLP", id: "ENSG00000145777" },
-    { type: "suggestion", entity: "target", name: "ADAM33", id: "ENSG00000149451" },
-    { type: "suggestion", entity: "target", name: "CFTR", id: "ENSG00000001626" },
-    { type: "suggestion", entity: "target", name: "KIT", id: "ENSG00000157404" },
-    { type: "suggestion", entity: "target", name: "NOD2", id: "ENSG00000167207" },
-    { type: "suggestion", entity: "target", name: "TYK2", id: "ENSG00000105397" },
-    { type: "suggestion", entity: "target", name: "TNF", id: "ENSG00000232810" },
-    { type: "suggestion", entity: "target", name: "PTGS2", id: "ENSG00000073756" },
-    { type: "suggestion", entity: "target", name: "ADORA3", id: "ENSG00000282608" },
-    { type: "suggestion", entity: "target", name: "APP", id: "ENSG00000142192" },
-    { type: "suggestion", entity: "target", name: "GRIN3A", id: "ENSG00000198785" },
-    { type: "suggestion", entity: "target", name: "IL2RA", id: "ENSG00000134460" },
-    { type: "suggestion", entity: "target", name: "ACHE", id: "ENSG00000087085" },
-    { type: "suggestion", entity: "target", name: "SNCA", id: "ENSG00000145335" },
-    { type: "suggestion", entity: "target", name: "BRAF", id: "ENSG00000157764" },
-    { type: "suggestion", entity: "target", name: "BRCA2", id: "ENSG00000139618" },
-    { type: "suggestion", entity: "target", name: "KRAS", id: "ENSG00000133703" },
-    { type: "suggestion", entity: "target", name: "PTEN", id: "ENSG00000171862" },
-    { type: "suggestion", entity: "target", name: "TP53", id: "ENSG00000141510" },
-  ],
-  diseases: [
-    { type: "suggestion", entity: "disease", name: "Asthma", id: "MONDO_0004979" },
-    { type: "suggestion", entity: "disease", name: "Lung Disease", id: "EFO_0003818" },
-    { type: "suggestion", entity: "disease", name: "Childhood Onset Asthma", id: "MONDO_0005405" },
-    { type: "suggestion", entity: "disease", name: "Pneumonia", id: "EFO_0003106" },
-    { type: "suggestion", entity: "disease", name: "Cystic Fibrosis", id: "MONDO_0009061" },
-    { type: "suggestion", entity: "disease", name: "Eczema", id: "HP_0000964" },
-    {
-      type: "suggestion",
-      entity: "disease",
-      name: "Inflammatory Bowel Disease",
-      id: "EFO_0003767",
-    },
-    { type: "suggestion", entity: "disease", name: "Crohn's Disease", id: "EFO_0000384" },
-    { type: "suggestion", entity: "disease", name: "Ulcerative Colitis", id: "EFO_0000729" },
-    { type: "suggestion", entity: "disease", name: "Liver Disease", id: "EFO_0001421" },
-    { type: "suggestion", entity: "disease", name: "Rheumatoid Arthritis", id: "EFO_0000685" },
-    { type: "suggestion", entity: "disease", name: "Brain Disease", id: "EFO_0005774" },
-    { type: "suggestion", entity: "disease", name: "Multiple Sclerosis", id: "MONDO_0005301" },
-    { type: "suggestion", entity: "disease", name: "Schizophrenia", id: "MONDO_0005090" },
-    { type: "suggestion", entity: "disease", name: "Alzheimers Disease", id: "MONDO_0004975" },
-    { type: "suggestion", entity: "disease", name: "Dementia", id: "MONDO_0001627" },
-    { type: "suggestion", entity: "disease", name: "Noonan Syndrome", id: "MONDO_0018997" },
-    { type: "suggestion", entity: "disease", name: "Melanoma", id: "EFO_0000756" },
-    { type: "suggestion", entity: "disease", name: "Leukemia", id: "EFO_0000565" },
-    { type: "suggestion", entity: "disease", name: "Cowden Syndrome", id: "MONDO_0016063" },
-  ],
-  drugs: [
-    { type: "suggestion", entity: "drug", name: "ROFECOXIB", id: "CHEMBL122" },
-    { type: "suggestion", entity: "drug", name: "REGRELOR", id: "CHEMBL1162175" },
-    { type: "suggestion", entity: "drug", name: "METFORMIN", id: "CHEMBL1431" },
-    { type: "suggestion", entity: "drug", name: "ACETAMINOPHEN", id: "CHEMBL112" },
-    { type: "suggestion", entity: "drug", name: "THALIDOMIDE", id: "CHEMBL468" },
-    { type: "suggestion", entity: "drug", name: "HUMIRA", id: "CHEMBL1201580" },
-    { type: "suggestion", entity: "drug", name: "VIAGRA", id: "CHEMBL192" },
-    { type: "suggestion", entity: "drug", name: "TAGRISSO", id: "CHEMBL3353410" },
-    { type: "suggestion", entity: "drug", name: "IVACAFTOR", id: "CHEMBL2010601" },
-    { type: "suggestion", entity: "drug", name: "LYRICA", id: "CHEMBL1059" },
-  ],
-  variants: [
-    { type: "suggestion", entity: "variant", name: "rs4129267", id: "1_154453788_C_T" },
-    { type: "suggestion", entity: "variant", name: "4_1804392_G_A", id: "4_1804392_G_A" },
-    { type: "suggestion", entity: "variant", name: "11_64600382_G_A", id: "11_64600382_G_A" },
-    { type: "suggestion", entity: "variant", name: "12_6333477_C_T", id: "12_6333477_C_T" },
-    { type: "suggestion", entity: "variant", name: "15_90088702_C_T", id: "15_90088702_C_T" },
-    { type: "suggestion", entity: "variant", name: "17_63945614_C_T", id: "17_63945614_C_T" },
   ],
 };

--- a/apps/platform/src/utils/global.ts
+++ b/apps/platform/src/utils/global.ts
@@ -1,6 +1,6 @@
 import { format } from "d3-format";
 import config from "../config";
-import { searchExamples, pppSearchExamples } from "../pages/HomePage/searchExamples";
+import { Examples, searchExamples, Suggestion } from "../pages/HomePage/searchExamples";
 
 interface ProteinId {
   source: string;
@@ -85,18 +85,8 @@ export async function fetcher(graphQLParams: GraphQLParams): Promise<unknown> {
   return data.json();
 }
 
-interface SuggestedSearchExample {
-  targets: string[];
-  diseases: string[];
-  drugs: string[];
-  variants: string[];
-  studies: string[];
-}
-
-export function getSuggestedSearch(): string[] {
-  const suggestionArray: SuggestedSearchExample = config.profile.isPartnerPreview
-    ? pppSearchExamples
-    : searchExamples;
+export function getSuggestedSearch(): Suggestion[] {
+  const suggestionArray: Examples = searchExamples;
   const targets = pickN(suggestionArray.targets, 2);
   const diseases = pickN(suggestionArray.diseases, 2);
   const drugs = pickN(suggestionArray.drugs, 2);

--- a/apps/platform/src/utils/global.ts
+++ b/apps/platform/src/utils/global.ts
@@ -90,6 +90,7 @@ interface SuggestedSearchExample {
   diseases: string[];
   drugs: string[];
   variants: string[];
+  studies: string[];
 }
 
 export function getSuggestedSearch(): string[] {
@@ -99,6 +100,7 @@ export function getSuggestedSearch(): string[] {
   const targets = pickN(suggestionArray.targets, 2);
   const diseases = pickN(suggestionArray.diseases, 2);
   const drugs = pickN(suggestionArray.drugs, 2);
-  const variants = pickN(suggestionArray.variants, 3);
-  return [...targets, ...diseases, ...drugs, ...variants];
+  const variants = pickN(suggestionArray.variants, 2);
+  const studies = pickN(suggestionArray.studies, 2);
+  return [...targets, ...diseases, ...drugs, ...variants, ...studies];
 }


### PR DESCRIPTION
# [Platform]: Homepage study suggestions

Added homepage study suggestions 

## Description

- Added study suggestions for homepage
- Change variant suggestions count from 3 to 2 
- Updating examples array to common one to remove ppp examples vs public examples.

**Issue:** https://github.com/opentargets/issues/issues/3764
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A
- Test B

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
