### PR TITLE
[UI]: migrate PrivateRoute component to TypeScript

### DIFF
--- a/packages/ui/src/components/PrivateRoute.tsx
+++ b/packages/ui/src/components/PrivateRoute.tsx
@@ -1,7 +1,12 @@
 import { Navigate } from "react-router-dom";
 import usePermissions from "../hooks/usePermissions";
+import { ReactNode } from "react";
 
-function PrivateRoute({ children }) {
+type PrivateRouteProps = {
+  children: ReactNode;
+}
+
+function PrivateRoute({ children }: PrivateRouteProps) {
   const { isPartnerPreview } = usePermissions();
 
   if (!isPartnerPreview) {


### PR DESCRIPTION
## Description

Migrate the PrivateRoute component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Application was built locally. Component was manually inspected in the UI.

When trying to access the route `/projects` without permission, the component redirects to the 404 page:

<img width="1428" height="1200" alt="image" src="https://github.com/user-attachments/assets/0fcf6220-cabf-4177-ad47-4dce063eee60" />

In the opposite scenario, the user is redirected to the `/projects` page:

<img width="1853" height="1033" alt="image" src="https://github.com/user-attachments/assets/aa3acf32-147d-47c0-95d0-c9656b72b372" />

## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
