### PR TITLE
[Platform]: proper variant column in clinvar (EVA) somatic widget

### DIFF
--- a/packages/sections/src/evidence/EVASomatic/Body.jsx
+++ b/packages/sections/src/evidence/EVASomatic/Body.jsx
@@ -10,6 +10,7 @@ import {
   ClinvarStars,
   DirectionOfEffectIcon,
   DirectionOfEffectTooltip,
+  DisplayVariantId,
   OtTableSSP,
 } from "ui";
 import { epmcUrl, sentenceCase } from "@ot/utils";
@@ -62,16 +63,20 @@ const getColumns = label => [
     id: "variantId",
     label: "Variant",
     enableHiding: false,
-    renderCell: ({ variant: { id: variantId } }) =>
-      variantId ? (
-        <>
-          {variantId.substring(0, 20)}
-          {variantId.length > 20 ? "\u2026" : ""}
-        </>
-      ) : (
-        naLabel
-      ),
-    filterValue: ({ variant: { id: variantId } }) => `${variantId}`,
+    renderCell: ({ variant }) => {
+      if (!variant) return naLabel;
+      const { id: variantId, referenceAllele, alternateAllele } = variant;
+      return (
+        <Link asyncTooltip to={`/variant/${variantId}`}>
+          <DisplayVariantId
+            variantId={variantId}
+            referenceAllele={referenceAllele}
+            alternateAllele={alternateAllele}
+            expand={false}
+          />
+        </Link>
+      );
+    },
   },
   {
     id: "variantRsId",

--- a/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
+++ b/packages/sections/src/evidence/EVASomatic/EvaSomaticQuery.gql
@@ -23,6 +23,9 @@ query EvaSomaticQuery($ensemblId: String!, $efoId: String!, $size: Int!, $cursor
         diseaseFromSource
         variant {
           id
+          hgvsId
+          referenceAllele
+          alternateAllele
         }
         variantRsId
         studyId


### PR DESCRIPTION
The ClinVar (EVA) somatic evidence widget didn't yet have the variant column with proper links, tooltip, etc.

Since the widget is a clone of the ClinVar (EVA), I mimic the query, column (body) and updated dependencies for the tooltip.  Seems to work fine locally 