### PR TITLE
[Platform]: Update drug synonyms and trade names

### DIFF
--- a/apps/platform/src/pages/DrugPage/ProfileHeader.gql
+++ b/apps/platform/src/pages/DrugPage/ProfileHeader.gql
@@ -1,7 +1,10 @@
 fragment DrugProfileHeaderFragment on Drug {
   description
   drugType
-  synonyms
+  synonyms {
+    label
+    source
+  }
   parentMolecule {
     id
     name
@@ -11,5 +14,8 @@ fragment DrugProfileHeaderFragment on Drug {
     name
   }
   maximumClinicalStage
-  tradeNames
+  tradeNames {
+    label
+    source
+  }
 }

--- a/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
+++ b/apps/platform/src/pages/DrugPage/ProfileHeader.tsx
@@ -8,6 +8,7 @@ import {
 } from "ui";
 import { Button, Paper, Modal } from "@mui/material";
 import { Fragment, useState } from "react";
+import { parseDrugLabels } from "@ot/utils";
 import { clinicalStageCategories } from "@ot/constants";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faMagnifyingGlassPlus, faXmark } from "@fortawesome/free-solid-svg-icons";
@@ -31,14 +32,14 @@ function ProfileHeader({ chemblId }: { chemblId: string }) {
     description,
     parentMolecule,
     childMolecules = [],
-    synonyms,
-    tradeNames,
+    synonyms = [],
+    tradeNames = [],
     drugType,
     maximumClinicalStage
   } = data?.drug || {};
 
   const maxStage = clinicalStageCategories[maximumClinicalStage] ? clinicalStageCategories[maximumClinicalStage].label : "N/A";
- 
+
   return (
     <BaseProfileHeader>
       <>
@@ -63,10 +64,10 @@ function ProfileHeader({ chemblId }: { chemblId: string }) {
           ))}
         </Field>
         <ProfileChipList title="Synonyms" inline loading={loading}>
-          {synonyms}
+          {parseDrugLabels(synonyms)}
         </ProfileChipList>
         <ProfileChipList title="Known trade names" inline loading={loading}>
-          {tradeNames}
+          {parseDrugLabels(tradeNames)}
         </ProfileChipList>
       </>
       <Paper
@@ -162,3 +163,4 @@ ProfileHeader.fragments = {
 };
 
 export default ProfileHeader;
+

--- a/apps/platform/src/pages/SearchPage/DrugDetail.jsx
+++ b/apps/platform/src/pages/SearchPage/DrugDetail.jsx
@@ -1,7 +1,9 @@
 import { CardContent, Typography } from "@mui/material";
+import { ProfileChipList } from "ui";
 import { makeStyles } from "@mui/styles";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faPrescriptionBottleAlt } from "@fortawesome/free-solid-svg-icons";
+import { parseDrugLabels } from "@ot/utils";
 
 import { LongText, Chip, Link, LongList } from "ui";
 
@@ -55,28 +57,14 @@ function DrugDetail({ data }) {
         </>
       )}
       {data.synonyms.length > 0 && (
-        <>
-          <Typography className={classes.subtitle} variant="subtitle1">
-            Synonyms
-          </Typography>
-          <LongList
-            terms={data.synonyms}
-            maxTerms={5}
-            render={synonym => <Chip key={synonym} title={synonym} label={synonym} />}
-          />
-        </>
+        <ProfileChipList title="Synonyms" maxTerms={5} titleVariant="subtitle1">
+          {parseDrugLabels(data.synonyms)}
+        </ProfileChipList>
       )}
       {data.tradeNames.length > 0 && (
-        <>
-          <Typography className={classes.subtitle} variant="subtitle1">
-            Trade names
-          </Typography>
-          <LongList
-            terms={data.tradeNames}
-            maxTerms={5}
-            render={tradeName => <Chip key={tradeName} title={tradeName} label={tradeName} />}
-          />
-        </>
+        <ProfileChipList title="Trade names" maxTerms={5} titleVariant="subtitle1">
+          {parseDrugLabels(data.tradeNames)}
+        </ProfileChipList>
       )}
     </CardContent>
   );

