### PR TITLE
[AppConfig]: Genetics redirection

### DIFF
--- a/apps/platform/etc/platform.conf
+++ b/apps/platform/etc/platform.conf
@@ -1,28 +1,41 @@
+log_format fw '$remote_addr ("$http_x_forwarded_for") - $remote_user [$time_local] '
+              '"$request" $status $body_bytes_sent "$http_referer" "$http_user_agent"';
+
 server {
   listen 8080;
+  server_name genetics.opentargets.org www.genetics.opentargets.org genetics-dev.opentargets.org;
   http2  on;
 
+  location ~ ^/gene/(.*)$ {
+    return 301 https://platform.opentargets.org/target/$1?from=genetics;
+  }
+
+  location / {
+    return 301 https://platform.opentargets.org$request_uri?from=genetics;
+  }
+
+  access_log /dev/stdout fw;
+  error_log  /dev/stdout;
+}
+
+server {
+  listen 8080 default_server;
   server_name _;
+  http2       on;
 
   brotli            on;
   brotli_comp_level 6;
   brotli_static     on;
   brotli_types      application/atom+xml application/javascript application/json application/rss+xml application/vnd.ms-fontobject application/x-font-opentype application/x-font-truetype application/x-font-ttf application/x-javascript application/xhtml+xml application/xml font/eot font/opentype font/otf font/truetype image/svg+xml image/vnd.microsoft.icon image/x-icon image/x-win-bitmap text/css text/javascript text/plain text/xml;
 
-  keepalive_timeout 650;
-  keepalive_requests 10000;
-
   root /usr/share/nginx/html;
 
   location / {
-    try_files $uri $uri/ /index.html =404;
-    access_log /dev/stdout;
-    error_log  /dev/stdout info;
-    add_header 'Access-Control-Allow-Origin' '*';
+    try_files  $uri $uri/ /index.html;
+    add_header 'Access-Control-Allow-Origin'  '*';
     add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
   }
-  
-  access_log /dev/stdout;
-  error_log /dev/stdout info;
-    
+
+  access_log /dev/stdout fw;
+  error_log  /dev/stdout;
 }


### PR DESCRIPTION
# [AppConfig]: Genetics redirection

## Description

This PR adds a configuration to the nginx server that redirects requests for the deprecated genetics app into the new merged platform. It appends a `from=genetics` queryparam so the frontend can notify users.

Pending work: showing that modal dialog with information when coming from a redirection.

**Issue:** https://github.com/opentargets/issues/issues/3881
**Deploy preview:** https://genetics-dev.opentargets.org

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Test URLs:

home: https://genetics-dev.opentargets.org
a variant: https://genetics-dev.opentargets.org/variant/1_154453788_C_T
a study: https://genetics-dev.opentargets.org/Study/GCST010340
a gene: https://genetics-dev.opentargets.org/gene/ENSG00000169174   (/gene/ becomes /target/)
a study that no longer exists: https://genetics.opentargets.org/study/GCST002222