### PR TITLE
[Platform]: Add molQTL credible sets widget to target page

### DIFF
--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,6 +1,3 @@
-# VITE_API_URL=https://eeff.opentargets.xyz/api/v4/graphql
-VITE_API_URL=https://gdce.opentargets.xyz/api/v4/graphql
-# VITE_API_URL=https://debf.opentargets.xyz/api/v4/graphql
-# VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://dev.opentargets.xyz/api/v4/graphql
 VITE_AI_API_URL=https://dev-ai-api-w37vlfsidq-ew.a.run.app
 VITE_PROFILE=platform

--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,4 +1,5 @@
-VITE_API_URL=https://eeff.opentargets.xyz/api/v4/graphql
+# VITE_API_URL=https://eeff.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://debf.opentargets.xyz/api/v4/graphql
 # VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
 VITE_AI_API_URL=https://dev-ai-api-w37vlfsidq-ew.a.run.app
 VITE_PROFILE=platform

--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,5 +1,6 @@
 # VITE_API_URL=https://eeff.opentargets.xyz/api/v4/graphql
-VITE_API_URL=https://debf.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://gdce.opentargets.xyz/api/v4/graphql
+# VITE_API_URL=https://debf.opentargets.xyz/api/v4/graphql
 # VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
 VITE_AI_API_URL=https://dev-ai-api-w37vlfsidq-ew.a.run.app
 VITE_PROFILE=platform

--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,3 +1,4 @@
-VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
+VITE_API_URL=https://eeff.opentargets.xyz/api/v4/graphql
+# VITE_API_URL=https://api.platform.dev.opentargets.xyz/api/v4/graphql
 VITE_AI_API_URL=https://dev-ai-api-w37vlfsidq-ew.a.run.app
 VITE_PROFILE=platform

--- a/apps/platform/src/pages/TargetPage/Profile.tsx
+++ b/apps/platform/src/pages/TargetPage/Profile.tsx
@@ -28,6 +28,7 @@ const targetProfileWidgets = new Map<string, Widget>([
   [Target.CancerHallmarks.definition.id, Target.CancerHallmarks],
   [Target.MousePhenotypes.definition.id, Target.MousePhenotypes],
   [Target.ComparativeGenomics.definition.id, Target.ComparativeGenomics],
+  [Target.QTLCredibleSets.definition.id, Target.QTLCredibleSets],
   [Target.Bibliography.definition.id, Target.Bibliography],
   // [Target.OverlappingVariants.definition.id, Target.OverlappingVariants],
 ]);