--- a/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
+++ b/apps/platform/src/pages/SearchPage/SearchPageQuery.gql
@@ -120,8 +120,14 @@ query SearchPageQuery($queryString: String!, $index: Int!, $entityNames: [String
               }
             }
           }
-          synonyms
-          tradeNames
+          synonyms {
+            label
+            source
+          }
+          tradeNames {
+            label
+            source
+          }
         }
       }
     }

--- a/packages/ot-utils/src/drug.ts
+++ b/packages/ot-utils/src/drug.ts
@@ -1,0 +1,31 @@
+interface DrugLabelEntry {
+  label: string;
+  source: string;
+}
+
+interface ParsedDrugLabel {
+  label: string;
+  tooltip: string;
+}
+
+// parse array of {source, label} objects into unique labels with tooltip of sources
+export function parseDrugLabels(entries: DrugLabelEntry[]): ParsedDrugLabel[] {
+  const groupedEntries = Object.groupBy(entries, ({ label }) => label.toLowerCase());
+
+  const sortedEntries =
+    Object.values(groupedEntries).sort((a, b) => a[0].label.localeCompare(b[0].label));
+
+  // replace source property with tooltip property
+  const parsedEntries = sortedEntries.map(group => {
+    return {
+      label: group[0].label,
+      tooltip: 'Source: ' +
+        group
+          .map(({ source }) => source)
+          .sort((a, b) => a.localeCompare(b))
+          .join(', '),
+    };
+  });
+
+  return parsedEntries;
+}

--- a/packages/ot-utils/src/index.ts
+++ b/packages/ot-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./alphaFold";
 export * from "./comparators";
 export * from "./createScopedContext";
+export * from "./drug";
 export * from "./downloads";
 export * from "./fetch";
 export * from "./formatters";

--- a/packages/ui/src/components/ProfileHeader/ProfileChipList.tsx
+++ b/packages/ui/src/components/ProfileHeader/ProfileChipList.tsx
@@ -23,10 +23,19 @@ type ChipListProps = {
   children?: ChipListItem[] | string[];
   inline?: boolean;
   loading: boolean;
+  maxTerms?: number;
   title: string;
+  titleVariant?: string;
 };
 
-function ChipList({ children, title, loading = false, inline }: ChipListProps): ReactNode {
+function ChipList({
+  children,
+  title,
+  loading = false,
+  inline,
+  maxTerms = 10,
+  titleVariant = "subtitle2",
+}: ChipListProps): ReactNode {
   const classes = useContainerStyles();
   if (inline && loading) return <Skeleton />;
 
@@ -34,7 +43,7 @@ function ChipList({ children, title, loading = false, inline }: ChipListProps): 
 
   return (
     <Box data-testid={`profile-${title.toLowerCase().replace(/\s+/g, '-')}`}>
-      <Typography variant="subtitle2" display={inline ? "inline" : ""}>
+      <Typography variant={titleVariant} display={inline ? "inline" : ""}>
         {title}
         {inline ? ": " : ""}
       </Typography>
@@ -43,7 +52,7 @@ function ChipList({ children, title, loading = false, inline }: ChipListProps): 
       ) : (
         <LongList
           terms={children}
-          maxTerms={10}
+          maxTerms={maxTerms}
           render={(item: ChipListItem | string) => {
             if (_.isString(item)) {
               return <Chip key={item} data-testid={`chip-${item}`} label={item} title={item} />;


### PR DESCRIPTION
## Description

Update drug synonyms and trade names in drug profile and search results:
- use new `{label, source}` structure from API
- add source tooltips

**Issue:** [#4414](https://github.com/opentargets/issues/issues/4414)
**Deploy preview:** https://deploy-preview-974--ot-platform.netlify.app/

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Checked on dev

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
