### PR TITLE
[Platform]: re-oredring conditions to handle null case

### DIFF
--- a/packages/sections/src/variant/GWASCredibleSets/Body.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/Body.tsx
@@ -258,9 +258,10 @@ function getColumns({ id, referenceAllele, alternateAllele }: getColumnsType) {
         </>
       ),
       renderCell: ({ studyLocusId, l2GPredictions }) => {
+        if (!l2GPredictions || !l2GPredictions.rows.length) return naLabel;
         const score = l2GPredictions?.rows[0]?.score;
-        const { target } = l2GPredictions?.rows[0];
         if (!score) return naLabel;
+        const { target } = l2GPredictions?.rows[0];
         return <L2GScoreIndicator score={score} studyLocusId={studyLocusId} targetId={target.id} />;
       },
       exportValue: ({ l2GPredictions }) => l2GPredictions?.rows[0]?.score,


### PR DESCRIPTION
# [Platform]: re-oredring conditions to handle null case

## Description

re-oredring conditions to handle null case

**Issue:** https://github.com/opentargets/issues/issues/3869
**Deploy preview:** https://deploy-preview-731--ot-platform.netlify.app/variant/2_59928185_A_T

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A:  Go to https://platform.opentargets.org/variant/2_59928185_A_T gwas cred widget is crashing
- Test B:  Go to https://deploy-preview-731--ot-platform.netlify.app/variant/2_59928185_A_T gwas cred widget should not crash

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
