### PR TITLE
[Platform]: Add tooltips to y-labels on variant effect plot

### DIFF
--- a/packages/sections/src/variant/VariantEffect/Body.tsx
+++ b/packages/sections/src/variant/VariantEffect/Body.tsx
@@ -23,9 +23,10 @@ const columns = [
         }
         showHelpIcon
       >
-        {method}
+        {VARIANT_EFFECT_METHODS[method].prettyName}
       </Tooltip>
     ),
+    exportValue: ({ method }) => VARIANT_EFFECT_METHODS[method].prettyName,
   },
   {
     id: "assessment",
@@ -71,7 +72,11 @@ function getSortedRows(request) {
   return request.data?.variant?.variantEffect
     ? [...request.data.variant.variantEffect]
         .filter(e => e.method !== null)
-        .sort((row1, row2) => row1.method.localeCompare(row2.method))
+        .sort((row1, row2) =>
+          VARIANT_EFFECT_METHODS[row1.method].prettyName.localeCompare(
+            VARIANT_EFFECT_METHODS[row2.method].prettyName
+          )
+        )
     : [];
 }
 


### PR DESCRIPTION
## Description

Add tooltips to y-labels on variant effect plot.

**Issue:** [#3815](https://github.com/opentargets/issues/issues/3815)
**Deploy preview:** https://deploy-preview-758--ot-platform.netlify.app/variant/19_44908822_C_T

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
