### PR TITLE
[Platform]: Remove genetics portal URL references from configuration and utility

### DIFF
--- a/apps/docs/src/docs/configuration/PartnerPreview.mdx
+++ b/apps/docs/src/docs/configuration/PartnerPreview.mdx
@@ -14,11 +14,6 @@ The Platform reads runtime configuration at startup — either from environment 
 
 URL of the Platform GraphQL API. Required for all deployments.
 
-### `configGeneticsPortalUrl`
-
-URL for links to the Open Targets Genetics portal (no trailing slash).  
-Default: `https://genetics.opentargets.org`
-
 ### `configPrimaryColor`
 
 Primary colour used by MUI components and data visualisations.  

--- a/apps/docs/src/docs/packages/OtConfig.mdx
+++ b/apps/docs/src/docs/packages/OtConfig.mdx
@@ -37,7 +37,6 @@ const config = getConfig();
 // config.gitVersion   → build SHA, injected at deploy time
 // config.profile      → partner preview flags, colours, etc.
 // config.googleTagManagerID
-// config.geneticsPortalUrl
 ```
 
 ### Config resolution order
@@ -49,7 +48,6 @@ const config = getConfig();
 | `gitVersion` | `window.gitVersion` | `VITE_GIT_VERSION` | `""` |
 | `profile` | `window.configProfile` | — | `{ isPartnerPreview: false }` |
 | `googleTagManagerID` | `window.configGoogleTagManagerID` | — | `null` |
-| `geneticsPortalUrl` | `window.configGeneticsPortalUrl` | — | `"https://genetics.opentargets.org"` |
 
 ### `Config` type
 
@@ -59,7 +57,6 @@ interface Config {
   urlAiApi: string;
   profile: Record<string, unknown>;
   googleTagManagerID: string | null;
-  geneticsPortalUrl: string;
   gitVersion: string;
 }
 ```
@@ -106,7 +103,6 @@ declare global {
     configOTAiApi?: string;
     configProfile?: Record<string, unknown>;
     configGoogleTagManagerID?: string;
-    configGeneticsPortalUrl?: string;
     gitVersion?: string;
   }
 }

--- a/apps/docs/src/docs/packages/OtUtils.mdx
+++ b/apps/docs/src/docs/packages/OtUtils.mdx
@@ -36,11 +36,9 @@ formatPercentage(0)       // → "0"
 URL builders for external services, all config-aware.
 
 ```ts
-import { epmcUrl, otgStudyUrl, otgVariantUrl, europePmcLiteratureQuery } from "@ot/utils";
+import { epmcUrl, europePmcLiteratureQuery } from "@ot/utils";
 
 epmcUrl("33303749")                    // → "https://europepmc.org/article/MED/33303749"
-otgStudyUrl("GCST006614")              // → "${geneticsPortalUrl}/study/GCST006614"
-otgVariantUrl("1_154426264_C_T")       // → "${geneticsPortalUrl}/variant/1_154426264_C_T"
 ```
 
 ### `fetch`

--- a/packages/ot-config/src/environment.ts
+++ b/packages/ot-config/src/environment.ts
@@ -8,7 +8,6 @@ export const getEnvironmentConfig = (env: Environment): Config => {
       urlPathwaysApi: "",
       profile: {},
       googleTagManagerID: null,
-      geneticsPortalUrl: "https://genetics.opentargets.org",
       gitVersion: "",
     },
     production: {
@@ -17,7 +16,6 @@ export const getEnvironmentConfig = (env: Environment): Config => {
       urlPathwaysApi: "",
       profile: {},
       googleTagManagerID: "GTM-XXXXX",
-      geneticsPortalUrl: "https://genetics.opentargets.org",
       gitVersion: "",
     },
   };
@@ -39,6 +37,5 @@ export const getConfig = (): Config => {
     gitVersion: window.gitVersion ?? ENV_GIT_VERSION ?? "",
     profile: window.configProfile ?? { isPartnerPreview: false },
     googleTagManagerID: window.configGoogleTagManagerID ?? null,
-    geneticsPortalUrl: window.configGeneticsPortalUrl ?? "https://genetics.opentargets.org",
   };
 };

--- a/packages/ot-config/src/index.ts
+++ b/packages/ot-config/src/index.ts
@@ -10,7 +10,6 @@ declare global {
     configPathwaysApi?: string;
     configProfile?: Record<string, unknown>;
     configGoogleTagManagerID?: string;
-    configGeneticsPortalUrl?: string;
     gitVersion?: string;
   }
 }

--- a/packages/ot-config/src/types.ts
+++ b/packages/ot-config/src/types.ts
@@ -4,7 +4,6 @@ export interface Config {
   urlPathwaysApi: string;
   profile: Record<string, unknown>;
   googleTagManagerID: string | null;
-  geneticsPortalUrl: string;
   gitVersion: string;
 }
 

--- a/packages/ot-utils/src/urls.ts
+++ b/packages/ot-utils/src/urls.ts
@@ -1,7 +1,3 @@
-import { getConfig } from "@ot/config";
-
-const config = getConfig();
-
 interface RequestOptions {
   method: string;
   headers: Record<string, string>;
@@ -16,14 +12,6 @@ interface SearchPostResult {
 
 export function epmcUrl(id: string): string {
   return `https://europepmc.org/article/MED/${id}`;
-}
-
-export function otgStudyUrl(id: string): string {
-  return `${config.geneticsPortalUrl}/study/${id}`;
-}
-
-export function otgVariantUrl(id: string): string {
-  return `${config.geneticsPortalUrl}/variant/${id}`;
 }
 
 export function europePmcLiteratureQuery(ids: string[]): string {


### PR DESCRIPTION
# [Platform]: Remove genetics portal URL references from configuration and utility

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
