### PR TITLE
[Platform]: old Genetics modal from redirection

### DIFF
--- a/apps/platform/src/App.tsx
+++ b/apps/platform/src/App.tsx
@@ -1,6 +1,6 @@
 import { ReactElement } from "react";
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
-import { SearchProvider, PrivateRoute, OTConfigurationProvider } from "ui";
+import { SearchProvider, PrivateRoute, OTConfigurationProvider, FromGeneticsModal } from "ui";
 import { getConfig } from "@ot/config";
 
 import SEARCH_QUERY from "./components/Search/SearchQuery.gql";
@@ -29,6 +29,7 @@ function App(): ReactElement {
         searchPlaceholder="Search for a target, drug, disease, or phenotype..."
       >
         <Router>
+          <FromGeneticsModal />
           <Routes>
             <Route path="/" element={<HomePage />} />
             <Route path="/api" element={<APIPage />} />

--- a/packages/ui/src/components/FromGeneticsModal.tsx
+++ b/packages/ui/src/components/FromGeneticsModal.tsx
@@ -1,0 +1,40 @@
+import { Modal, Box, Typography } from "@mui/material";
+import { useState } from "react";
+
+interface FromGeneticsModalProps {
+  title: string;
+  text: string;
+}
+
+const FromGeneticsModal = ({ title, text }: FromGeneticsModalProps) => {
+  const [open, setOpen] = useState(true);
+
+  const onClose = () => {
+    setOpen(false);
+  };
+
+  return (
+    <Modal open={open} onClose={onClose}>
+      <Box
+        sx={{
+          position: "absolute",
+          top: "50%",
+          left: "50%",
+          transform: "translate(-50%, -50%)",
+          width: 400,
+          bgcolor: "background.paper",
+          boxShadow: 24,
+          p: 4,
+          borderRadius: 2,
+        }}
+      >
+        <Typography variant="h6" component="h2" gutterBottom>
+          {title}
+        </Typography>
+        <Typography variant="body1">{text}</Typography>
+      </Box>
+    </Modal>
+  );
+};
+
+export default FromGeneticsModal;

--- a/packages/ui/src/components/FromGeneticsModal.tsx
+++ b/packages/ui/src/components/FromGeneticsModal.tsx
@@ -1,37 +1,99 @@
-import { Modal, Box, Typography } from "@mui/material";
-import { useState } from "react";
+import { Modal, Box, Typography, Button, styled } from "@mui/material";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { Link } from "ui";
 
-interface FromGeneticsModalProps {
-  title: string;
-  text: string;
-}
+const StyledButton = styled(Button)(({ theme }) => ({
+  background: theme.palette.secondary.main,
+  color: "#fff",
+  "&:hover": {
+    background: theme.palette.primary.main,
+    color: "#fff",
+  },
+}));
 
-const FromGeneticsModal = ({ title, text }: FromGeneticsModalProps) => {
-  const [open, setOpen] = useState(true);
+const FromGeneticsModal = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [open, setOpen] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get("from") === "genetics") {
+      setOpen(true);
+    }
+  }, [searchParams]);
 
   const onClose = () => {
     setOpen(false);
+    setSearchParams({});
   };
 
   return (
-    <Modal open={open} onClose={onClose}>
+    <Modal open={open} onClose={onClose} disableAutoFocus>
       <Box
         sx={{
           position: "absolute",
           top: "50%",
           left: "50%",
           transform: "translate(-50%, -50%)",
-          width: 400,
-          bgcolor: "background.paper",
-          boxShadow: 24,
-          p: 4,
+          maxWidth: 700,
+          py: 4,
+          px: 4,
           borderRadius: 2,
+          backgroundColor: "#fff",
         }}
       >
-        <Typography variant="h6" component="h2" gutterBottom>
-          {title}
+        <Typography
+          variant="h4"
+          component="h2"
+          gutterBottom
+          mb={3}
+          color="secondary.main"
+          fontWeight={500}
+        >
+          Welcome to the upgraded Open Targets Platform!
         </Typography>
-        <Typography variant="body1">{text}</Typography>
+        <Typography variant="body2">
+          Open Targets Genetics has been integrated into the Open Targets Platform to create a
+          unified resource for human genetic and target discovery information.
+        </Typography>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="subtitle2">What&apos;s new:</Typography>
+          <Typography variant="body2">
+            <ul style={{ listStyleType: "disc", paddingLeft: 20 }}>
+              <li>
+                Updated genetic analyses with improved quality control and ancestry-specific
+                fine-mapping
+              </li>
+              <li>20% more direct gene-disease associations from GWAS credible sets</li>
+              <li>
+                Enhanced Locus-to-Gene model with better performance and feature interpretation
+              </li>
+              <li>Comprehensive variant annotation and state-of-the-art statistical analyses</li>
+            </ul>
+          </Typography>
+        </Box>
+        <Box sx={{ mt: 2 }}>
+          <Typography variant="body2">
+            <b>Please note:</b> Some analyses like V2G are no longer available, and we now only
+            include variants with phenotypic information.
+          </Typography>
+        </Box>
+        <Box sx={{ mt: 4, mb: 2 }}>
+          <Typography variant="body2">
+            Need help? Check our{" "}
+            <Link newTab external to="https://docs.opentargets.org">
+              documentation
+            </Link>{" "}
+            or visit the{" "}
+            <Link newTab external to="https://community.opentargets.org">
+              Open Targets Community
+            </Link>{" "}
+            for support.
+          </Typography>
+        </Box>
+        <Box sx={{ mt: 4, display: "flex", justifyContent: "flex-end" }}>
+          <StyledButton onClick={onClose}>Continue to the Open Targets Platform</StyledButton>
+        </Box>
       </Box>
     </Modal>
   );

--- a/packages/ui/src/index.tsx
+++ b/packages/ui/src/index.tsx
@@ -95,3 +95,4 @@ export { default as usePermissions } from "./hooks/usePermissions";
 export { default as useDebounce } from "./hooks/useDebounce";
 
 export { default as BrokenSearchIcon } from "./components/icons/BrokenSearchIcon";
+export { default as FromGeneticsModal } from "./components/FromGeneticsModal";


### PR DESCRIPTION
# [Platform]: old Genetics modal from redirection

## Description

Modal that shows in the UI when the`?from=genetics` is present in the URL

**Issue:** https://github.com/opentargets/issues/issues/3881
**Deploy preview:** (link)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
