### PR TITLE
[Platform]: Add links to tooltips - confidence columns and L2G heatmap legend

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/Body.tsx
@@ -98,8 +98,19 @@ const columns = [
   {
     id: "confidence",
     label: "Fine-mapping confidence",
-    tooltip:
-      "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
+    tooltip: (
+      <>
+        Fine-mapping confidence based on the suitability of the linkage-disequilibrium information
+        and fine-mapping method. See{" "}
+        <Link
+          external
+          to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+        >
+          here
+        </Link>{" "}
+        for more details.
+      </>
+    ),
     sortable: true,
     comparator: nullishComparator(
       (a, b) => a - b,

--- a/packages/sections/src/study/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/study/QTLCredibleSets/Body.tsx
@@ -86,8 +86,19 @@ const columns = [
   {
     id: "confidence",
     label: "Fine-mapping confidence",
-    tooltip:
-      "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
+    tooltip: (
+      <>
+        Fine-mapping confidence based on the suitability of the linkage-disequilibrium information
+        and fine-mapping method. See{" "}
+        <Link
+          external
+          to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+        >
+          here
+        </Link>{" "}
+        for more details.
+      </>
+    ),
     sortable: true,
     comparator: nullishComparator(
       (a, b) => a - b,

--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -190,8 +190,19 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
     {
       id: "confidence",
       label: "Fine-mapping confidence",
-      tooltip:
-        "Fine-mapping confidence based on the suitability of the linkage-disequilibrium information and fine-mapping method",
+      tooltip: (
+        <>
+          Fine-mapping confidence based on the suitability of the linkage-disequilibrium information
+          and fine-mapping method. See{" "}
+          <Link
+            external
+            to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+          >
+            here
+          </Link>{" "}
+          for more details.
+        </>
+      ),
       sortable: true,
       renderCell: ({ confidence }) => {
         if (!confidence) return naLabel;

--- a/packages/sections/src/variant/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/QTLCredibleSets/Body.tsx
@@ -206,8 +206,19 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
     {
       id: "confidence",
       label: "Fine-mapping confidence",
-      tooltip:
-        "Fine-mapping confidence based on the quality of the linkage-disequilibrium information available and fine-mapping method",
+      tooltip: (
+        <>
+          Fine-mapping confidence based on the suitability of the linkage-disequilibrium information
+          and fine-mapping method. See{" "}
+          <Link
+            external
+            to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+          >
+            here
+          </Link>{" "}
+          for more details.
+        </>
+      ),
       sortable: true,
       renderCell: ({ confidence }) => {
         if (!confidence) return naLabel;

--- a/packages/ui/src/components/HeatmapTable/HeatmapLegend.tsx
+++ b/packages/ui/src/components/HeatmapTable/HeatmapLegend.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import * as PlotLib from "@observablehq/plot";
 import { Box, Typography } from "@mui/material";
+import { Tooltip, Link } from "ui";
 
 function HeatmapLegend({ legendOptions }) {
   const containerRef = useRef(null);
@@ -14,8 +15,26 @@ function HeatmapLegend({ legendOptions }) {
   }, []);
 
   return (
-    <Box>
-      <Typography variant="subtitle2">Feature contributions (Shapley)</Typography>
+    <Box position="relative">
+      <Tooltip
+        showHelpIcon
+        title={
+          <>
+            See{" "}
+            <Link
+              external
+              to="https://platform-docs.opentargets.org/gentropy/locus-to-gene-l2g#explaining-l2g-predictions"
+            >
+              here
+            </Link>{" "}
+            for more details.
+          </>
+        }
+      >
+        <Typography variant="subtitle2" component="span">
+          Feature contributions (Shapley)
+        </Typography>
+      </Tooltip>
       <Box position="relative" top="-12px" ref={containerRef} />
     </Box>
   );


### PR DESCRIPTION
## Description

Add links to tooltips - confidence columns and L2G heatmap legend

**Issue:** [#3787](https://github.com/opentargets/issues/issues/3787)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
