### PR TITLE
[Platform]: Fix study page profile for FinnGen studies

### DIFF
--- a/apps/platform/src/pages/StudyPage/Header.tsx
+++ b/apps/platform/src/pages/StudyPage/Header.tsx
@@ -40,7 +40,7 @@ function Header({
       id: "GWAS Catalog",
       url: `https://www.ebi.ac.uk/gwas/studies/${studyId}`,
     };
-  } else if (projectId === "FINNGEN_R11") {
+  } else if (projectId?.startsWith("FINNGEN")) {
     if (diseases?.length) {
       traitLinks = (
         <XRefLinks
@@ -53,7 +53,7 @@ function Header({
     }
     sourceLink = {
       id: "FinnGen",
-      url: `https://r10.finngen.fi/pheno/${studyId}`,
+      url: `https://r12.finngen.fi/pheno/${studyId.slice(12)}`, // remove FINNGEN_R12_ from start
     };
   } else if (projectId === "UKB_PPP_EUR") {
     if (diseases?.length) {

--- a/packages/sections/src/disease/GWASStudies/Description.tsx
+++ b/packages/sections/src/disease/GWASStudies/Description.tsx
@@ -8,7 +8,7 @@ function Description({ name }) {
         GWAS Catalog
       </Link>
       ,{" "}
-      <Link external to="https://r10.finngen.fi">
+      <Link external to="https://r12.finngen.fi">
         FinnGen
       </Link>
       .

--- a/packages/sections/src/study/SharedTraitStudies/Description.tsx
+++ b/packages/sections/src/study/SharedTraitStudies/Description.tsx
@@ -12,7 +12,7 @@ function Description({ studyId }: DescriptionProps) {
         GWAS Catalog
       </Link>
       ,{" "}
-      <Link external to="https://r10.finngen.fi">
+      <Link external to="https://r12.finngen.fi">
         FinnGen
       </Link>
       .


### PR DESCRIPTION
## Description

Fix study page profile for FinnGen studies.

Also update FinnGen links to R12. (This is expected to be the last FinGenn release so should not be an ongoing issue.)

**Issue:** [#3789](https://github.com/opentargets/issues/issues/3789)
**Deploy preview:**

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
