### PR TITLE
[Platform]: Allow EVA (ClinVar) widget in evidence to have null variant

### DIFF
--- a/packages/sections/src/evidence/EVA/Body.jsx
+++ b/packages/sections/src/evidence/EVA/Body.jsx
@@ -152,15 +152,14 @@ function getColumns(label) {
     {
       id: "variantConsequence",
       label: "Variant Consequence",
-      renderCell: ({
-        variantFunctionalConsequence,
-        variant: {
+      renderCell: ({ variantFunctionalConsequence, variant }) => {
+        if (!variant) return naLabel;
+        const {
           chromosome,
           position,
           referenceAllele,
           alternateAllele
-        }
-      }) => {
+        } = variant;
         return (
           <div style={{ display: "flex", gap: "5px" }}>
             {variantFunctionalConsequence && (


### PR DESCRIPTION
## Description

Allow EVA (ClinVar) widget in evidence to have null variant.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
