### PR TITLE
[Platform]: Correct non-existent EFO code in example query

### DIFF
--- a/apps/platform/src/pages/APIPage/TargetDiseaseEvidence.gql
+++ b/apps/platform/src/pages/APIPage/TargetDiseaseEvidence.gql
@@ -1,5 +1,5 @@
 query targetDiseaseEvidence {
-  disease(efoId: "MONDO_0005952") {
+  disease(efoId: "MONDO_0018908") {
     id
     name
     evidences(datasourceIds: ["intogen"], ensemblIds: ["ENSG00000172936"]) {


### PR DESCRIPTION
Pull request https://github.com/opentargets/platform-webapp/pull/958 replaced some superseded EFO codes, but I noticed that at least this one was not replaced by the actual successor, but by a mix of the new prefix with the old number, leading to a zero-row response for a very different disease, that does not relate to the queried gene at all.

See the deprecation notice for EFO_0005952 on
<https://www.ebi.ac.uk/ols4/ontologies/efo/classes/?short_form=EFO_0005952>

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I tried the query with the corrected ID on <https://platform.opentargets.org/api>, and no longer got a zero-row response but one that's identical, though with different disease IDs/names and sorting, to the equivalent as of 26.03.

## Checklist:

- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation
