### PR TITLE
[Platform]: Fix text and ticks in pathogenicity legend

### DIFF
--- a/packages/ot-constants/src/alphaFold.ts
+++ b/packages/ot-constants/src/alphaFold.ts
@@ -46,27 +46,19 @@ export function getAlphaFoldPathogenicity(atom, scores, propertyName = "label") 
 export const PRIORITISATION_COLORS = [
   rgb("#2e5943"),
   rgb("#2f735f"),
-  // rgb("#528b78"),
-  // rgb("#78a290"),
-  // rgb("#9ebaa8"),
-  // rgb("#c5d2c1"),
   rgb("#eceada"),
   rgb("#eceada"),
-  // rgb("#e6ca9c"),
-  // rgb("#e3a772"),
-  // rgb("#e08145"),
   rgb("#d65a1f"),
-  // rgb("#bc3a19"),
   rgb("#a01813"),
 ];
-// export const alphaFoldPathogenicityColorScale = scaleQuantize().domain([0, 0.34, 0.564, 1]);
-// export const prioritizationScale = alphaFoldPathogenicityColorScale.range(PRIORITISATION_COLORS);
 
 export const alphaFoldPathogenicityColorScale = scaleLinear()
   .domain([0, 0.1, 0.34, 0.564, 0.8, 1])
   .range(PRIORITISATION_COLORS)
   .interpolate(interpolateLab)
   .clamp(true);
+// only some of the scale breakpoints are meaningful for the legend
+alphaFoldPathogenicityColorScale._primaryDomain = [0, 0.34, 0.564, 1];
 
 export function getAlphaFoldPathogenicityColor(atom, scores) {
   return alphaFoldPathogenicityColorScale(scores[atom.resi]);

--- a/packages/ui/src/components/AlphaFoldPathogenicityLegend.tsx
+++ b/packages/ui/src/components/AlphaFoldPathogenicityLegend.tsx
@@ -13,7 +13,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
     });
   }
 
-  const domain = alphaFoldPathogenicityColorScale.domain();
+  const primaryDomain = alphaFoldPathogenicityColorScale._primaryDomain;
 
   const gradientId = "color-gradient";
   const fontSize = 11.5;
@@ -44,7 +44,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
                 stroke="none"
               />
               <g transform={`translate(0, ${barHeight + 20})`}>
-                {domain.map((t, i) => (
+                {primaryDomain.map((t, i) => (
                   <text
                     key={i}
                     x={t * barWidth}
@@ -62,7 +62,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
                 {["likely benign", "uncertain", "likely pathogenic"].map((label, i) => (
                   <text
                     key={i}
-                    x={((domain[i] + domain[i + 1]) * barWidth) / 2}
+                    x={((primaryDomain[i] + primaryDomain[i + 1]) * barWidth) / 2}
                     y={0}
                     fontSize={fontSize}
                     fill={textColor}
@@ -73,7 +73,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
                   </text>
                 ))}
               </g>
-              {domain.map((t, i) => (
+              {primaryDomain.map((t, i) => (
                 <line
                   key={i}
                   x1={t * barWidth}
@@ -87,10 +87,6 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
             </g>
           </svg>
         </Box>
-        {/* <Typography variant="caption" mt={1}>
-          The displayed colour for each residue is the average AlphaMissense pathogenicity score
-          across all possible amino acid substitutions at that position.
-        </Typography> */}
       </Box>
     </Box>
   );


### PR DESCRIPTION
## Description

Fix text and ticks in pathogenicity legend.

**Issue:** [#3840](https://github.com/opentargets/issues/issues/3840)
**Deploy preview:** 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
