### PR TITLE
[Platform]:  fix credible set sample id on api examples page

### DIFF
--- a/apps/platform/src/pages/APIPage/CredibleSetAnnotation.gql
+++ b/apps/platform/src/pages/APIPage/CredibleSetAnnotation.gql
@@ -1,5 +1,5 @@
 query GWASColocQuery {
-  credibleSet(studyLocusId: "7d68cc9c70351c9dbd2a2c0c145e555d") {
+  credibleSet(studyLocusId: "118db6d05cf67fe7668ee7bac1170fd3") {
     colocalisation(studyTypes: [gwas]) {
       count
       rows {


### PR DESCRIPTION
# [Platform]:  fix credible set sample id on api examples page


## Description
This adds a valid credible set annotation example API query Id so that the query works again.

**Issue:** ([4178](https://github.com/opentargets/issues/issues/4178))


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Check the credible set annotation example


## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
