### PR TITLE
[UI]: migrate useDebounce hook to TypeScript

### DIFF
--- a/packages/ui/src/hooks/useDebounce.ts
+++ b/packages/ui/src/hooks/useDebounce.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-function useDebounce(value, delay) {
+function useDebounce(value: string, delay: number): string {
   const [debouncedValue, setDebouncedValue] = useState(value);
 
   useEffect(() => {


### PR DESCRIPTION
## Description

Migrate the useDebounce hook to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Application was built locally. Hook was tested by logging the return value of the `performance.now` function, outside (start) and inside (end) the `setTimeout` callback:

<img width="1445" height="285" alt="image" src="https://github.com/user-attachments/assets/c05bdf05-e56a-48c2-a802-a1698c2a26a6" />


## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
