### PR TITLE
[AppConfig] Revert actions to remove manual trigger

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,42 +2,22 @@ name: Build bundle
 
 on:
   workflow_call:
-    inputs:
-      tag:
-        type: string
-        description: 'Tag to build against'
-        required: true
-      data_release_location:
-        type: string
-        description: 'Location of the data release'
-        required: false
 
 jobs:
   bundle:
     name: Bundle 📦
     runs-on: ubuntu-22.04
-    env:
-      TAG: ${{ inputs.tag }}
-      DATA_RELEASE_LOCATION: ${{ inputs.data_release_location || '' }}
     permissions:
       contents: read
       id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ github.ref_name }}
 
       - uses: actions/setup-node@v4
         with:
           node-version: 23
-
-      - name: Prepare environment
-        run: |
-          if [ -z "$DATA_RELEASE_LOCATION" ]; then
-            echo "Building $TAG with default data"
-          else
-            echo "Building $TAG with data from $DATA_RELEASE_LOCATION"
-          fi
 
       - uses: mskelton/setup-yarn@v3
 

--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -2,11 +2,6 @@ name: Build images
 
 on:
   workflow_call:
-    inputs:
-      tag:
-        type: string
-        description: 'Tag to build against'
-        required: true
 
 jobs:
   build:
@@ -18,16 +13,15 @@ jobs:
       attestations: write
       id-token: write
     env:
-      TAG: ${{ inputs.tag }}
       REPO: ${{ github.event.repository.name }}
     steps:
       # prepare environment
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.TAG }}
+          ref: ${{ github.ref_name }}
       - name: Prepare environment
         run: |
-          TAG=$(echo $TAG | sed 's/^v//')
+          TAG=$(echo ${{ github.ref_name }} | sed 's/^v//')
           echo "TAG=$TAG" >> $GITHUB_ENV
           echo "The tag for this build is $TAG"
           echo "The repo name is: $REPO"

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -4,16 +4,6 @@ on:
   push:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      tag:
-        type: string
-        description: 'Tag to build against'
-        required: true
-      data_release_location:
-        type: string
-        description: 'Location of the data release'
-        required: true
 
 jobs:
   ci:
@@ -22,15 +12,10 @@ jobs:
   build:
     uses: ./.github/workflows/build.yaml
     needs: ci
-    with:
-      tag: ${{ inputs.tag || github.ref_name }}
-      data_release_location: ${{ inputs.data_release_location || '' }}
 
   image:
     uses: ./.github/workflows/image.yaml
     needs: build
-    with:
-      tag: ${{ inputs.tag || github.ref_name }}
 
   release:
     name: Release 🚀
@@ -38,16 +23,10 @@ jobs:
     needs: build
     permissions:
       contents: write
-    env:
-      TAG: ${{ inputs.tag || github.ref_name }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ env.TAG }}
-      - name: Prepare release tag
-        run: |
-          TAG=$(echo $TAG | sed 's/^v//')
-          echo "TAG=$TAG" >> $GITHUB_ENV
+          ref: ${{ github.ref_name }}
       - uses: actions/download-artifact@v4
         with:
           name: bundle
@@ -59,8 +38,8 @@ jobs:
           gh release create
           --draft
           --repo ${{ github.repository }}
-          --title ${{ env.TAG }}
-          ${{ env.TAG }}
+          --title ${{ github.ref_name }}
+          ${{ github.ref_name }}
           bundle.tar.gz
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# [AppConfig] Revert actions to remove manual trigger

## Description

With PRs #751 and #754, it is no longer needed to fetch static assets from the data release to build the web. There is no further need to trigger manual builds with a data release path.

## Type of change

This is a revert of the build workflow back into the simpler one we had originally.
