### PR TITLE
[Platform]: Add heritability estimates to study page summary statistics

### DIFF
--- a/packages/ui/src/components/SummaryStatsTable.tsx
+++ b/packages/ui/src/components/SummaryStatsTable.tsx
@@ -21,6 +21,39 @@ const dicSummary = [
     label: "SD diff P-Z",
     tooltip: "Standard deviation of the difference between reported and calculated log p-values",
   },
+  {
+    id: "h2",
+    label: "SNP heritability",
+    tooltip: "LDSC-estimated SNP-based heritability (liability scale for case/control traits)",
+  },
+  {
+    id: "h2_se",
+    label: "SNP heritability SE",
+    tooltip: "Standard error of the LDSC SNP-heritability estimate",
+  },
+  {
+    id: "intercept",
+    label: "LDSC intercept",
+    tooltip:
+      "LDSC regression intercept; values above 1 indicate inflation from confounding (e.g. population stratification) rather than polygenic signal",
+  },
+  {
+    id: "intercept_se",
+    label: "LDSC intercept SE",
+    tooltip: "Standard error of the LDSC regression intercept",
+  },
+  {
+    id: "mean_chisq",
+    label: "Mean chi-squared",
+    tooltip:
+      "Mean chi-squared statistic across variants used in LDSC; values above 1 reflect a mix of true polygenic signal and confounding",
+  },
+  {
+    id: "lambda_gc",
+    label: "GC lambda (LDSC)",
+    tooltip:
+      "Genomic control lambda computed from the LDSC-filtered variant set used for heritability estimation",
+  },
 ];
 
 function formatValue(v: number) {


### PR DESCRIPTION
## Description

Adds LDSC-derived heritability estimates to the **Harmonised summary statistics** popover on the study page (and credible set page, which shares the `SummaryStatsTable` component).

Six new rows are appended to the summary dictionary, rendered when the corresponding QC value is present in the study's `sumstatQCValues`:

- **SNP heritability** (`h2`) and its SE (`h2_se`)
- **LDSC intercept** (`intercept`) and its SE (`intercept_se`)
- **Mean chi-squared** (`mean_chisq`)
- **GC lambda (LDSC)** (`lambda_gc`)

Each row carries a tooltip explaining the statistic.

**Dependency / merge order — depends on #977:** this PR only adds dictionary entries; it does not add a guard for missing QC values. Studies whose `sumstatQCValues` lack these new LDSC fields (e.g. GWAS without LDSC estimates such as `GCST90295916`) would crash the popover. The guard lives in the companion bug fix #977, which must be merged **before or together with** this PR. The two branches touch different regions of `SummaryStatsTable.tsx` and merge cleanly in either order.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Ran the Platform dev server against the dev GraphQL API (`dev.opentargets.xyz`) and inspected the popover:

- GWAS study `GCST90475211` (Heart attack) — all six LDSC rows render with values matching the API (`h2` 0.0544, `intercept` 1.21, `mean_chisq` 1.55, `lambda_gc` 1.47, plus the two SE rows).
- Regression: the existing standard QC rows (Total variants, GC lambda, Mean beta, etc.) continue to render unchanged.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

