### PR TITLE
[Platform]: Adding a new column+drawer to Pharmacogenetics widgets to visualise new variant annotation dataset

### DIFF
--- a/packages/sections/src/drug/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/drug/Pharmacogenomics/Body.jsx
@@ -1,7 +1,15 @@
 import classNames from "classnames";
 import { useQuery } from "@apollo/client";
 import { makeStyles } from "@mui/styles";
-import { Link, SectionItem, Tooltip, LabelChip, PublicationsDrawer, OtTable } from "ui";
+import {
+  Link,
+  SectionItem,
+  Tooltip,
+  LabelChip,
+  PublicationsDrawer,
+  OtTable,
+  DirectionalityDrawer,
+} from "ui";
 
 import { epmcUrl, identifiersOrgLink, sentenceCase } from "@ot/utils";
 import { definition } from ".";
@@ -189,6 +197,13 @@ function Body({ id: chemblId, label: name, entity }) {
       label: "Drug Response Category",
       renderCell: ({ pgxCategory }) => pgxCategory || naLabel,
       filterValue: ({ pgxCategory }) => pgxCategory,
+    },
+    {
+      id: "directionality",
+      label: "Directionality",
+      renderCell: ({ variantAnnotation }) => (
+        <DirectionalityDrawer variantAnnotation={variantAnnotation} caption="Directionality" />
+      ),
     },
     {
       id: "isDirectTarget",

--- a/packages/sections/src/drug/Pharmacogenomics/Pharmacogenomics.gql
+++ b/packages/sections/src/drug/Pharmacogenomics/Pharmacogenomics.gql
@@ -2,6 +2,16 @@ query PharmacogenomicsQuery($chemblId: String!) {
   drug(chemblId: $chemblId) {
     id
     pharmacogenomics {
+      variantAnnotation {
+        entity
+        effect
+        effectType
+        effectDescription
+        literature
+        directionality
+        baseAlleleOrGenotype
+        comparisonAlleleOrGenotype
+      }
       variantRsId
       genotypeId
       variantFunctionalConsequence {

--- a/packages/sections/src/target/Pharmacogenomics/Body.jsx
+++ b/packages/sections/src/target/Pharmacogenomics/Body.jsx
@@ -1,7 +1,15 @@
 import { useQuery } from "@apollo/client";
 import classNames from "classnames";
 import { makeStyles } from "@mui/styles";
-import { SectionItem, Link, Tooltip, LabelChip, PublicationsDrawer, OtTable } from "ui";
+import {
+  SectionItem,
+  Link,
+  Tooltip,
+  LabelChip,
+  PublicationsDrawer,
+  OtTable,
+  DirectionalityDrawer,
+} from "ui";
 
 import { epmcUrl, identifiersOrgLink, sentenceCase } from "@ot/utils";
 import { naLabel, PHARM_GKB_COLOR, variantConsequenceSource } from "@ot/constants";
@@ -192,6 +200,13 @@ function getColumns(classes) {
       label: "Drug Response Category",
       renderCell: ({ pgxCategory }) => pgxCategory || naLabel,
       filterValue: ({ pgxCategory }) => pgxCategory,
+    },
+    {
+      id: "directionality",
+      label: "Directionality",
+      renderCell: ({ variantAnnotation }) => (
+        <DirectionalityDrawer variantAnnotation={variantAnnotation} caption="Directionality" />
+      ),
     },
     {
       id: "isDirectTarget",

--- a/packages/sections/src/target/Pharmacogenomics/Pharmacogenomics.gql
+++ b/packages/sections/src/target/Pharmacogenomics/Pharmacogenomics.gql
@@ -2,6 +2,16 @@ query PharmacogenomicsQuery($ensemblId: String!) {
   target(ensemblId: $ensemblId) {
     id
     pharmacogenomics {
+      variantAnnotation {
+        entity
+        effect
+        effectType
+        effectDescription
+        literature
+        directionality
+        baseAlleleOrGenotype
+        comparisonAlleleOrGenotype
+      }
       variantRsId
       genotypeId
       variantFunctionalConsequence {

--- a/packages/sections/src/variant/Pharmacogenomics/Body.tsx
+++ b/packages/sections/src/variant/Pharmacogenomics/Body.tsx
@@ -5,7 +5,7 @@ import PHARMACOGENOMICS_QUERY from "./PharmacogenomicsQuery.gql";
 import { Fragment } from "react";
 import classNames from "classnames";
 import { makeStyles } from "@mui/styles";
-import { Link, Tooltip, PublicationsDrawer, OtTable, SectionItem } from "ui";
+import { Link, Tooltip, PublicationsDrawer, OtTable, SectionItem, DirectionalityDrawer } from "ui";
 import { epmcUrl } from "@ot/utils";
 import { naLabel, PHARM_GKB_COLOR } from "@ot/constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
@@ -155,6 +155,13 @@ function Body({ id, entity }: BodyProps) {
         );
       },
       filterValue: ({ target }) => target.approvedSymbol,
+    },
+    {
+      id: "directionality",
+      label: "Directionality",
+      renderCell: ({ variantAnnotation }) => (
+        <DirectionalityDrawer variantAnnotation={variantAnnotation} caption="Directionality" />
+      ),
     },
     {
       id: "isDirectTarget",

--- a/packages/sections/src/variant/Pharmacogenomics/PharmacogenomicsQuery.gql
+++ b/packages/sections/src/variant/Pharmacogenomics/PharmacogenomicsQuery.gql
@@ -4,6 +4,16 @@ query PharmacogenomicsQuery($variantId: String!) {
     referenceAllele
     alternateAllele
     pharmacogenomics {
+      variantAnnotation {
+        entity
+        effect
+        effectType
+        effectDescription
+        literature
+        directionality
+        baseAlleleOrGenotype
+        comparisonAlleleOrGenotype
+      }
       genotypeId
       isDirectTarget
       target {

--- a/packages/ui/src/components/DirectionalityDrawer.tsx
+++ b/packages/ui/src/components/DirectionalityDrawer.tsx
@@ -1,0 +1,216 @@
+import {
+  faArrowAltCircleDown,
+  faArrowAltCircleUp,
+  faXmark,
+} from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { Box, ButtonBase, Divider, Drawer, IconButton, Paper, Typography } from "@mui/material";
+import { useState } from "react";
+import { makeStyles } from "@mui/styles";
+import { naLabel } from "@ot/constants";
+import { v1 } from "uuid";
+import Link from "./Link";
+import OtTable from "./OtTable/OtTable";
+import Tooltip from "./Tooltip";
+
+const sourceDrawerStyles = makeStyles(theme => ({
+  drawerLink: {
+    color: `${theme.palette.primary.main} !important`,
+  },
+  drawerBody: {
+    overflowY: "overlay",
+  },
+  drawerModal: {
+    "& .MuiBackdrop-root": {
+      opacity: "0 !important",
+    },
+  },
+  drawerPaper: {
+    backgroundColor: theme.palette.grey[300],
+    maxWidth: "100%",
+  },
+  drawerTitle: {
+    borderBottom: "1px solid #ccc",
+    padding: "1rem",
+  },
+  drawerTitleCaption: {
+    color: theme.palette.grey[700],
+    fontSize: "1.2rem",
+    fontWeight: "bold",
+  },
+  AccordionExpanded: {
+    margin: "1rem !important",
+  },
+  AccordionRoot: {
+    border: "1px solid #ccc",
+    margin: "1rem 1rem 0 1rem",
+    padding: "1rem",
+    "&::before": {
+      backgroundColor: "transparent",
+    },
+  },
+  AccordionSubtitle: {
+    color: theme.palette.grey[400],
+    fontSize: "0.8rem",
+    fontStyle: "italic",
+  },
+  AccordionTitle: {
+    color: theme.palette.grey[700],
+    fontSize: "1rem",
+    fontWeight: "bold",
+  },
+  summaryBoxRoot: {
+    marginRight: "2rem",
+  },
+  blue: {
+    color: theme.palette.primary.dark,
+  },
+  grey: {
+    color: theme.palette.grey[400],
+  },
+}));
+
+const LABEL = {
+  increased: {
+    title: "Directionality: Increased",
+    icon: faArrowAltCircleUp,
+  },
+  decreased: {
+    title: "Directionality: Decreased",
+    icon: faArrowAltCircleDown,
+  },
+  default: {
+    title: naLabel,
+  },
+};
+
+export function DirectionalityList({ variantAnnotation }) {
+  const classes = sourceDrawerStyles();
+
+  function getTooltipTitle(directionality) {
+    if (!directionality) return LABEL.default.title;
+    return LABEL[directionality].title;
+  }
+
+  const columns = [
+    {
+      id: "publications",
+      label: " ",
+      renderCell: ({ directionality, effectDescription, literature }) => (
+        <Box key={v1()} sx={{ whiteSpace: "normal", display: "flex" }}>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              justifyContent: "center",
+              padding: 1,
+              mr: 1,
+              mt: "2px",
+              alignItems: "center",
+              background: theme => theme.palette.grey[200],
+              borderRadius: 4,
+              // minWidth: "40px",
+              maxWidth: "40px",
+              height: "min-content",
+            }}
+          >
+            <Tooltip title={getTooltipTitle(directionality)} style={{ background: `red` }}>
+              <FontAwesomeIcon
+                className={directionality === "increased" ? classes.blue : classes.grey}
+                icon={LABEL.increased.icon}
+                size="lg"
+              />
+              <Box sx={{ mt: 1 }}>
+                <FontAwesomeIcon
+                  className={directionality === "decreased" ? classes.blue : classes.grey}
+                  icon={LABEL.decreased.icon}
+                  size="lg"
+                />
+              </Box>
+            </Tooltip>
+          </Box>
+          <Box>
+            <Box>
+              <Box>
+                <Box sx={{ typography: "subtitle2", fontWeight: "bold" }} component="span">
+                  Description:{" "}
+                </Box>
+
+                {effectDescription}
+              </Box>
+              <Box sx={{ typography: "subtitle2", fontWeight: "bold" }} component="span">
+                Publication:{" "}
+              </Box>
+              <Link external to={literature}>
+                {literature}{" "}
+              </Link>{" "}
+            </Box>
+          </Box>
+        </Box>
+      ),
+      filterValue: ({ directionality, effectDescription, literature }) =>
+        `${directionality} ${effectDescription} ${literature}`,
+    },
+  ];
+
+  return <OtTable columns={columns} rows={variantAnnotation} showColumnVisibilityControl={false} />;
+}
+
+function DirectionalityDrawer({ variantAnnotation, customLabel, caption }) {
+  const [open, setOpen] = useState(false);
+  const classes = sourceDrawerStyles();
+
+  if (!variantAnnotation || !variantAnnotation.length) {
+    return naLabel;
+  }
+
+  function toggleDrawer(event) {
+    if (event.type === "keydown" && (event.key === "Tab" || event.key === "Shift")) {
+      return;
+    }
+    setOpen(true);
+  }
+
+  function closeDrawer() {
+    setOpen(false);
+  }
+
+  return (
+    <>
+      <ButtonBase disableRipple onClick={toggleDrawer} className={classes.drawerLink}>
+        <Typography variant="body2">
+          {" "}
+          {customLabel ||
+            `${variantAnnotation.length} ${
+              variantAnnotation.length === 1 ? "entry" : "entries"
+            }`}{" "}
+        </Typography>
+      </ButtonBase>
+
+      <Drawer
+        anchor="right"
+        classes={{ modal: classes.drawerModal, paper: classes.drawerPaper }}
+        open={open}
+        onClose={closeDrawer}
+      >
+        <Paper classes={{ root: classes.drawerTitle }} elevation={0}>
+          <Box display="flex" justifyContent="space-between" alignItems="center">
+            <Typography className={classes.drawerTitleCaption}>{caption}</Typography>
+            <IconButton onClick={closeDrawer}>
+              <FontAwesomeIcon icon={faXmark} />
+            </IconButton>
+          </Box>
+        </Paper>
+
+        <Box width={600} maxWidth="100%" className={classes.drawerBody}>
+          {open && (
+            <Box my={3} mx={3} p={3} pb={6} bgcolor="white">
+              <DirectionalityList variantAnnotation={variantAnnotation} />
+            </Box>
+          )}
+        </Box>
+      </Drawer>
+    </>
+  );
+}
+export default DirectionalityDrawer;

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -57,6 +57,7 @@ export { default as OtInvalidResultFilters } from "./components/OtInvalidResultF
 export { default as OtCopyToClipboard } from "./components/OtCopyToClipboard";
 export { default as OtBtnGroup } from "./components/OtBtnGroup";
 export { default as CopyUrlButton } from "./components/CopyUrlButton";
+export { default as DirectionalityDrawer } from "./components/DirectionalityDrawer";
 
 export * as summaryUtils from "./components/Summary/utils";
 export * from "./components/Footer";


### PR DESCRIPTION
# [Platform]: Adding a new column+drawer to Pharmacogenetics widgets to visualise new variant annotation dataset

## Description

Added a common component for directionality drawer to show the contents

**Issue:** https://github.com/opentargets/issues/issues/3913
**Deploy preview:** https://deploy-preview-759--ot-platform.netlify.app/

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Test A
- Test B

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
