### PR TITLE
[Platform]: Show units in tooltip at top level of baseline widget

### DIFF
--- a/packages/sections/src/target/BaselineExpression/processData.ts
+++ b/packages/sections/src/target/BaselineExpression/processData.ts
@@ -106,6 +106,9 @@ export function processData(
         firstLevelRow[datatypeId]._firstLevelName ??= biosampleParent.biosampleName;
         firstLevelRow[datatypeId]._firstLevelId ??= biosampleParent.biosampleId;
 
+        // units are same within a column
+        firstLevelRow[datatypeId].unit ??= row.unit;
+
         // distribution score - same for all 2nd-level entries with same datatype
         firstLevelRow[datatypeId].distribution_score ??= row.distribution_score;
 


### PR DESCRIPTION
## Description

Show units in tooltip at top level of baseline widget

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
