### PR TITLE
[Platform] Add finemapping confidence column to qtl credible sets on study page

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -101,6 +101,11 @@ const columns = [
     tooltip:
       "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
     sortable: true,
+    comparator: nullishComparator(
+      (a, b) => a - b,
+      row => credsetConfidenceMap?.[row.confidence],
+      false
+    ),
     renderCell: ({ confidence }) => {
       if (!confidence) return naLabel;
       return (

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -1,10 +1,19 @@
 import { useQuery } from "@apollo/client";
-import { Link, SectionItem, ScientificNotation, DisplayVariantId, OtTable, Navigate } from "ui";
-import { naLabel } from "@ot/constants";
+import {
+  Link,
+  SectionItem,
+  ScientificNotation,
+  DisplayVariantId,
+  OtTable,
+  Navigate,
+  Tooltip,
+  ClinvarStars,
+} from "ui";
+import { naLabel, credsetConfidenceMap } from "@ot/constants";
 import { definition } from ".";
 import Description from "./Description";
 import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
-import { mantissaExponentComparator, variantComparator } from "@ot/utils";
+import { mantissaExponentComparator, nullishComparator, variantComparator } from "@ot/utils";
 
 const columns = [
   {
@@ -73,6 +82,27 @@ const columns = [
   {
     id: "finemappingMethod",
     label: "Fine-mapping method",
+  },
+  {
+    id: "confidence",
+    label: "Fine-mapping confidence",
+    tooltip:
+      "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
+    sortable: true,
+    comparator: nullishComparator(
+      (a, b) => a - b,
+      row => credsetConfidenceMap?.[row.confidence],
+      false
+    ),
+    renderCell: ({ confidence }) => {
+      if (!confidence) return naLabel;
+      return (
+        <Tooltip title={confidence} style="">
+          <ClinvarStars num={credsetConfidenceMap[confidence]} />
+        </Tooltip>
+      );
+    },
+    filterValue: ({ confidence }) => credsetConfidenceMap[confidence],
   },
   {
     id: "credibleSetSize",

--- a/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/study/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -19,6 +19,7 @@ query QTLCredibleSetsQuery($studyId: String!) {
           count
         }
         finemappingMethod
+        confidence
       }
     }
   }


### PR DESCRIPTION
## Description

Add finemapping confidence column to qtl credible sets on study page.

Also fix sorting on this column to use number of stars rather than confidence string.

**Issue:** [#3787](https://github.com/opentargets/issues/issues/3787)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
