### PR TITLE
[Platform]: link underline color on hover table rows

### DIFF
--- a/packages/ui/src/components/Link.tsx
+++ b/packages/ui/src/components/Link.tsx
@@ -8,8 +8,8 @@ import OtAsyncTooltip from "./OtAsyncTooltip/OtAsyncTooltip";
 const useStyles = makeStyles(theme => ({
   base: {
     fontSize: "inherit",
-    "text-decoration-color": "white",
-    "-webkit-text-decoration-color": "white",
+    "text-decoration-color": "transparent",
+    "-webkit-text-decoration-color": "transparent",
   },
   baseDefault: {
     color: theme.palette.primary.main,


### PR DESCRIPTION
# [Platform]: link underline color on hover table rows

Make default transparent

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
