### PR TITLE
fix:wrong level of nested path

### DIFF
--- a/apps/platform/src/pages/DownloadsPage/ContainedInDrawer.tsx
+++ b/apps/platform/src/pages/DownloadsPage/ContainedInDrawer.tsx
@@ -131,7 +131,7 @@ function FtpLocation({ link, version, path }) {
         Wget
       </Typography>
       <div className={classes.resourceURL}>
-        wget --recursive --no-parent --no-host-directories --cut-dirs 8
+        wget --recursive --no-parent --no-host-directories --cut-dirs 6
         ftp://ftp.ebi.ac.uk/pub/databases/opentargets/platform/{version}/output/{path} .
       </div>
     </>


### PR DESCRIPTION
Because the paths have changed, the level of directory that we want to download is different now.

This is causing the directory contents to be downloaded instead of the directory itself