### PR TITLE
[AppConfig] environment variable based config

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -2,24 +2,6 @@ name: Image
 
 on:
   workflow_call:
-    inputs:
-      flavor:
-        description: 'Either platform or ppp. Will be appended after the repo name, e.g. ot-ui-apps/ot-ui-apps-platform:1.0.0'
-        type: string
-        default: 'platform'
-        required: true
-      api_url:
-        description: 'The API URL'
-        type: string
-        required: true
-      ai_api_url:
-        description: 'The AI API URL'
-        type: string
-        required: true
-    secrets:
-      google_tag_manager_id:
-        description: 'The Google Tag Manager ID'
-        required: true
 
 jobs:
   build:
@@ -77,15 +59,6 @@ jobs:
           name: bundle
           path: apps/platform/bundle-platform
 
-      - name: write config
-        run: |
-          cat << EOF > apps/platform/bundle-platform/config.js
-          var configUrlApi = '${{ inputs.api_url }}'
-          var configOTAiApi = '${{ inputs.ai_api_url }}'
-          var configGoogleTagManagerID = '${{ secrets.google_tag_manager_id }}'
-          EOF
-          cat apps/platform/public/profiles/${{ inputs.flavor }}.js >> apps/platform/bundle-platform/config.js
-
       - id: push
         name: Build and push Docker image
         uses: docker/build-push-action@v5
@@ -93,15 +66,15 @@ jobs:
           context: ./apps/platform
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/${{ env.REPO }}-${{ inputs.flavor }}:latest
-            ghcr.io/${{ github.repository }}/${{ env.REPO }}-${{ inputs.flavor }}:${{ env.TAG }}
-            europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}-${{ inputs.flavor }}:latest
-            europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}-${{ inputs.flavor }}:${{ env.TAG }}
+            ghcr.io/${{ github.repository }}/${{ env.REPO }}:latest
+            ghcr.io/${{ github.repository }}/${{ env.REPO }}:${{ env.TAG }}
+            europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}:latest
+            europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}:${{ env.TAG }}
 
       - id: generate-attestations
         name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2
         with:
-          subject-name: europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}-${{ inputs.flavor }}
+          subject-name: europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -13,25 +13,9 @@ jobs:
     uses: ./.github/workflows/build.yaml
     needs: ci
 
-  image_platform:
+  image:
     uses: ./.github/workflows/image.yaml
     needs: build
-    with:
-      flavor: 'platform'
-      api_url: https://api.platform.opentargets.org/api/v4/graphql
-      ai_api_url: https://ai.platform.opentargets.org
-    secrets:
-      google_tag_manager_id: ${{ secrets.PLATFORM_GOOGLE_TAG_MANAGER_ID }}
-
-  image_ppp:
-    uses: ./.github/workflows/image.yaml
-    needs: build
-    with:
-      flavor: 'ppp'
-      api_url: https://api.partner-platform.opentargets.org/api/v4/graphql
-      ai_api_url: https://ai.partner-platform.opentargets.org
-    secrets:
-      google_tag_manager_id: ${{ secrets.PPP_GOOGLE_TAG_MANAGER_ID }}
 
   release:
     name: Release 🚀

--- a/apps/platform/Dockerfile
+++ b/apps/platform/Dockerfile
@@ -4,9 +4,11 @@ FROM alpine
 RUN apk update
 RUN apk add --upgrade nginx brotli nginx-mod-http-brotli
 
-# copy assets and config
+# copy assets, config and entrypoint
 COPY ./bundle-platform /usr/share/nginx/html
 COPY ./etc/platform.conf /etc/nginx/http.d/platform.conf
+COPY ./etc/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 # run nginx
-CMD ["nginx", "-g", "daemon off;"]
+ENTRYPOINT [ "/entrypoint.sh" ]

--- a/apps/platform/etc/entrypoint.sh
+++ b/apps/platform/etc/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cat << EOF > /usr/share/nginx/html/config.js
+var configUrlApi = '${WEBAPP_API_URL:-https://api.platform.opentargets.org/api/v4/graphql}'
+var configOTAiApi = '${WEBAPP_OPENAI_URL:-https://ai.platform.opentargets.org}'
+var configGoogleTagManagerID = '${WEBAPP_GOOGLE_TAG_MANAGER_ID:-GTM-XXXXX}'
+EOF
+
+cat "/usr/share/nginx/html/profiles/${WEBAPP_FLAVOR:-platform}.js" >> /usr/share/nginx/html/config.js
+
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
# Change the way the config is generated

## Description

This PR changes the new build process so the configuration is passed as env vars to the `Dockerfile`. Currently we're writing the config in the GitHub action using arguments, but this is not flexible enough if we would like to build outside of GitHub. The benefit is we don't have to build two images anymore, as the specific web app config can be passed using env vars in the deployment process for platform/ppp.

## Type of change

None apply, this PR is related to workflow automation.

## How Has This Been Tested?

There is a working run of the ci/cd pipelines [in my fork](https://github.com/javfg/ot-ui-apps/actions/runs/13867640578), and a [new image](https://github.com/javfg/ot-ui-apps/pkgs/container/ot-ui-apps%2Fot-ui-apps) with platform-specific config.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation **— nothing is required atm**.
