### PR TITLE
[UI ]#4153 Exposed releaseNotesURL env variable

### DIFF
--- a/apps/platform/.env
+++ b/apps/platform/.env
@@ -1,3 +1,4 @@
 VITE_API_URL=https://dev.opentargets.xyz/api/v4/graphql
 VITE_AI_API_URL=https://dev-ai-api-w37vlfsidq-ew.a.run.app
 VITE_PROFILE=platform
+VITE_RELEASE_NOTES_URL="https://platform-docs.opentargets.org/release-notes"

--- a/apps/platform/docs/CUSTOM_CONFIG.md
+++ b/apps/platform/docs/CUSTOM_CONFIG.md
@@ -32,6 +32,10 @@ URL for links to corresponding pages of the Open Targets Genetics portal,
 no trailing slash;
 defaults to `https://genetics.opentargets.org`
 
+### configReleaseNotesURL
+
+Release notes URL. Defaults to `https://platform-docs.opentargets.org/release-notes`.
+
 #### configPrimaryColor
 
 Define the primary colour used by the Material UI components and visualisations. Default Open Targets blue is `#3489ca`.

--- a/apps/platform/src/pages/HomePage/HomePage.tsx
+++ b/apps/platform/src/pages/HomePage/HomePage.tsx
@@ -136,7 +136,7 @@ function HomePage(): JSX.Element {
   const { isPartnerPreview } = usePermissions();
   const releaseNotesURL = isPartnerPreview
     ? "http://home.opentargets.org/ppp-release-notes"
-    : "https://platform-docs.opentargets.org/release-notes";
+    : config.releaseNotesUrl;
   const classes = useStyles();
 
   const handleScrollDown = (): void => {

--- a/packages/ot-config/src/environment.ts
+++ b/packages/ot-config/src/environment.ts
@@ -9,6 +9,7 @@ export const getEnvironmentConfig = (env: Environment): Config => {
       googleTagManagerID: null,
       geneticsPortalUrl: "https://genetics.opentargets.org",
       gitVersion: "",
+      releaseNotesUrl: "https://platform-docs.opentargets.org/release-notes",
     },
     production: {
       urlApi: "https://api.platform.opentargets.org",
@@ -17,6 +18,7 @@ export const getEnvironmentConfig = (env: Environment): Config => {
       googleTagManagerID: "GTM-XXXXX",
       geneticsPortalUrl: "https://genetics.opentargets.org",
       gitVersion: "",
+      releaseNotesUrl: "https://platform-docs.opentargets.org/release-notes",
     },
   };
 
@@ -27,6 +29,7 @@ export const getEnvironmentConfig = (env: Environment): Config => {
 const ENV_API_URL: string | undefined = import.meta.env.VITE_API_URL;
 const ENV_AI_API_URL: string | undefined = import.meta.env.VITE_AI_API_URL;
 const ENV_GIT_VERSION: string | undefined = import.meta.env.VITE_GIT_VERSION;
+const ENV_RELEASE_NOTES_URL: string | undefined = import.meta.env.VITE_RELEASE_NOTES_URL;
 
 export const getConfig = (): Config => {
   return {
@@ -36,5 +39,6 @@ export const getConfig = (): Config => {
     profile: window.configProfile ?? { isPartnerPreview: false },
     googleTagManagerID: window.configGoogleTagManagerID ?? null,
     geneticsPortalUrl: window.configGeneticsPortalUrl ?? "https://genetics.opentargets.org",
+    releaseNotesUrl: window.configReleaseNotesUrl ?? ENV_RELEASE_NOTES_URL ?? "https://platform-docs.opentargets.org/release-notes/production",
   };
 };

--- a/packages/ot-config/src/index.ts
+++ b/packages/ot-config/src/index.ts
@@ -11,5 +11,6 @@ declare global {
     configGoogleTagManagerID?: string;
     configGeneticsPortalUrl?: string;
     gitVersion?: string;
+    configReleaseNotesUrl?: string;
   }
 }

--- a/packages/ot-config/src/types.ts
+++ b/packages/ot-config/src/types.ts
@@ -5,6 +5,7 @@ export interface Config {
   googleTagManagerID: string | null;
   geneticsPortalUrl: string;
   gitVersion: string;
+  releaseNotesUrl: string;
 }
 
 export type Environment = "development" | "production";


### PR DESCRIPTION
# Description

PR affects home page indirectly. A user starting UI from docker can adjust release-notes URL for local deployment.


**Issue:** Closes [4153](https://github.com/opentargets/issues/issues/4153)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [X] My changes generate no new warnings
- [X] I have made corresponding changes to the documentation
