### PR TITLE
[Platform] Hide cohorts label on study page if cohorts array empty

### DIFF
--- a/packages/ui/src/components/DisplaySampleSize.tsx
+++ b/packages/ui/src/components/DisplaySampleSize.tsx
@@ -15,7 +15,7 @@ export default function DisplaySampleSize({
   const display = (
     <>
       {nSamples?.toLocaleString()}
-      {cohorts ? ` (cohorts: ${cohorts.join(", ")})` : ""}
+      {cohorts?.length > 0 ? ` (cohorts: ${cohorts.join(", ")})` : ""}
     </>
   );
 


### PR DESCRIPTION
## Description

Hide cohorts label on study page if cohorts array empty.

**Issue:** (link)
**Deploy preview:** (link)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Checked on dev.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
