### PR TITLE
[UI]: migrate PlotContainerSection component to TypeScript

### DIFF
--- a/packages/ui/src/components/PlotContainerSection.tsx
+++ b/packages/ui/src/components/PlotContainerSection.tsx
@@ -1,13 +1,19 @@
+import { Theme } from "@mui/material";
 import { makeStyles } from "@mui/styles";
+import { ReactNode } from "react";
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme: Theme) => ({
   plotContainerSection: {
     padding: "4px 0",
     borderBottom: `1px solid ${theme.palette.grey[300]}`,
   },
 }));
 
-function PlotContainerSection({ children }) {
+type PlotContainerSectionProps = {
+  children: ReactNode;
+};
+
+function PlotContainerSection({ children }: PlotContainerSectionProps): ReactNode {
   const classes = useStyles();
   return <div className={classes.plotContainerSection}>{children}</div>;
 }


### PR DESCRIPTION
## Description

Migrate the KnownDrugsSourceDrawer component to TypeScript.

**Issue:** https://github.com/opentargets/issues/issues/2871

## Type of change

- [X] TypeScript refactor

## How Has This Been Tested?

Application was built locally. Component was manually inspected in the UI.

<img width="1766" height="792" alt="image" src="https://github.com/user-attachments/assets/ddf6ac95-bb70-4fa5-b459-617a538203d4" />


## Checklist:

- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] Any dependent changes have been merged and published in downstream modules
