### PR TITLE
[AppConfig] input-based manual release

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,33 +1,49 @@
-name: Build
+name: Build bundle
 
 on:
   workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'Tag to build against'
+        required: true
+      data_release_location:
+        type: string
+        description: 'Location of the data release'
+        required: false
 
 jobs:
   bundle:
     name: Bundle 📦
     runs-on: ubuntu-22.04
+    env:
+      TAG: ${{ inputs.tag }}
+      DATA_RELEASE_LOCATION: ${{ inputs.data_release_location || '' }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+
       - uses: actions/setup-node@v4
         with:
           node-version: 23
 
-      # prepare environment
       - name: Prepare environment
         run: |
-          DATA_RELEASE=$(node -p "require('./package.json').dataRelease")
-          echo "DATA_RELEASE=$DATA_RELEASE" >> $GITHUB_ENV
-          echo "building for data release $DATA_RELEASE"
+          if [ -z "$DATA_RELEASE_LOCATION" ]; then
+            echo "Building $TAG with default data"
+          else
+            echo "Building $TAG with data from $DATA_RELEASE_LOCATION"
+          fi
 
       - uses: mskelton/setup-yarn@v3
+
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
-      # authenticate in google cloud
       - uses: google-github-actions/auth@v2
         with:
           token_format: access_token
@@ -37,13 +53,13 @@ jobs:
           access_token_lifetime: 300s
       - uses: google-github-actions/setup-gcloud@v2
 
-      # copy disease ontology from release google bucket
       - name: copy disease ontology
-        run: gsutil cp gs://open-targets-pre-data-releases/${{ env.DATA_RELEASE }}/webapp/disease.jsonl apps/platform/public/data/ontology/efo_json/diseases_efo.jsonl
+        if: ${{ env.DATA_RELEASE_LOCATION != '' }}
+        run: gsutil cp ${{ env.DATA_RELEASE_LOCATION }}/webapp/disease.jsonl apps/platform/public/data/ontology/efo_json/diseases_efo.jsonl
 
-      # copy croissant metadata from release google bucket
       - name: copy croissant metadata
-        run: gsutil cp gs://open-targets-pre-data-releases/${{ env.DATA_RELEASE }}/webapp/downloads.json apps/platform/public/data/downloads.json
+        if: ${{ env.DATA_RELEASE_LOCATION != '' }}
+        run: gsutil cp ${{ env.DATA_RELEASE_LOCATION }}/webapp/downloads.json apps/platform/public/data/downloads.json
 
       - name: Build
         run: yarn build:platform

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -1,7 +1,12 @@
-name: Image
+name: Build images
 
 on:
   workflow_call:
+    inputs:
+      tag:
+        type: string
+        description: 'Tag to build against'
+        required: true
 
 jobs:
   build:
@@ -13,21 +18,19 @@ jobs:
       attestations: write
       id-token: write
     env:
-      TAG: ${{ github.ref_name }}
+      TAG: ${{ inputs.tag }}
       REPO: ${{ github.event.repository.name }}
     steps:
       # prepare environment
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
       - name: Prepare environment
         run: |
-          DATA_RELEASE=$(node -p "require('./package.json').dataRelease")
-          echo "DATA_RELEASE=$DATA_RELEASE" >> $GITHUB_ENV
           TAG=$(echo $TAG | sed 's/^v//')
           echo "TAG=$TAG" >> $GITHUB_ENV
-          echo "building for data release $DATA_RELEASE"
           echo "The tag for this build is $TAG"
           echo "The repo name is: $REPO"
-          echo "Github context:\n$GITHUB_CONTEXT"
 
       # authenticate in google cloud
       - id: auth-google
@@ -61,7 +64,7 @@ jobs:
 
       - id: push
         name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: ./apps/platform
           push: true

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,9 +1,19 @@
-name: Development build
+name: Publish release
 
 on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+    inputs:
+      tag:
+        type: string
+        description: 'Tag to build against'
+        required: true
+      data_release_location:
+        type: string
+        description: 'Location of the data release'
+        required: true
 
 jobs:
   ci:
@@ -12,10 +22,15 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
     needs: ci
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
+      data_release_location: ${{ inputs.data_release_location || '' }}
 
   image:
     uses: ./.github/workflows/image.yaml
     needs: build
+    with:
+      tag: ${{ inputs.tag || github.ref_name }}
 
   release:
     name: Release 🚀
@@ -24,9 +39,12 @@ jobs:
     permissions:
       contents: write
     env:
-      TAG: ${{ github.ref_name }}
+      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
-      - name: Prepare tag
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TAG }}
+      - name: Prepare release tag
         run: |
           TAG=$(echo $TAG | sed 's/^v//')
           echo "TAG=$TAG" >> $GITHUB_ENV
@@ -41,8 +59,8 @@ jobs:
           gh release create
           --draft
           --repo ${{ github.repository }}
-          --title ${{ github.ref_name }}
-          ${{ github.ref_name }}
+          --title ${{ env.TAG }}
+          ${{ env.TAG }}
           bundle.tar.gz
         env:
           GH_TOKEN: ${{ github.token }}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "ot-ui-apps",
   "version": "0.0.1",
-  "dataRelease": "25.06",
   "private": true,
   "license": "Apache-2.0",
   "workspaces": [


### PR DESCRIPTION
# [AppConfig]: Manual workflow trigger with custom inputs

## Description

Approximately a month ago we (@carcruz @jdhayhurst) discussed about the best option to provide the data files the frontend needs for its build process (disease_efo and the croissant). I'm going to summarize here because some time has passed.

* We have to provide defaults so anybody can build the frontend
* We need to authenticate in GCP to pull the latest files for our own builds
* We shouldn't tie the frontend repo to a data release, because although web is usually dependent on one, we have multiple test runs and each would require a change in the frontend (imagine 25.06-testrun-1, 2, etc).

The best idea right now is to provide those two data files in the repo itself as defaults (as we currently do already), and pass a Google Cloud bucket as an argument to the build workflow, that, if present, overwrites the default files.

If your build process is triggered by a tag, like before, it will use the defaults inside the repo. But if you want to provide different files, you can overwrite them by triggering a run of the build process yourself, and specifying where to fetch the files from.

This PR does that. Besides triggering the workflow automatically on a tag, you can now run it manually:

![image](https://github.com/user-attachments/assets/cdc8504e-26cb-4a5c-b5c4-6342b06970fb)

And pass the relevant data location in there.

> [!WARNING]
It is **very important** that the locations are always a private bucket controlled by us, as this could otherwise be used to inject malicious files into the bundle.

For now, we have to provide both the tag and the path, as the trigger is not on tag anymore.

## Type of change

This is a change on the build workflow.

