### PR TITLE
[Platform]: Disable Expression Atlas tab in Baseline Expression widget.

### DIFF
--- a/packages/sections/src/target/Expression/Body.jsx
+++ b/packages/sections/src/target/Expression/Body.jsx
@@ -23,7 +23,7 @@ function Section({ id: ensgId, label: symbol, entity }) {
   // this can be probably be rewritten differently, but that's a wider scope than the MUI migration we're currently doing
   const [request, setRequest] = {
     summary: [requestSummary, setRequestSummary],
-    atlas: [requestSummary, setRequestSummary], // [{ loading: false, data: true }, undefined],
+    // atlas: [requestSummary, setRequestSummary], // [{ loading: false, data: true }, undefined],
     gtex: [requestGtex, setRequestGtex],
   }[tab];
 
@@ -65,11 +65,11 @@ function Section({ id: ensgId, label: symbol, entity }) {
         <>
           <Tabs value={tab} onChange={handleChangeTab} style={{ marginBottom: "1rem" }}>
             <Tab value="summary" label="Summary" />
-            <Tab value="atlas" label="Experiments (Expression Atlas)" />
+            {/* <Tab value="atlas" label="Experiments (Expression Atlas)" /> */}
             <Tab value="gtex" label="Variation (GTEx)" />
           </Tabs>
           {tab === "summary" && <SummaryTab symbol={symbol} data={request.data} />}
-          {tab === "atlas" && <AtlasTab ensgId={ensgId} symbol={symbol} />}
+          {/* {tab === "atlas" && <AtlasTab ensgId={ensgId} symbol={symbol} />} */}
           {tab === "gtex" && <GtexTab symbol={symbol} data={request.data} />}
         </>
       )}


### PR DESCRIPTION
## Description

Disable Expression Atlas tab in Baseline Expression widget.

The widget we embed is broken due to [this recent change](https://github.com/ebi-gene-expression-group/atlas-heatmap/issues/33). It is difficult to for us to even detect an error in the widget so we will disable the tab for now.

**Issue:** [#3875](https://github.com/opentargets/issues/issues/3875)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
