### PR TITLE
[Platform]: Removing link for OTG in Platform footer

### DIFF
--- a/packages/ot-constants/src/index.ts
+++ b/packages/ot-constants/src/index.ts
@@ -69,7 +69,6 @@ export const externalLinks = {
   network: [
     { label: "Science", url: "https://www.opentargets.org/science" },
     { label: "Publications", url: "https://www.opentargets.org/publications" },
-    { label: "Open Targets Genetics", url: "https://genetics.opentargets.org" },
     { label: "Jobs", url: "https://www.opentargets.org/jobs" },
     { label: "Blog", url: "https://blog.opentargets.org" },
   ] as ExternalLink[],


### PR DESCRIPTION
# [Platform]: Removing OTG from Platform Footer

## Description

Removed the link to Open Targets Genetics from the list of external links included in the Platform footer. 

**Issue:** ([link](https://github.com/opentargets/issues/issues/3989))
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Previewed the changes on my local; the link was no longer there.
