### PR TITLE
[Platform]: Target page structure viewer - fetch results list from uniprot

### DIFF
--- a/packages/sections/src/target/MolecularStructure/Body.jsx
+++ b/packages/sections/src/target/MolecularStructure/Body.jsx
@@ -8,9 +8,9 @@ import MOLECULAR_STRUCTURE_QUERY from "./MolecularStructure.gql";
 import { useState, useEffect } from "react";
 import Table from "./Table";
 import Viewer from "./Viewer";
-import { getSegments } from "./helpers";
+import { getSegments, restructureRowProperties } from "./helpers";
 
-const experimentalResultsStem = "https://www.ebi.ac.uk/proteins/api/proteins/";
+const experimentalResultsStem = "https://rest.uniprot.org/uniprotkb/";
 const alphaFoldResultsStem = "https://alphafold.ebi.ac.uk/api/prediction/";
 
 function Body({ id: ensemblId, label: symbol, entity }) {
@@ -41,7 +41,7 @@ function Body({ id: ensemblId, label: symbol, entity }) {
             if (json.length > 0) {
               results.unshift({
                 id: json[0].entryId,
-                type: "AlphaFold",
+                database: "AlphaFold",
                 properties: {
                   chains: `A=${json[0].uniprotStart}-${json[0].uniprotEnd}`,
                   method: "Prediction",
@@ -63,7 +63,8 @@ function Body({ id: ensemblId, label: symbol, entity }) {
             console.error(`Response status (PDB request): ${response.status}`);
           } else {
             const json = await response.json();
-            const pdbResults = json?.dbReferences?.filter(row => row.type === "PDB") ?? [];
+            const pdbResults = json?.uniProtKBCrossReferences?.filter(row => row.database === "PDB") ?? [];
+            for (const row of pdbResults) restructureRowProperties(row);
             results.push(...pdbResults);
           }
         } catch (error) {

--- a/packages/sections/src/target/MolecularStructure/Table.tsx
+++ b/packages/sections/src/target/MolecularStructure/Table.tsx
@@ -51,17 +51,17 @@ function Table({ uniprotId, rows, segments, setSelectedRow, request, query, vari
       exportValue: ({ id }) => segments[id].segmentsString,
     },
     {
-      id: "type",
+      id: "properties.database",
       label: "Source",
       sortable: true,
-      renderCell: ({ id, type }) => {
-        const url = isAlphaFold({ type })
+      renderCell: ({ id, database }) => {
+        const url = isAlphaFold({ database })
           ? `https://www.alphafold.ebi.ac.uk/entry/${uniprotId}`
           : `https://www.ebi.ac.uk/pdbe/entry/pdb/${id}`;
         return (
           <div onClick={event => event.stopPropagation()}>
             <Link external to={url}>
-              {type}
+              {database}
             </Link>
           </div>
         );

--- a/packages/sections/src/target/MolecularStructure/helpers.ts
+++ b/packages/sections/src/target/MolecularStructure/helpers.ts
@@ -1,5 +1,5 @@
 export function isAlphaFold(selectedRow) {
-  return selectedRow?.type?.toLowerCase?.() === "alphafold";
+  return selectedRow?.database?.toLowerCase?.() === "alphafold";
 }
 
 export function zipToObject(arr1, arr2) {
@@ -12,6 +12,15 @@ export function zipToObject(arr1, arr2) {
 
 export function modulo(n, d) {
   return ((n % d) + d) % d;
+}
+
+// convert (in place) the 'properties' property from an array to an object
+export function restructureRowProperties(row) {
+  const obj = {};
+  for (const { key, value } of row?.properties ?? []) {
+    obj[key.toLowerCase()] = value;
+  }
+  row.properties = obj;
 }
 
 export function getSegments(chainsAndPositions) {


### PR DESCRIPTION
## Description

Target page structure viewer: The widget table is populated from a request to `https://www.ebi.ac.uk/proteins/api/proteins/` but this no longer works. This PR updates the request to use `rest.uniprot.org/uniprotkb/` and processes the results into the format expected by the widget.

**Issue:** Fixes [#4081](https://github.com/opentargets/issues/issues/4081)
**Deploy preview:** https://deploy-preview-825--ot-platform.netlify.app/target/ENSG00000133703

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
