### PR TITLE
feat(drug): render synonyms/tradeNames as {label, source}

### DIFF
--- a/apps/platform/src/pages/DrugPage/ProfileHeader.gql
+++ b/apps/platform/src/pages/DrugPage/ProfileHeader.gql
@@ -1,7 +1,10 @@
 fragment DrugProfileHeaderFragment on Drug {
   description
   drugType
-  synonyms
+  synonyms {
+    label
+    source
+  }
   parentMolecule {
     id
     name
@@ -11,5 +14,8 @@ fragment DrugProfileHeaderFragment on Drug {
     name
   }
   maximumClinicalStage
-  tradeNames
+  tradeNames {
+    label
+    source
+  }
 }

--- a/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
@@ -8,10 +8,15 @@ import {
 } from "ui";
 import { Fragment } from "react";
 import { clinicalStageCategories } from "@ot/constants";
+import { parseSynonyms } from "@ot/utils";
 
 import Smiles from "./Smiles";
 
 import DRUG_PROFILE_HEADER_FRAGMENT from "./ProfileHeader.gql";
+
+// Drug synonym/tradeName sources, in display order: ChEMBL first, then AACT
+// (names mined from clinical trials). Sources are shown raw in the chip tooltip.
+const DRUG_SYNONYM_SORT_ORDER = ["ChEMBL", "AACT"];
 
 function ProfileHeader({ chemblId }: { chemblId: string }) {
   const { loading, error, data } = usePlatformApi();
@@ -30,7 +35,10 @@ function ProfileHeader({ chemblId }: { chemblId: string }) {
   } = data?.drug || {};
 
   const maxStage = clinicalStageCategories[maximumClinicalStage] ? clinicalStageCategories[maximumClinicalStage].label : "N/A";
- 
+
+  const parsedSynonyms = parseSynonyms(synonyms || [], { sortOrder: DRUG_SYNONYM_SORT_ORDER });
+  const parsedTradeNames = parseSynonyms(tradeNames || [], { sortOrder: DRUG_SYNONYM_SORT_ORDER });
+
   return (
     <BaseProfileHeader>
       <>
@@ -55,10 +63,10 @@ function ProfileHeader({ chemblId }: { chemblId: string }) {
           ))}
         </Field>
         <ProfileChipList title="Synonyms" inline loading={loading}>
-          {synonyms}
+          {parsedSynonyms}
         </ProfileChipList>
         <ProfileChipList title="Known trade names" inline loading={loading}>
-          {tradeNames}
+          {parsedTradeNames}
         </ProfileChipList>
       </>
       <Smiles chemblId={chemblId} />

--- a/apps/platform/src/pages/SearchPage/DrugDetail.jsx
+++ b/apps/platform/src/pages/SearchPage/DrugDetail.jsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrescriptionBottleAlt } from "@fortawesome/free-solid-svg-icons";
 
 import { LongText, Chip, Link, LongList } from "ui";
