### PR TITLE
[Platform] Fix x-axis alignment issues in baseline and L2G widgets

### DIFF
--- a/packages/sections/src/target/BaselineExpression/BaselineExpressionTable.tsx
+++ b/packages/sections/src/target/BaselineExpression/BaselineExpressionTable.tsx
@@ -287,7 +287,7 @@ function XAxis({ datatype, maxMedian }) {
       sx={{
         position: "absolute",
         top: 0,
-        mt: -3.5,
+        mt: -4,
         left: "1.5rem",
         right: "3.5rem",
         display: "flex",
@@ -305,13 +305,17 @@ function XAxis({ datatype, maxMedian }) {
           sx={{
             display: "flex",
             justifyContent: "space-between",
-            alignItems: "baseline",
+            alignItems: "flex-end",
+            height: "1.25em",
+            overflow: "visible",
             pb: 0.25,
           }}
         >
           <Typography
             variant="caption"
             sx={{
+              display: "inline-block",
+              verticalAlign: "bottom",
               lineHeight: 1,
               cursor: "default",
               fontSize: { md: "11px", lg: "12px" }
@@ -321,6 +325,8 @@ function XAxis({ datatype, maxMedian }) {
           <Typography
             variant="caption"
             sx={{
+              display: "inline-block",
+              verticalAlign: "bottom",
               lineHeight: 1,
               cursor: "default",
               fontSize: { md: "11px", lg: "12px" }

--- a/packages/ui/src/components/HeatmapTable/renderWaterfallPlot.ts
+++ b/packages/ui/src/components/HeatmapTable/renderWaterfallPlot.ts
@@ -37,6 +37,7 @@ export function renderWaterfallPlot({
       reverse: true,
       axis: null,
       grid: true,
+      inset: -1,  // force x-axis upwards to correct position
     },
     marks: [
       // column headers


### PR DESCRIPTION
## Description

Fix x-axis alignment issues:
- baseline widget: previously an x-axis that used scientific notation in a label was slightly lower than x-axes in other columns.
- L2G, details waterfall plot: the x-axis was being displayed slightly lower than expected making it difficult to read the base score label.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
