### PR TITLE
[Platform]: Fix Probes&Drugs cross-reference source casing in DrugPage Header

### DIFF
--- a/apps/platform/src/pages/DrugPage/Header.tsx
+++ b/apps/platform/src/pages/DrugPage/Header.tsx
@@ -12,7 +12,7 @@ function DrugHeader({ loading, chemblId, name, crossReferences } : { loading: bo
     : null;
   const wikipedia = crossReferences ? crossReferences.find(cr => cr.source === "Wikipedia") : null;
   const probesDrugs = crossReferences
-    ? crossReferences.find(cr => cr.source === "probes&drugs")
+    ? crossReferences.find(cr => cr.source === "Probes&Drugs")
     : null;
 
   return (


### PR DESCRIPTION
## Summary
- Fix the `crossReferences` source filter in `DrugPage/Header.tsx` to use `"Probes&Drugs"` (capitalized) instead of `"probes&drugs"`, matching the actual source value returned by the API.

## Test plan
- [x] Navigate to a Drug page that has a Probes&Drugs cross-reference and verify the link appears correctly