### PR TITLE
[Platform] Fixed typo in population ancestry description

### DIFF
--- a/packages/ot-constants/src/index.ts
+++ b/packages/ot-constants/src/index.ts
@@ -292,7 +292,7 @@ export const variantConsequenceSource = {
 
 // Population Mapping
 export const populationMap: { [key: string]: string } = {
-  fin: "Finish",
+  fin: "Finnish",
   afr: "African",
   nfe: "non-Finnish Europeans",
   eas: "East Asian",


### PR DESCRIPTION
## Description

**Issue:** [#3872](https://github.com/opentargets/issues/issues/3872)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
