### PR TITLE
[Platform]: Avoid failed profile request on credible set page.

### DIFF
--- a/apps/platform/src/pages/CredibleSetPage/CredibleSetPage.tsx
+++ b/apps/platform/src/pages/CredibleSetPage/CredibleSetPage.tsx
@@ -50,7 +50,7 @@ function CredibleSetPage(): ReactElement {
             />
           </Tabs>
         </Box>
-        <Profile studyLocusId={studyLocusId} variantId={variantId} />
+        {variantId && <Profile studyLocusId={studyLocusId} variantId={variantId} />}
       </>
     </BasePage>
   );


### PR DESCRIPTION
## Description

Avoid failed profile request on credible set page by only rendering the profile once the the lead variant id is available - i.e. once the page query has completed.

**Issue:** Closes [#4112](https://github.com/opentargets/issues/issues/4112)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
