### PR TITLE
[Platform]: Fix font size in pharmacovigilance table

### DIFF
--- a/packages/sections/src/drug/AdverseEvents/Body.jsx
+++ b/packages/sections/src/drug/AdverseEvents/Body.jsx
@@ -30,7 +30,7 @@ const getColumns = (critVal, maxLlr, classes) => [
     renderCell: d =>
       d.meddraCode ? (
         <Link to={`https://identifiers.org/meddra:${d.meddraCode}`} external>
-          <Typography variant="caption" noWrap display="block" title={_.upperFirst(d.name)}>
+          <Typography variant="body2" noWrap display="block" title={_.upperFirst(d.name)}>
             {_.upperFirst(d.name)}
           </Typography>
         </Link>


### PR DESCRIPTION
## Description

Fix font size in pharmacovigilance table.

**Issue:** [#3787](https://github.com/opentargets/issues/issues/3787)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
