### PR TITLE
[Platform]: UI consistency updates for Open Targets style guide

### DIFF
--- a/apps/platform/src/components/AssociationsToolkit/static_datasets/prioritisationColumns.ts
+++ b/apps/platform/src/components/AssociationsToolkit/static_datasets/prioritisationColumns.ts
@@ -62,10 +62,10 @@ const hasPocket: Column = {
 
 const mouseOrthologMaxIdentityPercentage: Column = {
   id: "mouseOrthologMaxIdentityPercentage",
-  label: "Mouse ortholog identity",
+  label: "Mouse orthologue identity",
   aggregation: TargetPrioritisationAggregation.DOABILITY,
   sectionId: "compGenomics",
-  description: "Mouse ortholog maximum identity percentage",
+  description: "Mouse orthologue maximum identity percentage",
   docsLink:
     "https://platform-docs.opentargets.org/web-interface/target-prioritisation#mouse-ortholog-identity",
   sectionProps: { viewMode: "mouseOrthologMaxIdentityPercentage" },

--- a/apps/platform/src/pages/APIPage/APIPage.jsx
+++ b/apps/platform/src/pages/APIPage/APIPage.jsx
@@ -183,7 +183,7 @@ function APIPage() {
                   Run sample query
                 </QueryButton>
                 <Typography variant="subtitle2" display="block" paragraph>
-                  GWAS studies associated with a specified disease
+                  GWAS associated with a specified disease
                 </Typography>
                 <QueryButton
                   className={classes.buttonMargin}
@@ -264,7 +264,7 @@ function APIPage() {
             <AccordionDetails>
               <div>
                 <Typography variant="subtitle2" display="block" paragraph>
-                  Colocalisation metrics for overlapping credible sets from GWAS studies
+                  Colocalisation metrics for overlapping GWAS credible sets
                 </Typography>
                 <QueryButton
                   className={classes.buttonMargin}

--- a/packages/sections/src/credibleSet/GWASColoc/Description.tsx
+++ b/packages/sections/src/credibleSet/GWASColoc/Description.tsx
@@ -3,7 +3,7 @@ import { Link } from "ui";
 function Description() {
   return (
     <>
-      Colocalisation metrics for overlapping credible sets from GWAS studies. Source:{" "}
+      Colocalisation metrics for overlapping GWAS credible sets. Source:{" "}
       <Link to="https://platform-docs.opentargets.org/credible-set#colocalisation" external>
         Open Targets
       </Link>

--- a/packages/sections/src/credibleSet/Locus2Gene/Description.tsx
+++ b/packages/sections/src/credibleSet/Locus2Gene/Description.tsx
@@ -4,7 +4,7 @@ import { Link } from "ui";
 function Description(): ReactElement {
   return (
     <>
-      Gene assignment based on machine-learning prioritisation of credible set features. Only scores
+      Gene assignment based on machine learning prioritisation of credible set features. Only scores
       above 0.05 are shown. Source:{" "}
       <Link to="https://platform-docs.opentargets.org/credible-set#locus-to-gene-l2g" external>
         Open Targets

--- a/packages/sections/src/credibleSet/Locus2Gene/index.ts
+++ b/packages/sections/src/credibleSet/Locus2Gene/index.ts
@@ -3,7 +3,7 @@ import { CredibleSet } from "@ot/constants";
 
 export const definition = {
   id: "locus2gene",
-  name: "Locus to Gene",
+  name: "Locus-to-Gene",
   shortName: "LG",
   hasData: (data: CredibleSet) => (data.l2GPredictions?.count || 0) > 0,
 };

--- a/packages/sections/src/disease/GWASStudies/Description.tsx
+++ b/packages/sections/src/disease/GWASStudies/Description.tsx
@@ -1,9 +1,13 @@
 import { Link } from "ui";
 
-function Description({ name }) {
+type DescriptionProps = {
+  name: string;
+};
+
+function Description({ name }: DescriptionProps) {
   return (
     <>
-      GWAS studies associated with <strong>{name}</strong>. Source:{" "}
+      GWAS associated with <strong>{name}</strong>. Source:{" "}
       <Link external to="https://www.ebi.ac.uk/gwas/studies">
         GWAS Catalog
       </Link>

--- a/packages/sections/src/disease/GWASStudies/index.ts
+++ b/packages/sections/src/disease/GWASStudies/index.ts
@@ -2,7 +2,7 @@ import { lazy } from "react";
 
 export const definition = {
   id: "GWASStudies",
-  name: "GWAS Studies",
+  name: "GWAS",
   shortName: "GS",
   hasData: data =>
     data?.studies?.count > 0 || // summary

--- a/packages/sections/src/study/SharedTraitStudies/Description.tsx
+++ b/packages/sections/src/study/SharedTraitStudies/Description.tsx
@@ -7,7 +7,7 @@ type DescriptionProps = {
 function Description({ studyId }: DescriptionProps) {
   return (
     <>
-      GWAS studies that share traits with study <strong>{studyId}</strong>. Source{" "}
+      GWAS sharing traits with study <strong>{studyId}</strong>. Source{" "}
       <Link external to="https://www.ebi.ac.uk/gwas/studies">
         GWAS Catalog
       </Link>

--- a/packages/sections/src/target/ComparativeGenomics/ComparativeGenomicsPlot.tsx
+++ b/packages/sections/src/target/ComparativeGenomics/ComparativeGenomicsPlot.tsx
@@ -7,7 +7,7 @@ import { Link, DataDownloader } from "ui";
 
 const content = {
   mouseOrthologMaxIdentityPercentage:
-    "The Mouse Ortholog Identity visualization highlights the maximum sequence identity (%) of mouse orthologs for a given target, providing insight into its potential for in vivo assays. Data is sourced from the Ensembl Compara widget, and only orthologs with at least 80% identity are considered. Scores range from 0 to 1, where 1 indicates a mouse gene with 100% identity to the target, and 0 means no gene meets the 80% threshold. If multiple orthologs exist, the highest identity percentage is displayed.",
+    "The Mouse Orthologue Identity visualization highlights the maximum sequence identity (%) of mouse orthologues for a given target, providing insight into its potential for in vivo assays. Data is sourced from the Ensembl Compara widget, and only orthologues with at least 80% identity are considered. Scores range from 0 to 1, where 1 indicates a mouse gene with 100% identity to the target, and 0 means no gene meets the 80% threshold. If multiple orthologues exist, the highest identity percentage is displayed.",
   paralogMaxIdentityPercentage:
     "The Paralogues visualization displays the maximum sequence identity (%) of paralogues within the human genome, offering insights into functional redundancy or diversity. Data is sourced from the Ensembl Compara widget, focusing on paralogues with at least 60% identity to the target. Scores range from 0 to -1, where -1 represents paralogues with higher identity (≥60%), and 0 indicates paralogues with lower identity.",
 };


### PR DESCRIPTION
## Description

This PR addresses all the UI consistency issues identified in [GitHub issue #3868](https://github.com/opentargets/issues/issues/3868) to align with the Open Targets style guide.

@HelenaCornu GWAS studies I could do a few but there are cases in which is quite tricky. It's complicated. We use GWAS studies as a coined term to distinguish against molQTL studies. However they are technically both GWAS. There was some discussion around this in the early days of gentropy with Yakov and we concluded to stick to this nomenclature. It's however true the `S` in GWAS refers to studies but it would be very weird to have a `GWAS` widget in the target page that excludes molQTL.

Each task is in a different commit in case we want to revert anything 

## Changes Made

### 1. Locus-to-Gene Widget Name Spelling
- **File**: `packages/sections/src/credibleSet/Locus2Gene/index.ts`
- **Change**: Updated widget name from "Locus to Gene" to "Locus-to-Gene"
- **Impact**: Consistent hyphenated spelling across all pages

### 2. Machine Learning Terminology
- **File**: `packages/sections/src/credibleSet/Locus2Gene/Description.tsx`
- **Change**: Updated "machine-learning" to "machine learning" (removed hyphenation)
- **Impact**: Aligns with style guide recommendation to not hyphenate this term

### 3. GWAS Studies Terminology
- **Files**: Multiple widget description files and API pages
- **Change**: Updated "GWAS studies" to just "GWAS" (removed redundant "studies")
- **Impact**: Eliminates redundant "studies" after "GWAS" (genome-wide association studies)

### 4. Comparative Genomics Spelling
- **Files**: `packages/sections/src/target/ComparativeGenomics/ComparativeGenomicsPlot.tsx`, `apps/platform/src/components/AssociationsToolkit/static_datasets/prioritisationColumns.ts`
- **Change**: Updated "ortholog" to "orthologue" in user-facing text (British spelling)
- **Impact**: Consistent British spelling as recommended in style guide and broken links to documentation are now fixed


## Commits

- `fdc58fca` - fix: update Locus-to-Gene widget name spelling
- `140dd5a0` - fix: update machine learning terminology in Locus-to-Gene description  
- `9cebb62e` - fix: GWAS studies as GWAS when possible
- `369bcab3` - fix: update Comparative Genomics spelling to British English

## Closes

Closes https://github.com/opentargets/issues/issues/3868