### PR TITLE
[Platform]: correct Gene2Phenotype links to use proper query format

### DIFF
--- a/packages/sections/src/evidence/Gene2Phenotype/Body.jsx
+++ b/packages/sections/src/evidence/Gene2Phenotype/Body.jsx
@@ -17,8 +17,8 @@ import { epmcUrl, sentenceCase } from "@ot/utils";
 import OPEN_TARGETS_GENETICS_QUERY from "./sectionQuery.gql";
 import { definition } from ".";
 
-const g2pUrl = (studyId, symbol) =>
-  `https://www.ebi.ac.uk/gene2phenotype/search?query=${symbol}&panel=${studyId}`;
+const g2pUrl = (targetFromSourceId, diseaseFromSource) =>
+  `https://www.ebi.ac.uk/gene2phenotype/search?query=${targetFromSourceId}-related%20${diseaseFromSource}`;
 
 const getColumns = label => [
   {
@@ -98,8 +98,8 @@ const getColumns = label => [
     id: "studyId",
     label: "Panel",
     enableHiding: false,
-    renderCell: ({ studyId, target: { approvedSymbol } }) => (
-      <Link external to={g2pUrl(studyId, approvedSymbol)}>
+    renderCell: ({ studyId, targetFromSourceId, diseaseFromSource }) => (
+      <Link external to={g2pUrl(targetFromSourceId, diseaseFromSource)}>
         {studyId}
       </Link>
     ),

--- a/packages/sections/src/evidence/Gene2Phenotype/sectionQuery.gql
+++ b/packages/sections/src/evidence/Gene2Phenotype/sectionQuery.gql
@@ -1,4 +1,8 @@
-query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!) {
+query OpenTargetsGeneticsQuery(
+  $ensemblId: String!
+  $efoId: String!
+  $size: Int!
+) {
   disease(efoId: $efoId) {
     id
     gene2Phenotype: evidences(
@@ -18,6 +22,7 @@ query OpenTargetsGeneticsQuery($ensemblId: String!, $efoId: String!, $size: Int!
         allelicRequirements
         confidence
         studyId
+        targetFromSourceId
         target {
           approvedSymbol
         }


### PR DESCRIPTION
## Description

This PR fixes the Gene2Phenotype links in the evidence section to use the correct URL format.

## Changes

- Updated `g2pUrl` function to use the correct query parameter format
- Removed unnecessary `studyId` and `symbol` parameters from the function
- Now properly passes `targetFromSourceId` and `diseaseFromSource` to build the search URL
- Fixed URL format from `?panel=DD&search_term=FGFR3` to `?query=-related%20`

## Testing

The links now generate URLs in the expected format:
- **Before**: `https://www.ebi.ac.uk/gene2phenotype/search?panel=DD&search_term=FGFR3`
- **After**: `https://www.ebi.ac.uk/gene2phenotype/search?query=-related%20`

## Related Issue

Resolves https://github.com/opentargets/issues/issues/3831