### PR TITLE
[Platform]: Fix text alignment in pathogenicity legend

### DIFF
--- a/packages/ui/src/components/AlphaFoldPathogenicityLegend.tsx
+++ b/packages/ui/src/components/AlphaFoldPathogenicityLegend.tsx
@@ -52,7 +52,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
                     fontSize={fontSize}
                     fill={textColor}
                     textAnchor="middle"
-                    alignmentBaseline="hanging"
+                    dominantBaseline="hanging"
                   >
                     {t}
                   </text>
@@ -67,7 +67,7 @@ export default function AlphaFoldPathogenicityLegend({ showTitle = true }) {
                     fontSize={fontSize}
                     fill={textColor}
                     textAnchor="middle"
-                    alignmentBaseline="hanging"
+                    dominantBaseline="hanging"
                   >
                     {label}
                   </text>


### PR DESCRIPTION
## Description

[Platform]: Fix text alignment in pathogenicity legend

**Issue:** [#3840](https://github.com/opentargets/issues/issues/3840)
**Deploy preview:** https://deploy-preview-770--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
