### PR TITLE
[Platform-test]: Allow manual Preview Deployment for external contribution PRs we have reviewed

### DIFF
--- a/.github/workflows/e2e-ci.yml
+++ b/.github/workflows/e2e-ci.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      branch:
+        description: 'Branch to deploy (for fork PRs, use: username:branch-name)'
+        required: false
+        type: string
       test_scope:
         description: 'Test scope to run'
         required: true
@@ -55,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
       
       - uses: actions/setup-node@v3
         with:
@@ -105,6 +111,8 @@ jobs:
     timeout-minutes: 50
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
       
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
# [Platform-test]: Allow manual Preview Deployment for external contribution PRs we have reviewed


## Description

When external contributions are made via forks, there is no preview deployment for the e2e test to run on, this PR enables manual preview deployment for forks so we can run the tests on it



## Type of change

Please delete options that are not relevant.


- [ ] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?

will be tested after merge 

## Checklist:

- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
