### PR TITLE
[Platform]: Make plot tooltip links asynchronous

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -1,5 +1,5 @@
 import { useTheme, Box, Skeleton } from "@mui/material";
-import { ClinvarStars, Link, Tooltip, DisplayVariantId, Navigate, OtScoreLinearBar } from "ui";
+import { ClinvarStars, Link, Tooltip, DisplayVariantId, Navigate } from "ui";
 import * as PlotLib from "@observablehq/plot";
 import { ScientificNotation, ObsPlot, ObsTooltipTable, ObsTooltipRow } from "ui";
 import { naLabel, credsetConfidenceMap } from "@ot/constants";
@@ -160,7 +160,7 @@ function renderTooltip(datum) {
         </Box>
       </ObsTooltipRow>
       <ObsTooltipRow label="Lead variant">
-        <Link to={`/variant/${datum.variant.id}`}>
+        <Link asyncTooltip to={`/variant/${datum.variant.id}`}>
           <DisplayVariantId
             variantId={datum.variant.id}
             referenceAllele={datum.variant.referenceAllele}
@@ -195,7 +195,7 @@ function renderTooltip(datum) {
           <Box display="flex" gap={0.5}>
             Top:{" "}
             {datum.l2GPredictions?.rows?.[0]?.target ? (
-              <Link to={`/target/${datum.l2GPredictions.rows[0].target.id}`}>
+              <Link asyncTooltip to={`/target/${datum.l2GPredictions.rows[0].target.id}`}>
                 {datum.l2GPredictions.rows[0].target.approvedSymbol}
               </Link>
             ) : (

--- a/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
+++ b/packages/sections/src/variant/GWASCredibleSets/PheWasPlot.tsx
@@ -332,7 +332,9 @@ function renderTooltip(datum) {
             <Chip label="self" variant="outlined" size="small" />
           </Box>
         ) : (
-          <Link to={`/variant/${datum.variant.id}`}>{displayId}</Link>
+          <Link asyncTooltip to={`/variant/${datum.variant.id}`}>
+            {displayId}
+          </Link>
         )}
       </ObsTooltipRow>
       <ObsTooltipRow label="Reported trait" valueWidth={valueMaxWidth} truncateValue>
@@ -344,7 +346,9 @@ function renderTooltip(datum) {
             {datum.study.diseases.map((d, i) => (
               <Fragment key={d.id}>
                 {i > 0 && ", "}
-                <Link to={`/disease/${d.id}`}>{d.name}</Link>
+                <Link asyncTooltip to={`/disease/${d.id}`}>
+                  {d.name}
+                </Link>
               </Fragment>
             ))}
           </>
@@ -353,7 +357,13 @@ function renderTooltip(datum) {
         )}
       </ObsTooltipRow>
       <ObsTooltipRow label="Study">
-        {datum.study ? <Link to={`/study/${datum.study.id}`}>{datum.study.id}</Link> : naLabel}
+        {datum.study ? (
+          <Link asyncTooltip to={`/study/${datum.study.id}`}>
+            {datum.study.id}
+          </Link>
+        ) : (
+          naLabel
+        )}
       </ObsTooltipRow>
       <ObsTooltipRow label="P-value">
         <ScientificNotation number={[datum.pValueMantissa, datum.pValueExponent]} dp={2} />
@@ -384,7 +394,7 @@ function renderTooltip(datum) {
           <Box display="flex" gap={0.5}>
             Top:{" "}
             {datum.l2GPredictions?.rows?.[0]?.target ? (
-              <Link to={`/target/${datum.l2GPredictions.rows[0].target.id}`}>
+              <Link asyncTooltip to={`/target/${datum.l2GPredictions.rows[0].target.id}`}>
                 {datum.l2GPredictions.rows[0].target.approvedSymbol}
               </Link>
             ) : (


### PR DESCRIPTION
## Description

Make plot tooltip links asynchronous - Manhattan and PheWas plots.

**Issue:** [#3911](https://github.com/opentargets/issues/issues/3911)
**Deploy preview:**

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
