### PR TITLE
[Platform]: Fix tooltip remaining visible in Manhattan plot

### DIFF
--- a/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
+++ b/packages/sections/src/study/GWASCredibleSets/ManhattanPlot.tsx
@@ -41,7 +41,6 @@ function ManhattanPlot({ loading, data: originalData }) {
   }
 
   function highlightElement(elmt) {
-    elmt.parentNode.appendChild(elmt);
     elmt.style.fill = markColor;
     elmt.style.strokeOpacity = 1;
     if (elmt.tagName === "line") elmt.style.strokeWidth = 1.7;


### PR DESCRIPTION
## Description

Tooltip was remaining visible in the Manhattan plot (study page) after moving the cursor off the data point/line. This fix sacrifices the bring-to-front on hover feature - which can be reimplemented in a safer way in future if needed.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
