### PR TITLE
[Platform]: Show download error message in bibliography widgets

### DIFF
--- a/packages/sections/src/common/Literature/LiteratureContext.tsx
+++ b/packages/sections/src/common/Literature/LiteratureContext.tsx
@@ -77,6 +77,13 @@ function detailsReducer(detailsState: DetailsStateType, action: DetailsActionTyp
       }
       return newObj;
     }
+    case "setToTimedOut": {
+      const newObj = { ...detailsState };
+      for (const id of action.value) {
+        if (newObj[id] === "loading") newObj[id] = "timedOut";
+      }
+      return newObj;
+    }
   }
 }
 

--- a/packages/sections/src/common/Literature/PublicationsList.tsx
+++ b/packages/sections/src/common/Literature/PublicationsList.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { Box, Grid, Fade, Skeleton } from "@mui/material";
+import { Box, Grid, Fade, Skeleton, Typography } from "@mui/material";
 import { makeStyles } from "@mui/styles";
 import { PublicationWrapper, Table, useApolloClient } from "ui";
 import Loader from "./Loader";
@@ -12,6 +12,9 @@ import {
   useDetailsDispatch,
 } from "./LiteratureContext";
 import { fetchSimilarEntities, literaturesEuropePMCQuery } from "./requests";
+import { grey } from "@mui/material/colors";
+import { faCircleExclamation } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -45,18 +48,50 @@ function SkeletonRow() {
   return (
     <Fade in>
       <Box mb={2}>
-        <Skeleton height={60} />
-        <Skeleton width="60%" height={45} />
+        <Skeleton height={44} />
+        <Skeleton width="60%" height={44} />
         <Grid container wrap="nowrap">
           <Box width={130} mr={1}>
-            <Skeleton height={45} />
+            <Skeleton height={44} />
           </Box>
           <Box width={130}>
-            <Skeleton height={45} />
+            <Skeleton height={44} />
           </Box>
         </Grid>
       </Box>
     </Fade>
+  );
+}
+
+function TimedOutRow({ id }) {
+  return (
+    <Box
+      minHeight={148}
+      sx={{
+        "@keyframes fadeIn": { from: { opacity: 0 }, to: { opacity: 1 } },
+        animation: "fadeIn 0.3s ease-in",
+        display: "flex",
+        alignItems: "start",
+        gap: 2,
+        pt: 1,
+        pl: 1.5,
+        whiteSpace: "normal",
+      }}
+    >
+      <FontAwesomeIcon
+        icon={faCircleExclamation}
+        size="lg"
+        style={{ color: grey[500], paddingTop: 8 }}
+      />
+      <Box sx={{ minWidth: 0, flex: 1 }}>
+        <Typography component="div" variant="body1" sx={{ pt: 0.5, color: grey[500] }}>
+          Could not download publication details
+        </Typography>
+        <Typography component="div" variant="body2" sx={{ pt: 1, color: grey[500] }}>
+          Publication ID: {id}
+        </Typography>
+      </Box>
+    </Box>
   );
 }
 
@@ -79,13 +114,21 @@ function PublicationsList({ hideSearch = false }) {
         type: "setToLoading",
         value: missingDetails,
       });
-      const queryResult = await literaturesEuropePMCQuery({
-        literaturesIds: missingDetails,
-      });
-      detailsDispatch({
-        type: "addDetails",
-        value: parsePublications(queryResult),
-      });
+      const timeoutId = setTimeout(() => {
+        detailsDispatch({ type: "setToTimedOut", value: missingDetails });
+      }, 3000);
+      try {
+        const queryResult = await literaturesEuropePMCQuery({
+          literaturesIds: missingDetails,
+        });
+        detailsDispatch({
+          type: "addDetails",
+          value: parsePublications(queryResult),
+        });
+      } catch (e) {
+        clearTimeout(timeoutId);
+        detailsDispatch({ type: "setToTimedOut", value: missingDetails });
+      }
     };
     fetchFunction().catch(console.error);
   }, [literature]);
@@ -190,6 +233,8 @@ function PublicationsList({ hideSearch = false }) {
         const det = details[id];
         if (det === "loading") {
           return <SkeletonRow />;
+        } else if (det === "timedOut") {
+          return <TimedOutRow id={id} />;
         } else if (!det) {
           return null;
         } else {

--- a/packages/sections/src/common/Literature/PublicationsList.tsx
+++ b/packages/sections/src/common/Literature/PublicationsList.tsx
@@ -116,15 +116,19 @@ function PublicationsList({ hideSearch = false }) {
       });
       const timeoutId = setTimeout(() => {
         detailsDispatch({ type: "setToTimedOut", value: missingDetails });
-      }, 3000);
+      }, 5000);
       try {
         const queryResult = await literaturesEuropePMCQuery({
           literaturesIds: missingDetails,
         });
-        detailsDispatch({
-          type: "addDetails",
-          value: parsePublications(queryResult),
-        });
+        clearTimeout(timeoutId);
+        const parsed = parsePublications(queryResult);
+        detailsDispatch({ type: "addDetails", value: parsed });
+        const returnedIds = new Set(Object.keys(parsed));
+        const notFoundIds = missingDetails.filter(id => !returnedIds.has(id));
+        if (notFoundIds.length > 0) {
+          detailsDispatch({ type: "setToTimedOut", value: notFoundIds });
+        }
       } catch (e) {
         clearTimeout(timeoutId);
         detailsDispatch({ type: "setToTimedOut", value: missingDetails });

--- a/packages/sections/src/common/Literature/types.ts
+++ b/packages/sections/src/common/Literature/types.ts
@@ -95,7 +95,7 @@ export type RowType = {
 };
 
 export type DetailsStateType = {
-  [index: string]: undefined | "loading" | RowType;
+  [index: string]: undefined | "loading" | "timedOut" | RowType;
 };
 
 export type LiteratureActionType =
@@ -123,5 +123,9 @@ export type DetailsActionType =
     }
   | {
       type: "setToLoading";
+      value: string[];
+    }
+  | {
+      type: "setToTimedOut";
       value: string[];
     };


### PR DESCRIPTION
## Description

For each publication in bibliography widgets, replace the loading skeleton with a download error message if the details are missing from the response - or after 5s if there is a delay/problem fetching the data (if data loads it replaces the message). For now, message is "Could not download publication details". Possibly improve this once resolve (or better understand) issues on existing literature tickets.

**Issue:** [#4097](https://github.com/opentargets/issues/issues/4097) (but does not close ticket)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
