### PR TITLE
[Platform]: Switch order of sources links in drugs widgets

### DIFF
--- a/packages/sections/src/disease/Drugs/Description.tsx
+++ b/packages/sections/src/disease/Drugs/Description.tsx
@@ -5,12 +5,12 @@ function Description({ name }: any) {
     <>
       Investigational and approved drugs for <strong>{name}</strong> curated from clinical trial
       records and post-marketing package inserts. Source:{" "}
-      <Link to="https://www.ebi.ac.uk/chembl/" external>
-        ChEMBL
-      </Link>
-      {" "}and{" "}
       <Link to="https://platform-docs.opentargets.org/disease-or-phenotype/drugs" external>
         Open Targets
+      </Link>
+      {" "}and{" "}
+      <Link to="https://www.ebi.ac.uk/chembl/" external>
+        ChEMBL
       </Link>
       .
     </>

--- a/packages/sections/src/drug/Indications/Description.tsx
+++ b/packages/sections/src/drug/Indications/Description.tsx
@@ -5,12 +5,12 @@ function Description({ name }) {
     <>
       Investigational and approved indications for <strong>{name}</strong> curated from clinical
       trial records and post-marketing package inserts. Source:{" "}
-      <Link to="https://www.ebi.ac.uk/chembl/" external>
-        ChEMBL
-      </Link>
-      {" "}and{" "}
       <Link to="https://platform-docs.opentargets.org/drug/indications" external>
         Open Targets
+      </Link>
+      {" "}and{" "}
+      <Link to="https://www.ebi.ac.uk/chembl/" external>
+        ChEMBL
       </Link>
       .
     </>

--- a/packages/sections/src/evidence/ClinicalPrecedence/Description.tsx
+++ b/packages/sections/src/evidence/ClinicalPrecedence/Description.tsx
@@ -5,12 +5,12 @@ function Description({ symbol, name }) {
     <>
       Clinical candidates and/or approved drugs pharmacologically targeting{" "}
       <strong>{symbol}</strong> and indicated for <strong>{name}</strong>. Source:{" "}
-      <Link to="https://www.ebi.ac.uk/chembl/" external>
-        ChEMBL
-      </Link>
-      {" "}and{" "}
       <Link to="https://platform-docs.opentargets.org/evidence#clinical-precedence" external>
         Open Targets
+      </Link>
+      {" "}and{" "}
+      <Link to="https://www.ebi.ac.uk/chembl/" external>
+        ChEMBL
       </Link>
       .
     </>

--- a/packages/sections/src/target/Drugs/Description.tsx
+++ b/packages/sections/src/target/Drugs/Description.tsx
@@ -5,12 +5,12 @@ function Description({ name }: any) {
     <>
       Investigational and approved drugs for <strong>{name}</strong> curated from clinical trial
       records and post-marketing package inserts. Source:{" "}
-      <Link to="https://www.ebi.ac.uk/chembl/" external>
-        ChEMBL
-      </Link>
-      {" "}and{" "}
       <Link to="https://platform-docs.opentargets.org/target/drugs" external>
         Open Targets
+      </Link>
+      {" "}and{" "}
+      <Link to="https://www.ebi.ac.uk/chembl/" external>
+        ChEMBL
       </Link>
       .
     </>


### PR DESCRIPTION
## Description

Switch order of sources links in drugs widgets

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked in dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
