### PR TITLE
[Platform]: Fix tooltip in variants widget (CS page)

### DIFF
--- a/packages/sections/src/credibleSet/Variants/Body.tsx
+++ b/packages/sections/src/credibleSet/Variants/Body.tsx
@@ -109,18 +109,7 @@ function getColumns({ leadVariantId }: getColumnsType) {
       label: "LD (r²)",
       filterValue: false,
       numeric: true,
-      tooltip: ({ variant }) => (
-        <>
-          Linkage disequilibrium with the lead variant (
-          <DisplayVariantId
-            variantId={leadVariantId}
-            referenceAllele={variant?.leadReferenceAllele}
-            alternateAllele={variant?.leadAlternateAllele}
-            expand={false}
-          />
-          )
-        </>
-      ),
+      tooltip: "Linkage disequilibrium with the lead variant",
       renderCell: ({ r2Overall }) => {
         if (typeof r2Overall !== "number") return naLabel;
         return r2Overall.toPrecision(3);


### PR DESCRIPTION
## Description

Fix tooltip for LD(r^2) in variants widget (CS page).

**Deploy preview:** https://deploy-preview-881--ot-platform.netlify.app/credible-set/6300ecf8944dd4b6286cec5242d7e67a

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
