### PR TITLE
[Platform]: Add gene column to pgx widget on variant page

### DIFF
--- a/packages/sections/src/variant/Pharmacogenomics/Body.tsx
+++ b/packages/sections/src/variant/Pharmacogenomics/Body.tsx
@@ -144,6 +144,19 @@ function Body({ id, entity }: BodyProps) {
       filterValue: ({ pgxCategory }) => pgxCategory,
     },
     {
+      id: "target.approvedSymbol",
+      label: "Gene",
+      renderCell: ({ target }) => {
+        if (!target) return naLabel;
+        return (
+          <Link asyncTooltip to={`/target/${target.id}`}>
+            {target.approvedSymbol}
+          </Link>
+        );
+      },
+      filterValue: ({ target }) => target.approvedSymbol,
+    },
+    {
       id: "isDirectTarget",
       label: "Direct drug target",
       renderCell: ({ isDirectTarget }) => {

--- a/packages/sections/src/variant/Pharmacogenomics/PharmacogenomicsQuery.gql
+++ b/packages/sections/src/variant/Pharmacogenomics/PharmacogenomicsQuery.gql
@@ -6,6 +6,10 @@ query PharmacogenomicsQuery($variantId: String!) {
     pharmacogenomics {
       genotypeId
       isDirectTarget
+      target {
+        id
+        approvedSymbol
+      }
       drugs {
         drugFromSource
         drugId


### PR DESCRIPTION
## Description

Add gene column to pgx widget on variant page.

**Issue:** [3792](https://github.com/opentargets/issues/issues/3792)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