+import { parseSynonyms } from "@ot/utils";
 
 const useStyles = makeStyles({
   link: {
@@ -18,8 +19,13 @@ const useStyles = makeStyles({
   },
 });
 
+// ChEMBL first, then AACT (names mined from clinical trials)
+const DRUG_SYNONYM_SORT_ORDER = ["ChEMBL", "AACT"];
+
 function DrugDetail({ data }) {
   const classes = useStyles();
+  const synonyms = parseSynonyms(data.synonyms || [], { sortOrder: DRUG_SYNONYM_SORT_ORDER });
+  const tradeNames = parseSynonyms(data.tradeNames || [], { sortOrder: DRUG_SYNONYM_SORT_ORDER });
   return (
     <CardContent>
       <Typography color="primary" variant="h5">
@@ -54,27 +60,31 @@ function DrugDetail({ data }) {
           />
         </>
       )}
-      {data.synonyms.length > 0 && (
+      {synonyms.length > 0 && (
         <>
           <Typography className={classes.subtitle} variant="subtitle1">
             Synonyms
           </Typography>
           <LongList
-            terms={data.synonyms}
+            terms={synonyms}
             maxTerms={5}
-            render={synonym => <Chip key={synonym} title={synonym} label={synonym} />}
+            render={synonym => (
+              <Chip key={synonym.label} title={synonym.tooltip} label={synonym.label} />
+            )}
           />
         </>
       )}
-      {data.tradeNames.length > 0 && (
+      {tradeNames.length > 0 && (
         <>
           <Typography className={classes.subtitle} variant="subtitle1">
             Trade names
           </Typography>
           <LongList
-            terms={data.tradeNames}
+            terms={tradeNames}
             maxTerms={5}
-            render={tradeName => <Chip key={tradeName} title={tradeName} label={tradeName} />}
+            render={tradeName => (
+              <Chip key={tradeName.label} title={tradeName.tooltip} label={tradeName.label} />
+            )}
           />
         </>
       )}

--- a/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
+++ b/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
@@ -120,8 +120,14 @@ query SearchPageQuery($queryString: String!, $index: Int!, $entityNames: [String
               }
             }
           }
-          synonyms
-          tradeNames
+          synonyms {
+            label
+            source
+          }
+          tradeNames {
+            label
+            source
+          }
         }
       }
     }

--- a/apps/platform/src/pages/TargetPage/ProfileHeader.jsx
+++ b/apps/platform/src/pages/TargetPage/ProfileHeader.jsx
@@ -8,55 +8,20 @@ import {
 import { useTheme } from "@mui/styles";
 import TargetDescription from "./TargetDescription";
 
-import { clearDescriptionCodes } from "@ot/utils";
+import { clearDescriptionCodes, parseSynonyms } from "@ot/utils";
 
 import TARGET_PROFILE_HEADER_FRAGMENT from "./TargetProfileHeader.gql";
 import { Box } from "@mui/material";
 import { getGenomicLocation } from "@ot/constants";
 import GenomicLocation from "ui/src/components/GenomicLocation";
 
-/*
- * Target synonyms from the API have a "label" and a "source"
- * and can be lister more than once, with different sources.
- * Parse synonyms to a unique list (label) where terms can have
- * multiple sources in a tooltip
- */
-const parseSynonyms = synonyms => {
-  const sources = {
-    HGNC: "HGNC",
-    uniprot: "UniProt",
-    NCBI_entrez: "Entrez",
-  };
-  // Synonyms needs to be sorted by source in specific order
-  // (order converted to a map for convenience when doing the sort)
-  const sortingOrder = ["HGNC", "uniprot", "NCBI_entrez"].reduce(
-    (acc, a, i) => ({ ...acc, [a]: i }),
-    {}
-  );
-  const sortedSynonyms = synonyms
-    .slice()
-    .sort((a, b) => sortingOrder[a.source] - sortingOrder[b.source]);
-
-  const parsedSynonyms = [];
-
-  sortedSynonyms.forEach(s => {
-    const thisSyn = parsedSynonyms.find(
-      parsedSynonym => parsedSynonym.label.toLowerCase() === s.label.toLowerCase()
-    );
-    if (!thisSyn) {
-      parsedSynonyms.push({ label: s.label, tooltip: [s.source] });
-    } else {
-      // if synonym already in the list add the source to its tooltip
-      thisSyn.tooltip.push(s.source);
-    }
-  });
-
-  parsedSynonyms.forEach(syn => {
-    syn.tooltip = `Source: ${syn.tooltip.map(s => sources[s]).join(", ")}`;
-  });
-
-  return parsedSynonyms;
+// Target synonym sources, in display order, mapped to their display names.
+const TARGET_SYNONYM_SOURCE_LABELS = {
+  HGNC: "HGNC",
+  uniprot: "UniProt",
+  NCBI_entrez: "Entrez",
 };
+const TARGET_SYNONYM_SORT_ORDER = ["HGNC", "uniprot", "NCBI_entrez"];
 
 function ProfileHeader() {
   const { loading, error, data } = usePlatformApi();
@@ -70,7 +35,10 @@ function ProfileHeader() {
     data?.target.functionDescriptions,
     theme.palette.primary.main
   );
-  const synonyms = parseSynonyms(data?.target.synonyms || []);
+  const synonyms = parseSynonyms(data?.target.synonyms || [], {
+    sourceLabels: TARGET_SYNONYM_SOURCE_LABELS,
+    sortOrder: TARGET_SYNONYM_SORT_ORDER,
+  });
 
   // geneInfo currently holds the details for the "core essential" chip,
   // however in the future it will hold information to display other chips

--- a/packages/ot-utils/src/global.ts
+++ b/packages/ot-utils/src/global.ts
@@ -59,6 +59,58 @@ export function clearDescriptionCodes(
   });
 }
 
+export interface LabelAndSourceSynonym {
+  label: string;
+  source: string;
+}
+
+export interface ParsedSynonym {
+  label: string;
+  tooltip: string;
+}
+
+interface ParseSynonymsOptions {
+  // map raw source values to display names; unmapped sources fall back to the raw value
+  sourceLabels?: Record<string, string>;
+  // sort sources in this order; sources not listed are placed last
+  sortOrder?: string[];
+}
+
+/*
+ * Synonyms from the API have a "label" and a "source", and the same label can
+ * appear more than once with different sources. Collapse them into a unique
+ * list (by case-insensitive label) where each term lists all of its sources in
+ * a tooltip. Shared by the Target and Drug profile headers.
+ */
+export function parseSynonyms(
+  synonyms: LabelAndSourceSynonym[],
+  { sourceLabels = {}, sortOrder = [] }: ParseSynonymsOptions = {}
+): ParsedSynonym[] {
+  const rank = (source: string): number => {
+    const i = sortOrder.indexOf(source);
+    return i === -1 ? sortOrder.length : i;
+  };
+  const sortedSynonyms = synonyms.slice().sort((a, b) => rank(a.source) - rank(b.source));
+
+  const parsedSynonyms: { label: string; tooltip: string[] }[] = [];
+  sortedSynonyms.forEach((s) => {
+    const thisSyn = parsedSynonyms.find(
+      (parsedSynonym) => parsedSynonym.label.toLowerCase() === s.label.toLowerCase()
+    );
+    if (!thisSyn) {
+      parsedSynonyms.push({ label: s.label, tooltip: [s.source] });
+    } else {
+      // if the synonym is already in the list, add this source to its tooltip
+      thisSyn.tooltip.push(s.source);
+    }
+  });
+
+  return parsedSynonyms.map((syn) => ({
+    label: syn.label,
+    tooltip: `Source: ${syn.tooltip.map((s) => sourceLabels[s] ?? s).join(", ")}`,
+  }));
+}
+
 interface GraphQLParams {
   query: string;
   variables?: Record<string, unknown>;


### PR DESCRIPTION
> [!NOTE]
> **This is a placeholder PR.** Its purpose is to explain a frontend change required by the new drug-synonym schema (`synonyms`/`tradeNames` as `{label, source}`) that will arrive in the **next pipeline run (26.06)**. It depends on platform-api#349 and won't render correctly until that schema is deployed.
>
> I tried to reuse the logic already in the Target entity to avoid parallel implementations, but this carries some movement of code (Target's `parseSynonyms` extracted into `@ot/utils`). **Feel free to create your own implementation — discard all of this and do your own if you prefer.**

---

## Summary

Render drug `synonyms` and `tradeNames` using the new `{label, source}` schema. They changed from `[String]` to `[LabelAndSource]` in the API (opentargets/platform-api#349, tracking issue opentargets/issues#4414) — each name now carries its source (`ChEMBL`, or `AACT` for names mined from clinical trials).

The approach reuses Target's existing synonym handling rather than duplicating it (Target already renders `{label, source}` synonyms).

## What changed

- **`@ot/utils` (`global.ts`)** — extract Target's inline `parseSynonyms` into a shared, parameterized helper: `parseSynonyms(items, { sourceLabels, sortOrder })`. It dedupes by (case-insensitive) label and lists every source in a tooltip — returning `{label, tooltip}[]` for the shared `ProfileChipList`.
- **`TargetPage/ProfileHeader`** — drop the local copy, call the shared helper with Target's source map/order. **No behaviour change** (same dedupe, same tooltips).
- **`DrugPage/ProfileHeader`** (`.gql` + `.tsx`) — query `synonyms { label source }` / `tradeNames { label source }`; render both via the shared `parseSynonyms` → `ProfileChipList` (ChEMBL ordered before AACT, sources shown raw in the tooltip).
- **`SearchPage`** (`SearchPageQuery.gql` + `DrugDetail.jsx`) — same struct selection + shared parser for the drug search-result card (a scalar selection on these fields would otherwise be invalid against the new schema).

Net result: one `parseSynonyms`, three consumers (Target, Drug profile, Drug search) — no duplicated logic, and `ProfileChipList`/`Chip` were already shared.

## Notes

- The generated `Drug` type in `@ot/constants` still lists `synonyms: string[]` — that's codegen from the deployed schema and regenerates once platform-api#349 ships. The pages read `usePlatformApi().data` (typed `any`), so there's no transient type break.
- I couldn't run the local `lint-staged`/build (fresh worktree has no `node_modules`; the husky hook was skipped) — CI lint/typecheck/build is the verification. Changes are type-safe and pattern-consistent.

## Related

- platform-api: opentargets/platform-api#349 (the GraphQL schema change this consumes)
