### PR TITLE
[Platform]: Add deprecation message to expression widget

### DIFF
--- a/apps/platform/src/components/ShouldAccessPPP.tsx
+++ b/apps/platform/src/components/ShouldAccessPPP.tsx
@@ -11,9 +11,9 @@ import {
 } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { useLocation } from "react-router-dom";
+import { isOnPublic, testPPPaccess } from "@ot/utils";
+import { PPP_WEB_URL } from "@ot/constants";
 
-const PPP_API_URL = "https://api.partner-platform.opentargets.org/api/v4/graphql";
-const PPP_WEB_URL = "https://partner-platform.opentargets.org";
 const FOURTEEN = 14;
 
 const useStyles = makeStyles(theme => ({
@@ -48,13 +48,6 @@ function ShouldAccessPPP() {
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const classes = useStyles();
 
-  const isOnPublic = () => {
-    const windowLocation = window.location.href;
-    // escape validation on dev mode
-    if (import.meta.env.DEV) return false;
-    return !windowLocation.includes("partner");
-  };
-
   const shouldShowPopupAfterFixedDays = (DAYS: number) => {
     const currentDate = new Date();
     const oldDateObject = JSON.parse(localStorage.getItem("ppp-reminder-closed-on") || "{}");
@@ -85,25 +78,7 @@ function ShouldAccessPPP() {
   };
 
   const checkPPPaccess = () => {
-    fetch(PPP_API_URL, {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        operationName: "DataVersion",
-        variables: {},
-        query: `query DataVersion {
-        meta {
-          dataVersion {
-            month
-            year
-            __typename
-          }
-          __typename
-	
-      }
-    }`,
-      }),
-    })
+    testPPPaccess()
       .then(response => {
         if (response.status === 200) handleOpenDialog();
       })
@@ -119,7 +94,7 @@ function ShouldAccessPPP() {
   const goToPPP = () => {
     window.location.href = `${PPP_WEB_URL}${location.pathname}`;
   };
-
+  
   return (
     <>
       <Dialog

--- a/packages/ot-constants/src/index.ts
+++ b/packages/ot-constants/src/index.ts
@@ -28,6 +28,9 @@ interface MenuItem {
   showOnlyPartner?: boolean;
 }
 
+export const PPP_API_URL = "https://api.partner-platform.opentargets.org/api/v4/graphql";
+export const PPP_WEB_URL = "https://partner-platform.opentargets.org";
+
 export const PHARM_GKB_COLOR = {
   green: "#52a237",
   yellow: "#f0c584",

--- a/packages/ot-utils/src/index.ts
+++ b/packages/ot-utils/src/index.ts
@@ -7,6 +7,7 @@ export * from "./formatters";
 export * from "./global";
 export * from "./interactors";
 export * from "./literature";
+export * from "./publicOrPPP";
 export * from "./searchSuggestions";
 export * from "./study";
 export * from "./urls";

--- a/packages/ot-utils/src/publicOrPPP.ts
+++ b/packages/ot-utils/src/publicOrPPP.ts
@@ -1,0 +1,30 @@
+import { PPP_API_URL } from "@ot/constants";
+
+export const isOnPublic = () => {
+  const windowLocation = window.location.href;
+  // escape validation on dev mode
+  if (import.meta.env.DEV) return false;
+  return !windowLocation.includes("partner");
+};
+
+export async function testPPPaccess() {
+  return fetch(PPP_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      operationName: "DataVersion",
+      variables: {},
+      query: `query DataVersion {
+        meta {
+          dataVersion {
+            month
+            year
+            __typename
+          }
+          __typename
+    
+      }
+    }`,
+    }),
+  })
+}

--- a/packages/sections/src/target/Expression/Body.jsx
+++ b/packages/sections/src/target/Expression/Body.jsx
@@ -1,6 +1,11 @@
+import { faInfo } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useEffect, useState } from "react";
-import { Tab, Tabs } from "@mui/material";
-import { SectionItem, useApolloClient } from "ui";
+import { Alert, Collapse, Tab, Tabs, Typography } from "@mui/material";
+import { grey } from "@mui/material/colors";
+import { SectionItem, useApolloClient, Link } from "ui";
+import { testPPPaccess } from "@ot/utils";
+import { PPP_WEB_URL } from "@ot/constants";
 
 import { definition } from ".";
 import AtlasTab from "./AtlasTab";
@@ -10,6 +15,8 @@ import SummaryTab, { getData as getSummaryData } from "./SummaryTab";
 
 function Section({ id: ensgId, label: symbol, entity }) {
   const defaultTab = "summary";
+  const [showAlert, setShowAlert] = useState(true);
+  const [showPPPMessage, setShowPPPMessage] = useState(false);
   const [tab, setTab] = useState(defaultTab);
   const [requestSummary, setRequestSummary] = useState({ loading: true });
   const [requestGtex, setRequestGtex] = useState({ loading: true });
@@ -35,6 +42,15 @@ function Section({ id: ensgId, label: symbol, entity }) {
   const handleChangeTab = (_, tabChange) => {
     setTab(tabChange);
   };
+
+  useEffect(() => {
+    const checkPPP = async () => {
+      const canAccessPPP = await testPPPaccess();
+      if (canAccessPPP) setShowPPPMessage(true);
+    };
+
+    checkPPP();
+  }, []);
 
   useEffect(() => {
     let isCurrent = true;
@@ -63,6 +79,28 @@ function Section({ id: ensgId, label: symbol, entity }) {
       renderDescription={() => <Description symbol={symbol} />}
       renderBody={() => (
         <>
+          <Collapse in={showAlert} timeout={500}>
+            <Alert
+              sx={{
+                bgcolor: grey[100],
+                color: "text.primary",
+                my: 1.5,
+                "& .MuiAlert-icon": { color: grey[800] },
+              }}
+              severity="info"
+              onClose={() => setShowAlert(false)}
+            >
+              <Typography variant="body2">
+                This widget and the accompanying data will be deprecated in favour of new data in the June 2026 release.
+              </Typography>
+              {showPPPMessage && (
+                <Typography variant="body2" component="div" sx={{ pt: 1 }}>
+                  A beta version is available for testing and feedback on the{" "}
+                  <Link external to={PPP_WEB_URL}>Partner Preview Platform.</Link>
+                </Typography>
+              )}
+            </Alert>
+          </Collapse>
           <Tabs data-testid="expression-tabs" value={tab} onChange={handleChangeTab} style={{ marginBottom: "1rem" }}>
             <Tab data-testid="expression-tab-summary" value="summary" label="Summary" />
             {/* <Tab value="atlas" label="Experiments (Expression Atlas)" /> */}


### PR DESCRIPTION
## Description

Add deprecation message to expression widget.

Include link to PPP if user has access - just links to homepage since user may be on widget in profile page or target prioritisation.

Move functions and constants for testing if on public or PPP to `ot-utils` and `ot-constants`.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
