### PR TITLE
[Platform]: fix ld typo in credible set confidence tooltip

### DIFF
--- a/apps/platform/src/pages/CredibleSetPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/CredibleSetPage/ProfileHeader.tsx
@@ -139,7 +139,7 @@ function ProfileHeader() {
           loading={loading}
           title={
             <Tooltip
-              title="Fine-mapping confidence based on the quality of the linkage-desequilibrium information available and fine-mapping method"
+              title="Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method"
               showHelpIcon
             >
               Confidence

--- a/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
@@ -132,7 +132,7 @@ function getColumns(targetSymbol) {
       label: "Fine-mapping confidence",
       sortable: true,
       tooltip:
-        "Fine-mapping confidence based on the quality of the linkage-desequilibrium information available and fine-mapping method",
+        "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
       renderCell: ({ credibleSet }) => {
         if (!credibleSet?.confidence) return naLabel;
         return (

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -98,7 +98,7 @@ const columns = [
     id: "confidence",
     label: "Fine-mapping confidence",
     tooltip:
-      "Fine-mapping confidence based on the quality of the linkage-desequilibrium information available and fine-mapping method",
+      "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
     sortable: true,
     renderCell: ({ confidence }) => {
       if (!confidence) return naLabel;

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -190,7 +190,7 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       id: "confidence",
       label: "Fine-mapping confidence",
       tooltip:
-        "Fine-mapping confidence based on the suitability of the linkage-desequilibrium information and fine-mapping method",
+        "Fine-mapping confidence based on the suitability of the linkage-disequilibrium information and fine-mapping method",
       sortable: true,
       renderCell: ({ confidence }) => {
         if (!confidence) return naLabel;

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -199,7 +199,7 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       id: "confidence",
       label: "Fine-mapping confidence",
       tooltip:
-        "Fine-mapping confidence based on the quality of the linkage-desequilibrium information available and fine-mapping method",
+        "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
       sortable: true,
       renderCell: ({ confidence }) => {
         if (!confidence) return naLabel;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/b4ff0227-a7bc-48da-a6b4-4980275e7a6a)

Fixes the above typo (should be linkage-**_disequilibrium_**) in the confidence tooltip.






