### PR TITLE
[Platform] Fix number formatting in Genetic Constrint widget

### DIFF
--- a/packages/ot-utils/src/formatters.ts
+++ b/packages/ot-utils/src/formatters.ts
@@ -1,9 +1,10 @@
 /**
- * Formats a number to show only the first 3 non-zero significant digits.
+ * Formats a number to show only the first 3 significant digits.
  * Falls back to scientific notation for very small (<1e-3) or large (>=1e4) magnitudes.
  */
 export function formatSignificantDigits(
-  value: number | string | null | undefined
+  value: number | string | null | undefined,
+  sigFigs = 3
 ): string | number | null | undefined {
   if (value === null || value === undefined) return value;
 
@@ -20,13 +21,16 @@ export function formatSignificantDigits(
 
   // Determine required decimal places to keep 3 significant digits
   const magnitude = Math.floor(Math.log10(absNum)) + 1; // digits before decimal
-  const decimalPlaces = Math.max(0, 3 - magnitude);
+  const decimalPlaces = sigFigs - magnitude;
 
-  const rounded = Math.round(absNum * 10 ** decimalPlaces) / 10 ** decimalPlaces;
-  const formatted = rounded.toFixed(decimalPlaces);
-  const trimmed = formatted.replace(/\.?0+$/, "");
+  const factor = Math.pow(10, decimalPlaces);
+  const rounded = Math.round(num * factor) / factor;
 
-  return num < 0 ? `-${trimmed}` : trimmed;
+  // Convert to string without exponential notation
+  return rounded.toLocaleString("en-US", {
+    useGrouping: false,
+    maximumFractionDigits: Math.max(0, decimalPlaces),
+  });
 }
 
 /**

--- a/packages/sections/src/target/GeneticConstraint/Body.jsx
+++ b/packages/sections/src/target/GeneticConstraint/Body.jsx
@@ -77,7 +77,7 @@ function getColumns(ensemblId, symbol) {
     {
       id: "exp",
       label: "Expected SNVs",
-      renderCell: ({ exp }) => formatSignificantDigits(exp),
+      renderCell: ({ exp }) => Math.round(exp),
       tooltip: "Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth <1 were removed from the totals.",
     },
     {

--- a/packages/sections/src/target/GeneticConstraint/Body.jsx
+++ b/packages/sections/src/target/GeneticConstraint/Body.jsx
@@ -3,6 +3,7 @@ import { useQuery } from "@apollo/client";
 import { SectionItem, Link, Tooltip, OtTable } from "ui";
 
 import { definition } from ".";
+import { naLabel } from "@ot/constants";
 import { formatSignificantDigits } from "@ot/utils";
 import Description from "./Description";
 import upperBin6Map from "./upperBin6Map";
@@ -77,7 +78,7 @@ function getColumns(ensemblId, symbol) {
     {
       id: "exp",
       label: "Expected SNVs",
-      renderCell: ({ exp }) => Math.round(exp),
+      renderCell: ({ exp }) => exp == null ? naLabel : Math.round(exp),
       tooltip: "Expected variant counts were predicted using a depth corrected probability of mutation for each gene. More details can be found in the gnomAD flagship paper. Note that the expected variant counts for bases with a median depth <1 were removed from the totals.",
     },
     {


### PR DESCRIPTION
## Description

Fix number formatting in Genetic Constrint widget.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
