### PR TITLE
[Platform]: Prevent summary stats popover crash when QC values are missing

### DIFF
--- a/packages/ui/src/components/SummaryStatsTable.tsx
+++ b/packages/ui/src/components/SummaryStatsTable.tsx
@@ -36,9 +36,8 @@ export default function SummaryStatsTable({ sumstatQCValues }: any) {
       <table>
         <tbody>
           {dicSummary.map((sumstat: any) => {
-            const summStatValue = sumstatQCValues.find(
-              (v: any) => v.QCCheckName === sumstat.id
-            ).QCCheckValue;
+            const match = sumstatQCValues.find((v: any) => v.QCCheckName === sumstat.id);
+            if (!match) return null;
             return (
               <tr key={v1()}>
                 <td>
@@ -47,7 +46,7 @@ export default function SummaryStatsTable({ sumstatQCValues }: any) {
                   </Tooltip>
                 </td>
                 <Typography sx={{ textAlign: "right" }} component="td" variant="body2">
-                  {formatValue(summStatValue)}
+                  {formatValue(match.QCCheckValue)}
                 </Typography>
               </tr>
             );


### PR DESCRIPTION
## Description

Guards `SummaryStatsTable` against summary-statistics QC values that are absent for a given study. Previously the render assumed every dictionary entry had a matching `QCCheckValue`:

```js
const summStatValue = sumstatQCValues.find(v => v.QCCheckName === sumstat.id).QCCheckValue;
```

When a study has summary statistics (so the popover renders) but its `sumstatQCValues` is empty or missing a given check, `.find(...)` returns `undefined` and the page crashes with `Cannot read properties of undefined (reading 'QCCheckValue')`. The fix skips rows that have no matching value:

```js
const match = sumstatQCValues.find(v => v.QCCheckName === sumstat.id);
if (!match) return null;
```

This is a **pre-existing production crash** (it reproduces on `main`, e.g. for pQTL studies whose `sumstatQCValues` is `[]`), so it is addressed here as a standalone bug fix rather than bundled with a feature.

**Relationship to #976:** PR #976 (*heritability estimates in study page*) adds new LDSC dictionary rows but no guard. On its own it turns previously-working GWAS study pages (those with core QC but no LDSC estimates) into crashes. This fix should be merged **before or together with** #976. The two branches touch different regions of the file and merge cleanly in either order.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built the Platform bundle and served it against the dev GraphQL API (`dev.opentargets.xyz`), then exercised the summary statistics popover across studies in each state:

- **Was crashing, now safe** — `UKB_PPP_EUR_LPA_P08519_OID30747_v1` (pQTL, `sumstatQCValues: []`): popover now opens with 0 rows, no runtime error.
- **Was crashing, now safe** — `GCST90295916`, `GCST90018784` (GWAS, core QC only, no LDSC): render the available rows, skip the missing ones, no crash.
- **Regression check** — `GCST90475211`, `GCST90012877`, `GCST90204201` (full QC): all rows still render with correct values.
- **Unaffected** — `GCST90308590`, `GCST90239655` (`hasSumstats: false`): show "Not Available", no table, as before.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
