### PR TITLE
[Platform]: Show PPP access popup 

### DIFF
--- a/apps/platform/src/pages/HomePage/HomePage.tsx
+++ b/apps/platform/src/pages/HomePage/HomePage.tsx
@@ -27,6 +27,7 @@ import HomeBox from "./HomeBox";
 import Splash from "./Splash";
 import Version from "./Version";
 import HomePageSuggestions from "./HomePageSuggestions";
+import ShouldAccessPPP from "../../components/ShouldAccessPPP";
 
 const config = getConfig();
 
@@ -144,6 +145,8 @@ function HomePage(): JSX.Element {
 
   return (
     <>
+      <ShouldAccessPPP />
+
       <Helmet title={appTitle}>
         <meta name="description" content={appDescription} />
         <link rel="canonical" href={appCanonicalUrl} />


### PR DESCRIPTION
## Description

Add `ShouldAccessPPP` to homepage so shows access to PPP popup when appropriate.

**Issue:**
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev - need to temporarily comment out `ShouldAccessPPP.tsx`, line 54: `if (import.meta.env.DEV) return false;`

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
