### PR TITLE
[AppConfig] Fix GHCR image name

### DIFF
--- a/.github/workflows/image.yaml
+++ b/.github/workflows/image.yaml
@@ -63,8 +63,8 @@ jobs:
           context: ./apps/platform
           push: true
           tags: |
-            ghcr.io/${{ github.repository }}/${{ env.REPO }}:latest
-            ghcr.io/${{ github.repository }}/${{ env.REPO }}:${{ env.TAG }}
+            ghcr.io/${{ github.repository }}:latest
+            ghcr.io/${{ github.repository }}:${{ env.TAG }}
             europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}:latest
             europe-west1-docker.pkg.dev/open-targets-eu-dev/${{ env.REPO }}/${{ env.REPO }}:${{ env.TAG }}
 


### PR DESCRIPTION
The docker image in GHCR is being named incorrectly: `ghcr.io/opentargets/ot-ui-apps/ot-ui-apps`. This PR fixes the naming so it is `ghcr.io/opentargets/ot-ui-apps`.