### PR TITLE
[Platform]: Target page structure viewer - fix scroll and add info button 

### DIFF
--- a/packages/sections/src/variant/ProteinStructure/InfoPopper.tsx
+++ b/packages/sections/src/variant/ProteinStructure/InfoPopper.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faInfo } from "@fortawesome/free-solid-svg-icons";
+import { Box, Button, Typography } from "@mui/material";
+import { Tooltip } from "ui";
+
+function InfoPopper() {
+  const [isClicked, setIsClicked] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+
+  const handleClick = () => {
+    setIsHovered(false);
+    setIsClicked(prev => !prev);
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+  };
+
+  const handleMouseLeave = () => {
+    setIsHovered(false);
+  };
+
+  const tooltipOpen = isClicked || isHovered;
+
+  return (
+    <div>
+      <Tooltip
+        open={tooltipOpen}
+        slotProps={isClicked ? { tooltip: { sx: { borderColor: "#bbb" } } } : {}}
+        title={
+          <Box onClick={handleClick} sx={{ cursor: "pointer" }}>
+            <table style={{ borderSpacing: "0.3rem 0" }}>
+              <tbody>
+                <tr>
+                  <Typography component="td" variant="caption">
+                    <strong>Rotate:</strong>
+                  </Typography>
+                  <Typography component="td" variant="caption">
+                    Drag
+                  </Typography>
+                </tr>
+                <tr>
+                  <Typography component="td" variant="caption">
+                    <strong>Move:</strong>
+                  </Typography>
+                  <Typography component="td" variant="caption">
+                    Ctrl + Drag
+                  </Typography>
+                </tr>
+                <tr>
+                  <Typography component="td" variant="caption">
+                    <strong>Zoom:</strong>
+                  </Typography>
+                  <Typography component="td" variant="caption">
+                    Ctrl + Scroll
+                  </Typography>
+                </tr>
+                <tr>
+                  <Typography component="td" variant="caption">
+                    <strong>Variant:</strong>
+                  </Typography>
+                  <Typography component="td" variant="caption">
+                    Double click
+                  </Typography>
+                </tr>
+              </tbody>
+            </table>
+          </Box>
+        }
+        disableFocusListener
+        disableTouchListener
+        placement="top-end"
+      >
+        <Button
+          onClick={handleClick}
+          onMouseEnter={handleMouseEnter}
+          onMouseLeave={handleMouseLeave}
+          sx={{
+            bgcolor: "white",
+            "&:hover": {
+              bgcolor: "#f8f8f8d8",
+            },
+          }}
+        >
+          <FontAwesomeIcon icon={faInfo} />
+        </Button>
+      </Tooltip>
+    </div>
+  );
+}
+
+export default InfoPopper;

--- a/packages/sections/src/variant/ProteinStructure/Viewer.tsx
+++ b/packages/sections/src/variant/ProteinStructure/Viewer.tsx
@@ -1,4 +1,4 @@
-import { CompactAlphaFoldLegend } from "ui";
+import { CompactAlphaFoldLegend, Tooltip } from "ui";
 import { getAlphaFoldConfidence } from "@ot/constants";
 import { createViewer } from "3dmol";
 import { Box, Typography, Button } from "@mui/material";
@@ -7,6 +7,7 @@ import { useState, useEffect, useRef } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCamera } from "@fortawesome/free-solid-svg-icons";
 import { resetViewer, onClickCapture, noHoverStyle, hoverManagerFactory } from "./ViewerHelpers";
+import InfoPopper from "./InfoPopper";
 
 const alphaFoldStructureStem = "https://alphafold.ebi.ac.uk/files/";
 const alphaFoldStructureSuffix = "-model_v4.cif";
@@ -63,7 +64,13 @@ function Viewer({ row }) {
           antialias: true,
           cartoonQuality: 10,
         });
-        window.viewer = viewer; // !! REMOVE !!
+        viewer.getCanvas().addEventListener(
+          "wheel",
+          event => {
+            if (!event.ctrlKey) event.stopImmediatePropagation();
+          },
+          true // use capture phase so fires before library handler
+        );
         const hoverDuration = 10;
         viewer.getCanvas().ondblclick = () => resetViewer(viewer, variantResidues, 200); // use ondblclick so replaces existing
         viewer.addModel(structureData, "cif");
@@ -95,7 +102,7 @@ function Viewer({ row }) {
     <Box ref={viewerRef} position="relative" width="100%">
       {/* container to insert viewer into */}
       <Box className="viewerContainer" position="relative" width="100%" height={320} mb={1}>
-        {/* screenshot button */}
+        {/* info and screenshot buttons */}
         {!messageText && (
           <Box
             sx={{
@@ -106,16 +113,26 @@ function Viewer({ row }) {
               display: "flex",
               justifyContent: "center",
               alignItems: "center",
-              background: "white",
               m: 1,
+              gap: 1,
             }}
           >
-            <Button
-              sx={{ display: "flex", gap: 1 }}
-              onClick={() => onClickCapture(viewerRef, state.data.id)}
-            >
-              <FontAwesomeIcon icon={faCamera} /> Screenshot
-            </Button>
+            <InfoPopper />
+            <Tooltip title="Screenshot" placement="top-start">
+              <Button
+                sx={{
+                  display: "flex",
+                  gap: 1,
+                  bgcolor: "white",
+                  "&:hover": {
+                    bgcolor: "#f8f8f8d8",
+                  },
+                }}
+                onClick={() => onClickCapture(viewerRef, row?.target.id)}
+              >
+                <FontAwesomeIcon icon={faCamera} />
+              </Button>
+            </Tooltip>
           </Box>
         )}
 

--- a/packages/sections/src/variant/ProteinStructure/ViewerHelpers.tsx
+++ b/packages/sections/src/variant/ProteinStructure/ViewerHelpers.tsx
@@ -17,7 +17,7 @@ export function resetViewer(viewer, variantResidues, duration = 0) {
   viewer.zoomTo({ resi: [...variantResidues] }, duration);
 }
 
-export function onClickCapture(viewerRef) {
+export function onClickCapture(viewerRef, targetId) {
   if (!viewerRef.current) return;
 
   try {
@@ -48,7 +48,7 @@ export function onClickCapture(viewerRef) {
     // Create a temporary link and trigger download
     const link = document.createElement("a");
     link.href = dataUrl;
-    link.download = `${ensemblId}-molecular-structure.png`;
+    link.download = `${targetId}-molecular-structure.png`;
     link.click();
   } catch (error) {
     console.error("Error taking screenshot:", error);


### PR DESCRIPTION
## Description

Target page structure viewer - fix scroll and add info button.

Also fix screenshot bug.

**Issue:** [#3840](https://github.com/opentargets/issues/issues/3840)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
