### PR TITLE
[Platform]: Update navigate to credible set row in plot tooltips

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -154,9 +154,9 @@ export default ManhattanPlot;
 function renderTooltip(datum) {
   return (
     <ObsTooltipTable>
-      <ObsTooltipRow label="Navigate">
+      <ObsTooltipRow label="Credible set">
         <Box display="flex">
-          <Navigate to={`../credible-set/${datum.studyLocusId}`} />
+          <Navigate to={`/credible-set/${datum.studyLocusId}`} />
         </Box>
       </ObsTooltipRow>
       <ObsTooltipRow label="Lead variant">

--- a/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
@@ -1,17 +1,16 @@
 import { Fragment } from "react";
 import * as PlotLib from "@observablehq/plot";
 import { Box, Chip, Skeleton, Typography, useTheme } from "@mui/material";
-import { faArrowRightToBracket } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+
 import {
   ClinvarStars,
   Tooltip,
   Link,
   DisplayVariantId,
-  OtScoreLinearBar,
   ObsPlot,
   ObsTooltipTable,
   ObsTooltipRow,
+  Navigate,
   ScientificNotation,
   DataDownloader,
 } from "ui";
@@ -320,10 +319,10 @@ function renderTooltip(datum) {
 
   return (
     <ObsTooltipTable>
-      <ObsTooltipRow label="Navigate">
-        <Link to={`/credible-set/${datum.studyLocusId}`}>
-          <FontAwesomeIcon icon={faArrowRightToBracket} />
-        </Link>
+      <ObsTooltipRow label="Credible set">
+        <Box display="flex">
+          <Navigate to={`/credible-set/${datum.studyLocusId}`} />
+        </Box>
       </ObsTooltipRow>
       <ObsTooltipRow label="Lead variant">
         {datum.variant.id === datum._pageId ? (


### PR DESCRIPTION
## Description

Update navigate to credible set row in PheWas and Manhattan plot tooltips. (A previous PR updated the L2G score row in the tooltips but not the first row.)

**Issue:** [#3787](https://github.com/opentargets/issues/issues/3787)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
