### PR TITLE
fix: sample size as string locale

### DIFF
--- a/packages/sections/src/disease/GWASStudies/Body.tsx
+++ b/packages/sections/src/disease/GWASStudies/Body.tsx
@@ -7,6 +7,7 @@ import Description from "./Description";
 
 import GWAS_STUDIES_BODY_QUERY from "./GWASStudiesQuery.gql";
 import { definition } from ".";
+import { renderMatches } from "react-router-dom";
 
 const columns = [
   {
@@ -52,6 +53,9 @@ const columns = [
   {
     id: "nSamples",
     label: "Sample size",
+    renderCell: ({ nSamples }) => {
+      return typeof nSamples === "number" ? nSamples.toLocaleString() : naLabel;
+    },
     comparator: (a, b) => a?.nSamples - b?.nSamples,
     sortable: true,
   },


### PR DESCRIPTION
Adds formatting of the sample size in the GWAS studies widget in Platform
![Screenshot 2025-03-06 at 14 47 10](https://github.com/user-attachments/assets/5a17351f-55cc-4dbc-aef0-350761a21765)
