### PR TITLE
[Platform] L2G waterfall plot - handle when all bars have zero length

### DIFF
--- a/packages/ui/src/components/HeatmapTable/HeatmapTable.tsx
+++ b/packages/ui/src/components/HeatmapTable/HeatmapTable.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
-import { hsl } from "d3";
-import { ObsPlot, DataDownloader, Link, Tooltip } from "../../index";
+import { hsl, scaleLinear } from "d3";
+import { ObsPlot, DataDownloader, Link } from "../../index";
 import { Box, Typography, Popover, Dialog } from "@mui/material";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faChevronRight, faXmark } from "@fortawesome/free-solid-svg-icons";
@@ -158,7 +158,15 @@ function HeatCell({ value, bgrd, groupName, mouseLeaveRow, waterfallRow, waterfa
     filteredWaterfallRow.features = filteredWaterfallRow.features.filter(d => {
       return featureToGroup[d.name] === groupName;
     });
-    const { row, xDomain } = computeWaterfall(filteredWaterfallRow, waterfallXDomain, true);
+    let { row, xDomain } = computeWaterfall(filteredWaterfallRow, waterfallXDomain, true);
+    if (xDomain.some(Number.isNaN)) {
+      // all Shapley values are zero
+      const fullExtent = waterfallXDomain[1] - waterfallXDomain[0];
+      xDomain = scaleLinear()
+        .domain([-fullExtent / 8, fullExtent / 8])
+        .nice()
+        .domain();
+    }
     const plotWidth =
       waterfallMargins.left +
       waterfallMargins.right +


### PR DESCRIPTION
## Description

Explicitly set a non-empty x domain when waterfall plot has only zero-length bars.

**Issue:** [#3793](https://github.com/opentargets/issues/issues/3793)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
