### PR TITLE
[Platform]: Downloads - Updated Google Cloud commands text

### DIFF
--- a/apps/platform/src/pages/DownloadsPage/DownloadsAccessOptions.tsx
+++ b/apps/platform/src/pages/DownloadsPage/DownloadsAccessOptions.tsx
@@ -104,7 +104,7 @@ function GcpLocationMemo() {
         border: "1px solid",
       }}
     >
-    You need to specify <b>billing project</b> when accessing the data from the Google Cloud.
+    You need to specify <b>a billing project</b> when accessing the data from the Google Cloud.
     </Typography>
   )
 }


### PR DESCRIPTION
# [Platform]: Updated google cloud commands text

## Description

Due to the fact that when accessing from the google cloud requires to specify the `--billing-project`, it would be good to make sure that people understand why the command they attempt to run fails.

This PR adds:
* Added topology with short memo describing that the project needs to be specified
* Updated text for `google cloud rsync` commend to include `--billing-project`
**Issue:** (link)
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Checked on local deployment

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
