### PR TITLE
[Platform]: Hide variant page structure viewer if reference amino acid starts with a dash

### DIFF
--- a/packages/sections/src/variant/MolecularStructure/MolecularStructureSummaryFragment.gql
+++ b/packages/sections/src/variant/MolecularStructure/MolecularStructureSummaryFragment.gql
@@ -2,5 +2,8 @@ fragment MolecularStructureSummaryFragment on Variant {
   id
   proteinCodingCoordinates {
     count
+    rows {
+      referenceAminoAcid
+    }
   }
 }

--- a/packages/sections/src/variant/MolecularStructure/Viewer.tsx
+++ b/packages/sections/src/variant/MolecularStructure/Viewer.tsx
@@ -96,7 +96,10 @@ function Viewer({ row }) {
           .getModel()
           .selectedAtoms()
           .find(atom => atom.resi === row.aminoAcidPosition)?.resn;
-        if (aminoAcidLookup[row.referenceAminoAcid[0]] !== structureReferenceAminoAcid) {
+        if (
+          row.referenceAminoAcid[0] !== "-" &&
+          aminoAcidLookup[row.referenceAminoAcid[0]] !== structureReferenceAminoAcid
+        ) {
           setMessageText("AlphaFold structure not available");
           return;
         }

--- a/packages/sections/src/variant/MolecularStructure/Viewer.tsx
+++ b/packages/sections/src/variant/MolecularStructure/Viewer.tsx
@@ -96,10 +96,7 @@ function Viewer({ row }) {
           .getModel()
           .selectedAtoms()
           .find(atom => atom.resi === row.aminoAcidPosition)?.resn;
-        if (
-          row.referenceAminoAcid[0] !== "-" &&
-          aminoAcidLookup[row.referenceAminoAcid[0]] !== structureReferenceAminoAcid
-        ) {
+        if (aminoAcidLookup[row.referenceAminoAcid[0]] !== structureReferenceAminoAcid) {
           setMessageText("AlphaFold structure not available");
           return;
         }

--- a/packages/sections/src/variant/MolecularStructure/index.ts
+++ b/packages/sections/src/variant/MolecularStructure/index.ts
@@ -3,5 +3,7 @@ export const definition = {
   id,
   name: "Molecular Structure",
   shortName: "MS",
-  hasData: data => data.proteinCodingCoordinates.count > 0,
+  hasData: data =>
+    data.proteinCodingCoordinates.count > 0 &&
+    data.proteinCodingCoordinates.rows[0].referenceAminoAcid[0] !== "-",
 };


### PR DESCRIPTION
## Description

**Not ready for merge as there ongoing discussions on this issue.**

Hide variant page structure viewer if reference amino acid starts with a dash.

**Issue:** [#3840](https://github.com/opentargets/issues/issues/3840)
**Deploy preview:** https://deploy-preview-779--ot-platform.netlify.app/variant/12_25245375_A_AT

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
