### PR TITLE
[Platform]: Fix padding on smiles drawer on drug page

### DIFF
--- a/apps/platform/src/pages/DrugPage/Smiles/SmilesHelper.jsx
+++ b/apps/platform/src/pages/DrugPage/Smiles/SmilesHelper.jsx
@@ -59,13 +59,11 @@ function SmilesHelper({ smiles, chemblId }) {
       drawSmiles(smiles, `${chemblId}-modal`, {
         width: 750,
         height: 440,
-        padding: 10,
       });
     } else
       drawSmiles(smiles, chemblId, {
         width: 450,
         height: 240,
-        padding: 10,
       });
   });
 


### PR DESCRIPTION
## Description

Remove custom padding, which means the larger default padding is used - so text is less likely to be cropped.

Closes https://github.com/opentargets/issues/issues/3137

**Issue:** [#3137](https://github.com/opentargets/issues/issues/3137)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
