### PR TITLE
[Platform]: Show multi-residue variants in variant page molecular viewer 

### DIFF
--- a/packages/sections/src/variant/MolecularStructure/helpers.tsx
+++ b/packages/sections/src/variant/MolecularStructure/helpers.tsx
@@ -39,7 +39,7 @@ export function getHydrophobicityColor(resn) {
 const variantColor = "lime";
 const clickColor = "magenta";
 
-const labelStyle =   {
+const labelStyle = {
   alignment: "center",
   screenOffset: new Vector2(28, -28),
   backgroundColor: "#fff",
@@ -365,20 +365,23 @@ export function trackTicks(state) {
   ];
 }
 
-// after load data into viewer, check variant's reference amino acid matches
-// amino acid at same position in structure data
+// after load data into viewer, check variant's reference amino acids match
+// amino acids at same positions in structure data
 export function dataHandler(viewer, dispatch, row) {
   const allAtoms = viewer.getModel().selectedAtoms();
   dispatch({
     type: "setNResidues",
     value: max(allAtoms, atom => atom.resi),
   });
-  const structureReferenceAminoAcid = 
-    allAtoms.find(atom => atom.resi === row.aminoAcidPosition)?.resn;
-  if (aminoAcidLookup[row.referenceAminoAcid[0]] !== structureReferenceAminoAcid) {
-    dispatch({
-      type: "setMessage",
-      value: "AlphaFold structure not available",
-    });
+  for (const [j, residueChar] of [...row.referenceAminoAcid].entries()) {
+    const structureResidueName = allAtoms.find(atom => {
+      return atom.resi === row.aminoAcidPosition - row.referenceAminoAcid.length + 1 + j;
+    })?.resn;
+    if (aminoAcidLookup[residueChar] !== structureResidueName) {
+      dispatch({
+        type: "setMessage",
+        value: "AlphaFold structure not available",
+      });
+    }
   }
 }


### PR DESCRIPTION
## Description

Updates the check that the variant reference amino acids in the OT data match those in the downloaded structure file. 

The previous check failed for multi-residue variants since it assumed the amino acid position of the variant referred to the first reference amino acid when it actually refers to the last.

**Deploy preview:** https://deploy-preview-819--ot-platform.netlify.app/variant/10_110584225_GCAGGGTCGAGGAAGC_G

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
