### PR TITLE
[Platform]: Fix clinical dictionary keys and drug profile header and evidence

### DIFF
--- a/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
@@ -31,7 +31,7 @@ function ProfileHeader({ chemblId }: { chemblId: string }) {
 
 const clinicalPhase = maximumClinicalStage
     ? phaseMap(maximumClinicalStage)
-    : "Preclinical";
+    : "Unknown";
 
   return (
     <BaseProfileHeader>

--- a/packages/ot-constants/src/index.ts
+++ b/packages/ot-constants/src/index.ts
@@ -213,16 +213,9 @@ export const decimalPlaces = 3;
 
 // Clinical Phases Mapping
 const clinicalPhases: { [key: string]: string } = {
-  "-1": "Unknown",
-  "0": "Phase 0",
-  "0.5": "Phase I (Early)",
-  "1": "Phase I",
-  "2": "Phase II",
-  "3": "Phase III",
-  "4": "Phase IV",
-  APPROVED: "Approved",
+  APPROVAL: "Approval",
   PHASE_4: "Phase IV",
-  WITHDRAWN: "Withdrawn",
+  WITHDRAWAL: "Withdrawal",
   PREAPPROVAL: "Pre-approval",
   PHASE_3: "Phase III",
   PHASE_2_3: "Phase II/III",
@@ -233,18 +226,6 @@ const clinicalPhases: { [key: string]: string } = {
   IND: "IND",
   PRECLINICAL: "Preclinical",
   UNKNOWN: "Unknown",
-  // Lowercase display-name keys (from PTS maximumClinicalStage)
-  approved: "Approved",
-  "phase IV": "Phase IV",
-  "phase III": "Phase III",
-  "phase II/III": "Phase II/III",
-  "phase II": "Phase II",
-  "phase I/II": "Phase I/II",
-  "phase I": "Phase I",
-  "early phase I": "Phase I (Early)",
-  "pre-approval": "Pre-approval",
-  preclinical: "Preclinical",
-  unknown: "Unknown",
 };
 
 export const phaseMap = (clinicalPhase: number | string): string => {


### PR DESCRIPTION
There is an issue with dictionaries at the moment that it's causing the evidence clinical stage not to work properly because of the lack of alignment on the data.

Clinical stage in drug profile page currently works but it doesn't work in evidence widget.

This PR does not fix the current data, but instead it will be compatible with the data that will be available on 11/3. We will streamline the data so less cases need to be handled

   - Rename `APPROVED` → `APPROVAL` and `WITHDRAWN` → `WITHDRAWAL` in the
   `clinicalPhases` dictionary to align with `clinicalStageCategories` keys
   - Remove legacy numeric and lowercase display-name keys from `clinicalPhases` (no
   longer needed)
   - Update drug `ProfileHeader` fallback for missing `maximumClinicalStage` from
   `"Preclinical"` to `"Unknown"`                                                        