### PR TITLE
[Platform]: Credible set variants widget - sort lead variant higher if posteriors tie

### DIFF
--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -135,7 +135,16 @@ function getColumns({ leadVariantId, leadReferenceAllele, leadAlternateAllele }:
       numeric: true,
       tooltip:
         "Posterior inclusion probability that this variant is causal within the fine-mapped credible set",
-      comparator: (rowA, rowB) => rowA?.posteriorProbability - rowB?.posteriorProbability,
+      comparator: (rowA, rowB) => {
+        const aPosterior = rowA?.posteriorProbability;
+        const bPosterior = rowB?.posteriorProbability;
+        if (aPosterior === bPosterior) {
+          if (rowA?.variant.id === leadVariantId) return 1;
+          else if (rowB?.variant.id === leadVariantId) return -1;
+          return 0;
+        }
+        return aPosterior - bPosterior;
+      },
       sortable: true,
       renderCell: ({ posteriorProbability }) => {
         if (typeof posteriorProbability !== "number") return naLabel;


### PR DESCRIPTION
## Description

Credible set variants widget - sort lead variant higher if posteriors tie.

**Issue:** [#3794](https://github.com/opentargets/issues/issues/3794)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