--- a/apps/platform/src/pages/TargetPage/Profile.tsx
+++ b/apps/platform/src/pages/TargetPage/Profile.tsx
@@ -16,6 +16,7 @@ const targetProfileWidgets = new Map<string, Widget>([
   [Target.Tractability.definition.id, Target.Tractability],
   [Target.Safety.definition.id, Target.Safety],
   [Target.Pharmacogenomics.definition.id, Target.Pharmacogenomics],
+  [Target.QTLCredibleSets.definition.id, Target.QTLCredibleSets],
   [Target.ChemicalProbes.definition.id, Target.ChemicalProbes],
   [Target.Expression.definition.id, Target.Expression],
   [Target.DepMap.definition.id, Target.DepMap],
@@ -28,7 +29,6 @@ const targetProfileWidgets = new Map<string, Widget>([
   [Target.CancerHallmarks.definition.id, Target.CancerHallmarks],
   [Target.MousePhenotypes.definition.id, Target.MousePhenotypes],
   [Target.ComparativeGenomics.definition.id, Target.ComparativeGenomics],
-  [Target.QTLCredibleSets.definition.id, Target.QTLCredibleSets],
   [Target.Bibliography.definition.id, Target.Bibliography],
   // [Target.OverlappingVariants.definition.id, Target.OverlappingVariants],
 ]);

--- a/apps/platform/src/sections/targetSections.ts
+++ b/apps/platform/src/sections/targetSections.ts
@@ -17,6 +17,7 @@ const targetSections = new Map([
   ["interactions", Target.MolecularInteractions.getBodyComponent()],
   ["mousePhenotypes", Target.MousePhenotypes.getBodyComponent()],
   ["compGenomics", Target.ComparativeGenomics.getBodyComponent()],
+  ["qtlCredibleSets", Target.QTLCredibleSets.getBodyComponent()],
 ]);
 
 export default targetSections;

--- a/packages/sections/src/target/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/target/QTLCredibleSets/Body.tsx
@@ -51,7 +51,7 @@ const columns = [
     exportValue: ({ variant }: any) => variant?.id,
   },
   {
-    id: "studyId",
+    id: "study.id",
     label: "Study",
     renderCell: ({ study }: any) => {
       if (!study) return naLabel;
@@ -77,10 +77,10 @@ const columns = [
         </>
       );
     },
-    exportValue: ({ study, isTrans }: any) => {
+    exportValue: ({ study, isTransQtl }: any) => {
       const type = study?.studyType;
       if (!type) return null;
-      return `${type.slice(0, -3)}${type.slice(-3).toUpperCase()}, isTrans:${isTrans}`;
+      return `${type.slice(0, -3)}${type.slice(-3).toUpperCase()}, isTrans:${isTransQtl}`;
     },
   },
   {
@@ -171,6 +171,9 @@ const columns = [
       </>
     ),
     sortable: true,
+    comparator: (a, b) => {
+      return credsetConfidenceMap[a.confidence] - credsetConfidenceMap[b.confidence];
+    },
     renderCell: ({ confidence }: any) => {
       if (!confidence) return naLabel;
       return (
@@ -179,7 +182,7 @@ const columns = [
         </Tooltip>
       );
     },
-    filterValue: ({ confidence }: any) => credsetConfidenceMap[confidence],
+    filterValue: false,
   },
   {
     id: "finemappingMethod",

--- a/packages/sections/src/target/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/target/QTLCredibleSets/Body.tsx
@@ -1,0 +1,257 @@
+import { Chip } from "@mui/material";
+import { credsetConfidenceMap, naLabel, table5HChunkSize } from "@ot/constants";
+import { mantissaExponentComparator, variantComparator } from "@ot/utils";
+import {
+	ClinvarStars,
+	DisplayVariantId,
+	Link,
+	Navigate,
+	OtTable,
+	ScientificNotation,
+	SectionItem,
+	Tooltip,
+	useBatchQuery,
+} from "ui";
+import { definition } from ".";
+import Description from "./Description";
+import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
+
+function getColumns(): any[] {
+	return [
+		{
+			id: "studyLocusId",
+			label: "Credible set",
+			enableHiding: false,
+			sticky: true,
+			renderCell: ({ studyLocusId }: any) => (
+				<Navigate to={`/credible-set/${studyLocusId}`} />
+			),
+		},
+		{
+			id: "leadVariant",
+			label: "Lead variant",
+			enableHiding: false,
+			comparator: variantComparator((d) => d.variant),
+			sortable: true,
+			filterValue: ({ variant: v }: any) =>
+				`${v?.chromosome}_${v?.position}_${v?.referenceAllele}_${v?.alternateAllele}`,
+			renderCell: ({ variant }: any) => {
+				if (!variant) return naLabel;
+				const { id: variantId, referenceAllele, alternateAllele } = variant;
+				const displayElement = (
+					<DisplayVariantId
+						variantId={variantId}
+						referenceAllele={referenceAllele}
+						alternateAllele={alternateAllele}
+						expand={false}
+					/>
+				);
+				return (
+					<Link asyncTooltip to={`/variant/${variantId}`}>
+						{displayElement}
+					</Link>
+				);
+			},
+			exportValue: ({ variant }: any) => variant?.id,
+		},
+		{
+			id: "studyId",
+			label: "Study",
+			renderCell: ({ study }: any) => {
+				if (!study) return naLabel;
+				return (
+					<Link asyncTooltip to={`/study/${study.id}`}>
+						{study.id}
+					</Link>
+				);
+			},
+		},
+		{
+			id: "study.studyType",
+			label: "Type",
+			renderCell: ({ study, isTransQtl }: any) => {
+				const type = study?.studyType;
+				if (!type) return naLabel;
+				return (
+					<>
+						{`${type.slice(0, -3)}${type.slice(-3).toUpperCase()}`}{" "}
+						{isTransQtl && (
+							<Chip label="trans" variant="outlined" size="small" />
+						)}
+					</>
+				);
+			},
+			exportValue: ({ study, isTrans }: any) => {
+				const type = study?.studyType;
+				if (!type) return null;
+				return `${type.slice(0, -3)}${type.slice(-3).toUpperCase()}, isTrans:${isTrans}`;
+			},
+		},
+		{
+			id: "study",
+			label: "Affected tissue/cell",
+			renderCell: ({ study }: any) => {
+				const biosampleId = study?.biosample?.biosampleId;
+				if (!biosampleId) return naLabel;
+				return (
+					<Link
+						external
+						to={`https://www.ebi.ac.uk/ols4/search?q=${biosampleId}&ontology=uberon`}
+					>
+						{study?.biosample?.biosampleName}
+					</Link>
+				);
+			},
+			exportValue: ({ study }: any) => {
+				return `[${study?.biosample?.biosampleId}]:${study?.biosample?.biosampleName}`;
+			},
+		},
+		{
+			id: "study.condition",
+			label: "Condition",
+			renderCell: ({ study }: any) => study?.condition || naLabel,
+		},
+		{
+			id: "pValue",
+			label: "P-value",
+			numeric: true,
+			comparator: (a: any, b: any) =>
+				mantissaExponentComparator(
+					a?.pValueMantissa,
+					a?.pValueExponent,
+					b?.pValueMantissa,
+					b?.pValueExponent,
+				),
+			sortable: true,
+			filterValue: false,
+			renderCell: ({ pValueMantissa, pValueExponent }: any) => {
+				if (
+					typeof pValueMantissa !== "number" ||
+					typeof pValueExponent !== "number"
+				)
+					return naLabel;
+				return (
+					<ScientificNotation
+						number={[pValueMantissa, pValueExponent]}
+						dp={2}
+					/>
+				);
+			},
+			exportValue: ({ pValueMantissa, pValueExponent }: any) => {
+				if (
+					typeof pValueMantissa !== "number" ||
+					typeof pValueExponent !== "number"
+				)
+					return null;
+				return `${pValueMantissa}x10${pValueExponent}`;
+			},
+		},
+		{
+			id: "beta",
+			label: "Beta",
+			numeric: true,
+			filterValue: false,
+			tooltip: "Beta with respect to the ALT allele",
+			sortable: true,
+			renderCell: ({ beta }: any) => {
+				if (typeof beta !== "number") return naLabel;
+				return beta.toPrecision(3);
+			},
+		},
+		{
+			id: "confidence",
+			label: "Fine-mapping confidence",
+			tooltip: (
+				<>
+					Fine-mapping confidence based on the suitability of the
+					linkage-disequilibrium information and fine-mapping method. See{" "}
+					<Link
+						external
+						to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+					>
+						here
+					</Link>{" "}
+					for more details.
+				</>
+			),
+			sortable: true,
+			renderCell: ({ confidence }: any) => {
+				if (!confidence) return naLabel;
+				return (
+					<Tooltip title={confidence} style="">
+						<ClinvarStars num={credsetConfidenceMap[confidence]} />
+					</Tooltip>
+				);
+			},
+			filterValue: ({ confidence }: any) => credsetConfidenceMap[confidence],
+		},
+		{
+			id: "finemappingMethod",
+			label: "Fine-mapping method",
+		},
+		{
+			id: "credibleSetSize",
+			label: "Credible set size",
+			numeric: true,
+			comparator: (a: any, b: any) => a.locus?.count - b.locus?.count,
+			sortable: true,
+			filterValue: false,
+			renderCell: ({ locus }: any) => {
+				return typeof locus?.count === "number"
+					? locus.count.toLocaleString()
+					: naLabel;
+			},
+			exportValue: ({ locus }: any) => locus?.count,
+		},
+	];
+}
+
+type BodyProps = {
+	id: string;
+	entity: string;
+};
+
+function Body({ id, entity }: BodyProps) {
+	const variables = {
+		ensemblId: id,
+		size: table5HChunkSize,
+		index: 0,
+	};
+
+	const request = useBatchQuery({
+		query: QTL_CREDIBLE_SETS_QUERY,
+		variables,
+		dataPath: "target.qtlCredibleSets",
+		size: table5HChunkSize,
+	});
+
+	return (
+		<SectionItem
+			definition={definition}
+			entity={entity}
+			request={request}
+			showContentLoading
+			loadingMessage="Loading data. This may take some time..."
+			renderDescription={() => (
+				<Description targetSymbol={request.data?.target?.approvedSymbol} />
+			)}
+			renderBody={() => {
+				return (
+					<OtTable
+						dataDownloader
+						dataDownloaderFileStem={`${id}-qtl-credible-sets-target`}
+						showGlobalFilter
+						sortBy="pValue"
+						columns={getColumns()}
+						rows={request.data?.target.qtlCredibleSets.rows}
+						loading={request.loading}
+						query={QTL_CREDIBLE_SETS_QUERY.loc.source.body}
+						variables={variables}
+					/>
+				);
+			}}
+		/>
+	);
+}
+
+export default Body;

--- a/packages/sections/src/target/QTLCredibleSets/Body.tsx
+++ b/packages/sections/src/target/QTLCredibleSets/Body.tsx
@@ -16,195 +16,190 @@ import { definition } from ".";
 import Description from "./Description";
 import QTL_CREDIBLE_SETS_QUERY from "./QTLCredibleSetsQuery.gql";
 
-function getColumns(): any[] {
-	return [
-		{
-			id: "studyLocusId",
-			label: "Credible set",
-			enableHiding: false,
-			sticky: true,
-			renderCell: ({ studyLocusId }: any) => (
-				<Navigate to={`/credible-set/${studyLocusId}`} />
-			),
-		},
-		{
-			id: "leadVariant",
-			label: "Lead variant",
-			enableHiding: false,
-			comparator: variantComparator((d) => d.variant),
-			sortable: true,
-			filterValue: ({ variant: v }: any) =>
-				`${v?.chromosome}_${v?.position}_${v?.referenceAllele}_${v?.alternateAllele}`,
-			renderCell: ({ variant }: any) => {
-				if (!variant) return naLabel;
-				const { id: variantId, referenceAllele, alternateAllele } = variant;
-				const displayElement = (
-					<DisplayVariantId
-						variantId={variantId}
-						referenceAllele={referenceAllele}
-						alternateAllele={alternateAllele}
-						expand={false}
-					/>
-				);
-				return (
-					<Link asyncTooltip to={`/variant/${variantId}`}>
-						{displayElement}
-					</Link>
-				);
-			},
-			exportValue: ({ variant }: any) => variant?.id,
-		},
-		{
-			id: "studyId",
-			label: "Study",
-			renderCell: ({ study }: any) => {
-				if (!study) return naLabel;
-				return (
-					<Link asyncTooltip to={`/study/${study.id}`}>
-						{study.id}
-					</Link>
-				);
-			},
-		},
-		{
-			id: "study.studyType",
-			label: "Type",
-			renderCell: ({ study, isTransQtl }: any) => {
-				const type = study?.studyType;
-				if (!type) return naLabel;
-				return (
-					<>
-						{`${type.slice(0, -3)}${type.slice(-3).toUpperCase()}`}{" "}
-						{isTransQtl && (
-							<Chip label="trans" variant="outlined" size="small" />
-						)}
-					</>
-				);
-			},
-			exportValue: ({ study, isTrans }: any) => {
-				const type = study?.studyType;
-				if (!type) return null;
-				return `${type.slice(0, -3)}${type.slice(-3).toUpperCase()}, isTrans:${isTrans}`;
-			},
-		},
-		{
-			id: "study",
-			label: "Affected tissue/cell",
-			renderCell: ({ study }: any) => {
-				const biosampleId = study?.biosample?.biosampleId;
-				if (!biosampleId) return naLabel;
-				return (
-					<Link
-						external
-						to={`https://www.ebi.ac.uk/ols4/search?q=${biosampleId}&ontology=uberon`}
-					>
-						{study?.biosample?.biosampleName}
-					</Link>
-				);
-			},
-			exportValue: ({ study }: any) => {
-				return `[${study?.biosample?.biosampleId}]:${study?.biosample?.biosampleName}`;
-			},
-		},
-		{
-			id: "study.condition",
-			label: "Condition",
-			renderCell: ({ study }: any) => study?.condition || naLabel,
-		},
-		{
-			id: "pValue",
-			label: "P-value",
-			numeric: true,
-			comparator: (a: any, b: any) =>
-				mantissaExponentComparator(
-					a?.pValueMantissa,
-					a?.pValueExponent,
-					b?.pValueMantissa,
-					b?.pValueExponent,
-				),
-			sortable: true,
-			filterValue: false,
-			renderCell: ({ pValueMantissa, pValueExponent }: any) => {
-				if (
-					typeof pValueMantissa !== "number" ||
-					typeof pValueExponent !== "number"
-				)
-					return naLabel;
-				return (
-					<ScientificNotation
-						number={[pValueMantissa, pValueExponent]}
-						dp={2}
-					/>
-				);
-			},
-			exportValue: ({ pValueMantissa, pValueExponent }: any) => {
-				if (
-					typeof pValueMantissa !== "number" ||
-					typeof pValueExponent !== "number"
-				)
-					return null;
-				return `${pValueMantissa}x10${pValueExponent}`;
-			},
-		},
-		{
-			id: "beta",
-			label: "Beta",
-			numeric: true,
-			filterValue: false,
-			tooltip: "Beta with respect to the ALT allele",
-			sortable: true,
-			renderCell: ({ beta }: any) => {
-				if (typeof beta !== "number") return naLabel;
-				return beta.toPrecision(3);
-			},
-		},
-		{
-			id: "confidence",
-			label: "Fine-mapping confidence",
-			tooltip: (
-				<>
-					Fine-mapping confidence based on the suitability of the
-					linkage-disequilibrium information and fine-mapping method. See{" "}
-					<Link
-						external
-						to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
-					>
-						here
-					</Link>{" "}
-					for more details.
-				</>
-			),
-			sortable: true,
-			renderCell: ({ confidence }: any) => {
-				if (!confidence) return naLabel;
-				return (
-					<Tooltip title={confidence} style="">
-						<ClinvarStars num={credsetConfidenceMap[confidence]} />
-					</Tooltip>
-				);
-			},
-			filterValue: ({ confidence }: any) => credsetConfidenceMap[confidence],
-		},
-		{
-			id: "finemappingMethod",
-			label: "Fine-mapping method",
-		},
-		{
-			id: "credibleSetSize",
-			label: "Credible set size",
-			numeric: true,
-			comparator: (a: any, b: any) => a.locus?.count - b.locus?.count,
-			sortable: true,
-			filterValue: false,
-			renderCell: ({ locus }: any) => {
-				return typeof locus?.count === "number"
-					? locus.count.toLocaleString()
-					: naLabel;
-			},
-			exportValue: ({ locus }: any) => locus?.count,
-		},
-	];
-}
+const columns = [
+  {
+    id: "studyLocusId",
+    label: "Credible set",
+    enableHiding: false,
+    sticky: true,
+    renderCell: ({ studyLocusId }: any) => (
+      <Navigate to={`/credible-set/${studyLocusId}`} />
+    ),
+  },
+  {
+    id: "leadVariant",
+    label: "Lead variant",
+    enableHiding: false,
+    comparator: variantComparator((d) => d.variant),
+    sortable: true,
+    filterValue: ({ variant: v }: any) =>
+      `${v?.chromosome}_${v?.position}_${v?.referenceAllele}_${v?.alternateAllele}`,
+    renderCell: ({ variant }: any) => {
+      if (!variant) return naLabel;
+      const { id: variantId, referenceAllele, alternateAllele } = variant;
+      return (
+        <Link asyncTooltip to={`/variant/${variantId}`}>
+          <DisplayVariantId
+            variantId={variantId}
+            referenceAllele={referenceAllele}
+            alternateAllele={alternateAllele}
+            expand={false}
+          />
+        </Link>
+      );
+    },
+    exportValue: ({ variant }: any) => variant?.id,
+  },
+  {
+    id: "studyId",
+    label: "Study",
+    renderCell: ({ study }: any) => {
+      if (!study) return naLabel;
+      return (
+        <Link asyncTooltip to={`/study/${study.id}`}>
+          {study.id}
+        </Link>
+      );
+    },
+  },
+  {
+    id: "study.studyType",
+    label: "Type",
+    renderCell: ({ study, isTransQtl }: any) => {
+      const type = study?.studyType;
+      if (!type) return naLabel;
+      return (
+        <>
+          {`${type.slice(0, -3)}${type.slice(-3).toUpperCase()}`}{" "}
+          {isTransQtl && (
+            <Chip label="trans" variant="outlined" size="small" />
+          )}
+        </>
+      );
+    },
+    exportValue: ({ study, isTrans }: any) => {
+      const type = study?.studyType;
+      if (!type) return null;
+      return `${type.slice(0, -3)}${type.slice(-3).toUpperCase()}, isTrans:${isTrans}`;
+    },
+  },
+  {
+    id: "study",
+    label: "Affected tissue/cell",
+    renderCell: ({ study }: any) => {
+      const biosampleId = study?.biosample?.biosampleId;
+      if (!biosampleId) return naLabel;
+      return (
+        <Link
+          external
+          to={`https://www.ebi.ac.uk/ols4/search?q=${biosampleId}&ontology=uberon`}
+        >
+          {study?.biosample?.biosampleName}
+        </Link>
+      );
+    },
+    exportValue: ({ study }: any) => {
+      return `[${study?.biosample?.biosampleId}]:${study?.biosample?.biosampleName}`;
+    },
+  },
+  {
+    id: "study.condition",
+    label: "Condition",
+    renderCell: ({ study }: any) => study?.condition || naLabel,
+  },
+  {
+    id: "pValue",
+    label: "P-value",
+    numeric: true,
+    comparator: (a: any, b: any) =>
+      mantissaExponentComparator(
+        a?.pValueMantissa,
+        a?.pValueExponent,
+        b?.pValueMantissa,
+        b?.pValueExponent,
+      ),
+    sortable: true,
+    filterValue: false,
+    renderCell: ({ pValueMantissa, pValueExponent }: any) => {
+      if (
+        typeof pValueMantissa !== "number" ||
+        typeof pValueExponent !== "number"
+      )
+        return naLabel;
+      return (
+        <ScientificNotation
+          number={[pValueMantissa, pValueExponent]}
+          dp={2}
+        />
+      );
+    },
+    exportValue: ({ pValueMantissa, pValueExponent }: any) => {
+      if (
+        typeof pValueMantissa !== "number" ||
+        typeof pValueExponent !== "number"
+      )
+        return null;
+      return `${pValueMantissa}x10${pValueExponent}`;
+    },
+  },
+  {
+    id: "beta",
+    label: "Beta",
+    numeric: true,
+    filterValue: false,
+    tooltip: "Beta with respect to the ALT allele",
+    sortable: true,
+    renderCell: ({ beta }: any) => {
+      if (typeof beta !== "number") return naLabel;
+      return beta.toPrecision(3);
+    },
+  },
+  {
+    id: "confidence",
+    label: "Fine-mapping confidence",
+    tooltip: (
+      <>
+        Fine-mapping confidence based on the suitability of the
+        linkage-disequilibrium information and fine-mapping method. See{" "}
+        <Link
+          external
+          to="https://platform-docs.opentargets.org/credible-set#credible-set-confidence"
+        >
+          here
+        </Link>{" "}
+        for more details.
+      </>
+    ),
+    sortable: true,
+    renderCell: ({ confidence }: any) => {
+      if (!confidence) return naLabel;
+      return (
+        <Tooltip title={confidence} style="">
+          <ClinvarStars num={credsetConfidenceMap[confidence]} />
+        </Tooltip>
+      );
+    },
+    filterValue: ({ confidence }: any) => credsetConfidenceMap[confidence],
+  },
+  {
+    id: "finemappingMethod",
+    label: "Fine-mapping method",
+  },
+  {
+    id: "credibleSetSize",
+    label: "Credible set size",
+    numeric: true,
+    comparator: (a: any, b: any) => a.locus?.count - b.locus?.count,
+    sortable: true,
+    filterValue: false,
+    renderCell: ({ locus }: any) => {
+      return typeof locus?.count === "number"
+        ? locus.count.toLocaleString()
+        : naLabel;
+    },
+    exportValue: ({ locus }: any) => locus?.count,
+  },
+];
 
 type BodyProps = {
 	id: string;
@@ -221,10 +216,10 @@ function Body({ id, entity }: BodyProps) {
 	const request = useBatchQuery({
 		query: QTL_CREDIBLE_SETS_QUERY,
 		variables,
-		dataPath: "target.qtlCredibleSets",
+		dataPath: "target.credibleSets",
 		size: table5HChunkSize,
 	});
-
+ 
 	return (
 		<SectionItem
 			definition={definition}
@@ -242,8 +237,8 @@ function Body({ id, entity }: BodyProps) {
 						dataDownloaderFileStem={`${id}-qtl-credible-sets-target`}
 						showGlobalFilter
 						sortBy="pValue"
-						columns={getColumns()}
-						rows={request.data?.target.qtlCredibleSets.rows}
+						columns={columns}
+						rows={request.data?.target.credibleSets.rows}
 						loading={request.loading}
 						query={QTL_CREDIBLE_SETS_QUERY.loc.source.body}
 						variables={variables}

--- a/packages/sections/src/target/QTLCredibleSets/Description.tsx
+++ b/packages/sections/src/target/QTLCredibleSets/Description.tsx
@@ -1,0 +1,20 @@
+import type { ReactElement } from "react";
+import { Link } from "ui";
+
+type DescriptionProps = {
+	targetSymbol: string;
+};
+
+function Description({ targetSymbol }: DescriptionProps): ReactElement {
+	return (
+		<>
+			95% credible sets fine-mapped from quantitative trait loci associated with
+			molecular traits affecting <strong>{targetSymbol}</strong>. Source{" "}
+			<Link to="https://platform-docs.opentargets.org/target" external>
+				Open Targets
+			</Link>
+		</>
+	);
+}
+
+export default Description;

--- a/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -1,0 +1,40 @@
+query QTLCredibleSetsQuery($ensemblId: String!, $size: Int!, $index: Int!) {
+	target(ensemblId: $ensemblId) {
+		id
+		approvedSymbol
+		qtlCredibleSets: credibleSets(
+			# studyTypes: [scsqtl, sceqtl, scpqtl, sctuqtl, sqtl, eqtl, pqtl, tuqtl]
+			page: { size: $size, index: $index }
+		) {
+			count
+			rows {
+				studyLocusId
+				pValueMantissa
+				pValueExponent
+				beta
+				finemappingMethod
+				confidence
+				isTransQtl
+				variant {
+					id
+					chromosome
+					position
+					referenceAllele
+					alternateAllele
+				}
+				study {
+					id
+					studyType
+					condition
+					biosample {
+						biosampleId
+						biosampleName
+					}
+				}
+				locus {
+					count
+				}
+			}
+		}
+	}
+}

--- a/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsQuery.gql
+++ b/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsQuery.gql
@@ -2,10 +2,7 @@ query QTLCredibleSetsQuery($ensemblId: String!, $size: Int!, $index: Int!) {
 	target(ensemblId: $ensemblId) {
 		id
 		approvedSymbol
-		qtlCredibleSets: credibleSets(
-			# studyTypes: [scsqtl, sceqtl, scpqtl, sctuqtl, sqtl, eqtl, pqtl, tuqtl]
-			page: { size: $size, index: $index }
-		) {
+		credibleSets(page: { size: $size, index: $index }) {
 			count
 			rows {
 				studyLocusId

--- a/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,8 +1,5 @@
 fragment TargetQTLCredibleSetsSummaryFragment on Target {
-	qtlCredibleSets: credibleSets(
-		# studyTypes: [scsqtl, sceqtl, scpqtl, sctuqtl, sqtl, eqtl, pqtl, tuqtl]
-		page: { size: 1, index: 0 }
-	) {
+	credibleSets(page: { size: 1, index: 0 }) {
 		count
 	}
 }

--- a/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
+++ b/packages/sections/src/target/QTLCredibleSets/QTLCredibleSetsSummaryFragment.gql
@@ -1,0 +1,8 @@
+fragment TargetQTLCredibleSetsSummaryFragment on Target {
+	qtlCredibleSets: credibleSets(
+		# studyTypes: [scsqtl, sceqtl, scpqtl, sctuqtl, sqtl, eqtl, pqtl, tuqtl]
+		page: { size: 1, index: 0 }
+	) {
+		count
+	}
+}

--- a/packages/sections/src/target/QTLCredibleSets/Summary.tsx
+++ b/packages/sections/src/target/QTLCredibleSets/Summary.tsx
@@ -1,0 +1,16 @@
+import { SummaryItem, usePlatformApi } from "ui";
+
+import { definition } from ".";
+import QTL_CREDIBLE_SETS_SUMMARY from "./QTLCredibleSetsSummaryFragment.gql";
+
+function Summary() {
+  const request = usePlatformApi(QTL_CREDIBLE_SETS_SUMMARY);
+
+  return <SummaryItem definition={definition} request={request} />;
+}
+
+Summary.fragments = {
+  TargetQTLCredibleSetsSummaryFragment: QTL_CREDIBLE_SETS_SUMMARY,
+};
+
+export default Summary;

--- a/packages/sections/src/target/QTLCredibleSets/index.ts
+++ b/packages/sections/src/target/QTLCredibleSets/index.ts
@@ -6,7 +6,7 @@ export const definition = {
   name: "molQTL Credible Sets",
   shortName: "QT",
   // @ts-expect-error TODO: fix this
-  hasData: (data: Target) => (data.qtlCredibleSets?.count || 0) > 0,
+  hasData: (data: Target) => (data.credibleSets?.count || 0) > 0,
 };
 
 // Components

--- a/packages/sections/src/target/QTLCredibleSets/index.ts
+++ b/packages/sections/src/target/QTLCredibleSets/index.ts
@@ -1,0 +1,15 @@
+import { lazy } from "react";
+import { Target } from "@ot/constants";
+
+export const definition = {
+  id: "qtl_credible_sets",
+  name: "molQTL Credible Sets",
+  shortName: "QT",
+  // @ts-expect-error TODO: fix this
+  hasData: (data: Target) => (data.qtlCredibleSets?.count || 0) > 0,
+};
+
+// Components
+export { default as Summary } from "./Summary";
+
+export const getBodyComponent = () => lazy(() => import("./Body"));

--- a/packages/sections/src/target/index.ts
+++ b/packages/sections/src/target/index.ts
@@ -13,6 +13,7 @@ export * as MousePhenotypes from "./MousePhenotypes";
 export * as OverlappingVariants from "./OverlappingVariants";
 export * as Pathways from "./Pathways";
 export * as Pharmacogenomics from "./Pharmacogenomics";
+export * as QTLCredibleSets from "./QTLCredibleSets";
 export * as Safety from "./Safety";
 export * as SubcellularLocation from "./SubcellularLocation";
 export * as Tractability from "./Tractability"; 


### PR DESCRIPTION
## Description

Add molQTL credible sets widget to target page.

**Issue:** [#3892](https://github.com/opentargets/issues/issues/3892)
**Deploy preview:** https://deploy-preview-796--ot-platform-partner.netlify.app/target/ENSG00000136244

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on local.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
