### PR TITLE
[Platform] Harmonise credible set navigate and L2G score columns

### DIFF
--- a/packages/sections/src/credibleSet/GWASColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Body.tsx
@@ -18,8 +18,9 @@ import { ReactElement, useEffect, useState } from "react";
 const columns = [
   {
     id: "otherStudyLocus.studyLocusId",
-    label: "Navigate",
+    label: "Credible set",
     enableHiding: false,
+    sticky: true,
     renderCell: ({ otherStudyLocus }) => {
       if (!otherStudyLocus?.variant) return naLabel;
       return <Navigate to={`/credible-set/${otherStudyLocus.studyLocusId}`} />;
@@ -188,7 +189,8 @@ const columns = [
   {
     id: "clpp",
     label: "CLPP",
-    tooltip: "The sum of the products of the fine-mapping posterior probabilities for overlapping variants between two study loci",
+    tooltip:
+      "The sum of the products of the fine-mapping posterior probabilities for overlapping variants between two study loci",
     numeric: true,
     filterValue: false,
     comparator: (a, b) => a?.clpp - b?.clpp,

--- a/packages/sections/src/credibleSet/MolQTLColoc/Body.tsx
+++ b/packages/sections/src/credibleSet/MolQTLColoc/Body.tsx
@@ -18,7 +18,8 @@ import { useEffect, useState } from "react";
 const columns = [
   {
     id: "otherStudyLocus.studyLocusId",
-    label: "Navigate",
+    label: "Credible set",
+    sticky: true,
     renderCell: ({ otherStudyLocus }) => {
       if (!otherStudyLocus?.variant) return naLabel;
       return <Navigate to={`/credible-set/${otherStudyLocus.studyLocusId}`} />;
@@ -209,7 +210,8 @@ const columns = [
   {
     id: "clpp",
     label: "CLPP",
-    tooltip: "The sum of the products of the fine-mapping posterior probabilities for overlapping variants between two study loci",
+    tooltip:
+      "The sum of the products of the fine-mapping posterior probabilities for overlapping variants between two study loci",
     filterValue: false,
     numeric: true,
     comparator: (a, b) => a?.clpp - b?.clpp,

--- a/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
+++ b/packages/sections/src/evidence/GWASCredibleSets/Body.jsx
@@ -158,11 +158,9 @@ function getColumns(targetSymbol, targetId) {
       label: "L2G score",
       tooltip: (
         <>
-          Causal inference score - see{" "}
-          <Link
-            external
-            to="https://platform-docs.opentargets.org/evidence#open-targets-genetics-portal"
-          >
+          Machine learning prediction linking a gene to a credible set using all features. Score
+          range [0,1]. See{" "}
+          <Link external to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g">
             our documentation
           </Link>{" "}
           for more information.
@@ -177,15 +175,6 @@ function getColumns(targetSymbol, targetId) {
             targetId={targetId}
             studyLocusId={credibleSet?.studyLocusId}
           />
-        );
-        return (
-          <Tooltip title={score.toFixed(3)} style="">
-            <Box sx={{ display: "flex", flexDirection: "row", gap: 1, alignItems: "center" }}>
-              {score.toFixed(3)}
-              cee
-              <OtScoreLinearBar variant="determinate" value={score * 100} />
-            </Box>
-          </Tooltip>
         );
       },
     },

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -115,7 +115,15 @@ const columns = [
     id: "topL2G",
     label: "Top L2G",
     filterValue: ({ l2GPredictions }) => l2GPredictions?.rows[0]?.target.approvedSymbol,
-    tooltip: "Top gene prioritised by our locus-to-gene model",
+    tooltip: (
+      <>
+        Top gene prioritised by our locus-to-gene model. See{" "}
+        <Link external to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g">
+          our documentation
+        </Link>{" "}
+        for more information.
+      </>
+    ),
     renderCell: ({ l2GPredictions }) => {
       const target = l2GPredictions?.rows[0]?.target;
       if (!target) return naLabel;

--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -5,7 +5,7 @@ import {
   DisplayVariantId,
   Tooltip,
   ClinvarStars,
-  OtScoreLinearBar,
+  L2GScoreIndicator,
   OtTable,
   useBatchQuery,
   Navigate,
@@ -28,8 +28,9 @@ import { ReactElement, useEffect, useState } from "react";
 const columns = [
   {
     id: "studyLocusId",
-    label: "Navigate",
+    label: "Credible set",
     enableHiding: false,
+    sticky: true,
     renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
   },
   {
@@ -135,16 +136,20 @@ const columns = [
       false
     ),
     sortable: true,
-    tooltip:
-      "Machine learning prediction linking a gene to a credible set using all features. Score range [0,1].",
-    renderCell: ({ l2GPredictions }) => {
+    tooltip: (
+      <>
+        Machine learning prediction linking a gene to a credible set using all features. Score range
+        [0,1]. See{" "}
+        <Link external to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g">
+          our documentation
+        </Link>{" "}
+        for more information.
+      </>
+    ),
+    renderCell: ({ studyLocusId, l2GPredictions }) => {
       const score = l2GPredictions?.rows[0]?.score;
-      if (typeof score !== "number") return naLabel;
-      return (
-        <Tooltip title={score.toFixed(3)} style="">
-          <OtScoreLinearBar variant="determinate" value={score * 100} />
-        </Tooltip>
-      );
+      if (!score) return naLabel;
+      return <L2GScoreIndicator score={score} studyLocusId={studyLocusId} />;
     },
     exportValue: ({ l2GPredictions }) => l2GPredictions?.rows[0]?.score,
   },

--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -203,19 +203,7 @@ function renderTooltip(datum) {
             )}
           </Box>
           <Box display="flex" alignItems="center" gap={0.5}>
-            Score:{" "}
-            {datum.l2GPredictions?.rows?.[0]?.score ? (
-              <Tooltip title={datum.l2GPredictions.rows[0].score.toFixed(3)} style="">
-                <div>
-                  <OtScoreLinearBar
-                    variant="determinate"
-                    value={datum.l2GPredictions.rows[0].score * 100}
-                  />
-                </div>
-              </Tooltip>
-            ) : (
-              naLabel
-            )}
+            Score: {datum.l2GPredictions?.rows?.[0]?.score?.toFixed(3) ?? naLabel}
           </Box>
         </Box>
       </ObsTooltipRow>

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -9,7 +9,8 @@ import { mantissaExponentComparator, variantComparator } from "@ot/utils";
 const columns = [
   {
     id: "studyLocusId",
-    label: "Navigate",
+    label: "Credible set",
+    sticky: true,
     renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
   },
   {

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -6,7 +6,7 @@ import {
   OtTable,
   Tooltip,
   ClinvarStars,
-  OtScoreLinearBar,
+  L2GScoreIndicator,
   useBatchQuery,
   Navigate,
 } from "ui";
@@ -36,7 +36,8 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
   return [
     {
       id: "studyLocusId",
-      label: "Navigate",
+      label: "Credible set",
+      sticky: true,
       enableHiding: false,
       renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
     },
@@ -227,15 +228,20 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
         false
       ),
       sortable: true,
-      tooltip:
-        "Machine learning prediction linking a gene to a credible set using all features. Score range [0,1].",
-      renderCell: ({ l2GPredictions }) => {
-        if (!l2GPredictions?.rows[0]?.score) return naLabel;
-        return (
-          <Tooltip title={l2GPredictions?.rows[0].score.toFixed(3)} style="">
-            <OtScoreLinearBar variant="determinate" value={l2GPredictions?.rows[0].score * 100} />
-          </Tooltip>
-        );
+      tooltip: (
+        <>
+          Machine learning prediction linking a gene to a credible set using all features. Score
+          range [0,1]. See{" "}
+          <Link external to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g">
+            our documentation
+          </Link>{" "}
+          for more information.
+        </>
+      ),
+      renderCell: ({ studyLocusId, l2GPredictions }) => {
+        const score = l2GPredictions?.rows[0]?.score;
+        if (!score) return naLabel;
+        return <L2GScoreIndicator score={score} studyLocusId={studyLocusId} />;
       },
       exportValue: ({ l2GPredictions }) => l2GPredictions?.rows[0]?.score,
     },

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -207,7 +207,15 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
       id: "l2Gpredictions",
       label: "Top L2G",
       filterValue: ({ l2GPredictions }) => l2GPredictions?.rows[0]?.target?.approvedSymbol,
-      tooltip: "Top gene prioritised by our locus-to-gene model",
+      tooltip: (
+        <>
+          Top gene prioritised by our locus-to-gene model. See{" "}
+          <Link external to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g">
+            our documentation
+          </Link>{" "}
+          for more information.
+        </>
+      ),
       renderCell: ({ l2GPredictions }) => {
         if (!l2GPredictions?.rows[0]?.target) return naLabel;
         const { target } = l2GPredictions?.rows[0];

--- a/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
@@ -392,19 +392,7 @@ function renderTooltip(datum) {
             )}
           </Box>
           <Box display="flex" alignItems="center" gap={0.5}>
-            Score:{" "}
-            {datum.l2GPredictions?.rows?.[0]?.score ? (
-              <Tooltip title={datum.l2GPredictions.rows[0].score.toFixed(3)} style="">
-                <div>
-                  <OtScoreLinearBar
-                    variant="determinate"
-                    value={datum.l2GPredictions.rows[0].score * 100}
-                  />
-                </div>
-              </Tooltip>
-            ) : (
-              naLabel
-            )}
+            Score: {datum.l2GPredictions?.rows?.[0]?.score?.toFixed(3) ?? naLabel}
           </Box>
         </Box>
       </ObsTooltipRow>

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -34,8 +34,9 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
   return [
     {
       id: "studyLocusId",
-      label: "Navigate",
+      label: "Credible set",
       enableHiding: false,
+      sticky: true,
       renderCell: ({ studyLocusId }) => <Navigate to={`/credible-set/${studyLocusId}`} />,
     },
     {


### PR DESCRIPTION
## Description

Harmonise credible set navigate and L2G score columns.

Also change L2G score in Manhattan and PheWas plots from bar to number.

**Issue:** [#3787](https://github.com/opentargets/issues/issues/3787)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
