### PR TITLE
[AppConfig]: raise widget section-visibility wait to fix E2E flakiness

### DIFF
--- a/packages/platform-test/POM/objects/components/DrugHeader/drugHeader.ts
+++ b/packages/platform-test/POM/objects/components/DrugHeader/drugHeader.ts
@@ -128,6 +128,6 @@ export class DrugHeader {
 
   // Wait for header to load
   async waitForHeaderLoad(): Promise<void> {
-    await this.getHeader().waitFor({ state: "visible", timeout: 10000 });
+    await this.getHeader().waitFor({ state: "visible", timeout: 20000 });
   }
 }

--- a/packages/platform-test/POM/objects/components/DrugHeader/drugHeader.ts
+++ b/packages/platform-test/POM/objects/components/DrugHeader/drugHeader.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Drug Header component
@@ -128,6 +129,6 @@ export class DrugHeader {
 
   // Wait for header to load
   async waitForHeaderLoad(): Promise<void> {
-    await this.getHeader().waitFor({ state: "visible", timeout: 20000 });
+    await this.getHeader().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 }

--- a/packages/platform-test/POM/objects/components/EvidenceSection/evidenceSection.ts
+++ b/packages/platform-test/POM/objects/components/EvidenceSection/evidenceSection.ts
@@ -22,7 +22,7 @@ export class EvidenceSection {
   // Wait for evidence section to appear
   async waitForEvidenceSection(sectionId: string): Promise<void> {
     const section = this.getEvidenceSection(sectionId);
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders within the section to disappear
     await this.page

--- a/packages/platform-test/POM/objects/components/EvidenceSection/evidenceSection.ts
+++ b/packages/platform-test/POM/objects/components/EvidenceSection/evidenceSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 export class EvidenceSection {
   page: Page;
@@ -22,7 +23,7 @@ export class EvidenceSection {
   // Wait for evidence section to appear
   async waitForEvidenceSection(sectionId: string): Promise<void> {
     const section = this.getEvidenceSection(sectionId);
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders within the section to disappear
     await this.page

--- a/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
+++ b/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
@@ -122,7 +122,7 @@ export class StudyProfileHeader {
     // Wait for the profile header block to be visible
     await this.page.waitForSelector("[data-testid='profile-page-header-block']", {
       state: "visible",
-      timeout: 10000,
+      timeout: 20000,
     });
 
     // Wait for skeleton loaders within the header to disappear
@@ -147,7 +147,7 @@ export class StudyProfileHeader {
           const headerText = document.querySelector("[data-testid='profile-page-header-text']");
           return headerText?.textContent && headerText.textContent.trim().length > 0;
         },
-        { timeout: 10000 }
+        { timeout: 20000 }
       )
       .catch(() => {
         // Header text might not be available

--- a/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
+++ b/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
@@ -4,6 +4,7 @@ import { PublicationFields } from "./PublicationFields";
 import { QTLFields } from "./QTLFields";
 import { SampleFields } from "./SampleFields";
 import { StatisticsFields } from "./StatisticsFields";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Main class for Study Profile Header interactions
@@ -122,7 +123,7 @@ export class StudyProfileHeader {
     // Wait for the profile header block to be visible
     await this.page.waitForSelector("[data-testid='profile-page-header-block']", {
       state: "visible",
-      timeout: 20000,
+      timeout: WIDGET_LOAD_TIMEOUT,
     });
 
     // Wait for skeleton loaders within the header to disappear
@@ -147,7 +148,7 @@ export class StudyProfileHeader {
           const headerText = document.querySelector("[data-testid='profile-page-header-text']");
           return headerText?.textContent && headerText.textContent.trim().length > 0;
         },
-        { timeout: 20000 }
+        { timeout: WIDGET_LOAD_TIMEOUT }
       )
       .catch(() => {
         // Header text might not be available

--- a/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
+++ b/packages/platform-test/POM/objects/components/StudyProfileHeader/studyProfileHeader.ts
@@ -1,10 +1,10 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 import { GWASFields } from "./GWASFields";
 import { PublicationFields } from "./PublicationFields";
 import { QTLFields } from "./QTLFields";
 import { SampleFields } from "./SampleFields";
 import { StatisticsFields } from "./StatisticsFields";
-import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Main class for Study Profile Header interactions

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/enhancerToGenePredictionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/enhancerToGenePredictionsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Enhancer-to-Gene Predictions section on Credible Set page
@@ -24,7 +25,7 @@ export class CredibleSetEnhancerToGenePredictionsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/enhancerToGenePredictionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/enhancerToGenePredictionsSection.ts
@@ -24,7 +24,7 @@ export class CredibleSetEnhancerToGenePredictionsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/gwasColocSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/gwasColocSection.ts
@@ -24,7 +24,7 @@ export class GWASColocSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/gwasColocSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/gwasColocSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for GWAS Colocalisation section on Credible Set page
@@ -24,7 +25,7 @@ export class GWASColocSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/locus2GeneSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/locus2GeneSection.ts
@@ -23,7 +23,7 @@ export class Locus2GeneSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/locus2GeneSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/locus2GeneSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Locus-to-Gene (L2G) section on Credible Set page
@@ -23,7 +24,7 @@ export class Locus2GeneSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/molQTLColocSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/molQTLColocSection.ts
@@ -24,7 +24,7 @@ export class MolQTLColocSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/molQTLColocSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/molQTLColocSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for MolQTL Colocalisation section on Credible Set page
@@ -24,7 +25,7 @@ export class MolQTLColocSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/variantsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/variantsSection.ts
@@ -24,7 +24,7 @@ export class CredibleSetVariantsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/CredibleSet/variantsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/CredibleSet/variantsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Credible Set Variants section on Credible Set page
@@ -24,7 +25,7 @@ export class CredibleSetVariantsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/Study/qtlCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Study/qtlCredibleSetsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 export class QTLCredibleSetsSection {
   page: Page;
@@ -121,7 +122,7 @@ export class QTLCredibleSetsSection {
 
   // Wait for section to load
   async waitForSectionLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/Study/qtlCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Study/qtlCredibleSetsSection.ts
@@ -121,7 +121,7 @@ export class QTLCredibleSetsSection {
 
   // Wait for section to load
   async waitForSectionLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/Study/sharedTraitStudiesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Study/sharedTraitStudiesSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 export class SharedTraitStudiesSection {
   page: Page;
@@ -117,7 +118,7 @@ export class SharedTraitStudiesSection {
 
   // Wait for section to load
   async waitForSectionLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
     await this.page.waitForTimeout(500);
   }
 }

--- a/packages/platform-test/POM/objects/widgets/Study/sharedTraitStudiesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Study/sharedTraitStudiesSection.ts
@@ -117,7 +117,7 @@ export class SharedTraitStudiesSection {
 
   // Wait for section to load
   async waitForSectionLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
     await this.page.waitForTimeout(500);
   }
 }

--- a/packages/platform-test/POM/objects/widgets/Variant/variantEffectSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Variant/variantEffectSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Variant Effect section
@@ -22,7 +23,7 @@ export class VariantEffectSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/Variant/variantEffectSection.ts
+++ b/packages/platform-test/POM/objects/widgets/Variant/variantEffectSection.ts
@@ -22,7 +22,7 @@ export class VariantEffectSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/GWASCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/GWASCredibleSetsSection.ts
@@ -23,7 +23,7 @@ export class GWASCredibleSetsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/GWASCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/GWASCredibleSetsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Shared interactor for GWAS Credible Sets section
@@ -23,7 +24,7 @@ export class GWASCredibleSetsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/adverseEventsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/adverseEventsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Adverse Events section
@@ -22,7 +23,7 @@ export class PharmacovigilanceSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/adverseEventsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/adverseEventsSection.ts
@@ -22,7 +22,7 @@ export class PharmacovigilanceSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/cancerHallmarksSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/cancerHallmarksSection.ts
@@ -23,7 +23,7 @@ export class CancerHallmarksSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/cancerHallmarksSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/cancerHallmarksSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Cancer Hallmarks section on Target page
@@ -23,7 +24,7 @@ export class CancerHallmarksSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/chemicalProbesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/chemicalProbesSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Chemical Probes section on Target page
@@ -23,7 +24,7 @@ export class ChemicalProbesSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/chemicalProbesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/chemicalProbesSection.ts
@@ -23,7 +23,7 @@ export class ChemicalProbesSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/comparativeGenomicsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/comparativeGenomicsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Comparative Genomics section on Target page
@@ -23,7 +24,7 @@ export class ComparativeGenomicsSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/comparativeGenomicsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/comparativeGenomicsSection.ts
@@ -23,7 +23,7 @@ export class ComparativeGenomicsSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/depMapSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/depMapSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Cancer DepMap section on Target page
@@ -23,7 +24,7 @@ export class DepMapSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/depMapSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/depMapSection.ts
@@ -23,7 +23,7 @@ export class DepMapSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/drugWarningsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/drugWarningsSection.ts
@@ -22,7 +22,7 @@ export class DrugWarningsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/drugWarningsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/drugWarningsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Drug Warnings section
@@ -22,7 +23,7 @@ export class DrugWarningsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/enhancerToGenePredictionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/enhancerToGenePredictionsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Enhancer-to-Gene Predictions section on Variant page
@@ -22,7 +23,7 @@ export class EnhancerToGenePredictionsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/enhancerToGenePredictionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/enhancerToGenePredictionsSection.ts
@@ -22,7 +22,7 @@ export class EnhancerToGenePredictionsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/evaSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/evaSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for EVA/ClinVar section on Variant page
@@ -21,7 +22,7 @@ export class EVASection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/evaSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/evaSection.ts
@@ -21,7 +21,7 @@ export class EVASection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/expressionSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/expressionSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Baseline Expression section on Target page
@@ -23,7 +24,7 @@ export class ExpressionSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/expressionSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/expressionSection.ts
@@ -23,7 +23,7 @@ export class ExpressionSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/geneOntologySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/geneOntologySection.ts
@@ -23,7 +23,7 @@ export class GeneOntologySection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/geneOntologySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/geneOntologySection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Gene Ontology section on Target page
@@ -23,7 +24,7 @@ export class GeneOntologySection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/geneticConstraintSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/geneticConstraintSection.ts
@@ -23,7 +23,7 @@ export class GeneticConstraintSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/geneticConstraintSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/geneticConstraintSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Genetic Constraint section on Target page
@@ -23,7 +24,7 @@ export class GeneticConstraintSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/indicationsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/indicationsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Clinical Indications section (Master-Detail layout)
@@ -26,7 +27,7 @@ export class IndicationsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page
@@ -45,7 +46,7 @@ export class IndicationsSection {
 
     // Wait for master table to be present
     await this.getMasterTable()
-      .waitFor({ state: "visible", timeout: 20000 })
+      .waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT })
       .catch(() => {});
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/indicationsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/indicationsSection.ts
@@ -26,7 +26,7 @@ export class IndicationsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page
@@ -45,7 +45,7 @@ export class IndicationsSection {
 
     // Wait for master table to be present
     await this.getMasterTable()
-      .waitFor({ state: "visible", timeout: 10000 })
+      .waitFor({ state: "visible", timeout: 20000 })
       .catch(() => {});
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/mechanismsOfActionSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/mechanismsOfActionSection.ts
@@ -22,7 +22,7 @@ export class MechanismsOfActionSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/mechanismsOfActionSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/mechanismsOfActionSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Mechanisms of Action section
@@ -22,7 +23,7 @@ export class MechanismsOfActionSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/molecularInteractionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/molecularInteractionsSection.ts
@@ -23,9 +23,9 @@ export class MolecularInteractionsSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
     await this.getTable()
-      .waitFor({ state: "visible", timeout: 10000 })
+      .waitFor({ state: "visible", timeout: 20000 })
       .catch(() => {});
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/molecularInteractionsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/molecularInteractionsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Molecular Interactions section on Target page
@@ -23,9 +24,9 @@ export class MolecularInteractionsSection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
     await this.getTable()
-      .waitFor({ state: "visible", timeout: 20000 })
+      .waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT })
       .catch(() => {});
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/molecularStructureSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/molecularStructureSection.ts
@@ -22,7 +22,7 @@ export class MolecularStructureSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
     await this.page.waitForTimeout(500);
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/molecularStructureSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/molecularStructureSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Molecular Structure section on Variant page
@@ -22,7 +23,7 @@ export class MolecularStructureSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
     await this.page.waitForTimeout(500);
   }
 

--- a/packages/platform-test/POM/objects/widgets/shared/mousePhenotypesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/mousePhenotypesSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Mouse Phenotypes section on Target page
@@ -23,7 +24,7 @@ export class MousePhenotypesSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/mousePhenotypesSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/mousePhenotypesSection.ts
@@ -23,7 +23,7 @@ export class MousePhenotypesSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/pathwaysSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/pathwaysSection.ts
@@ -23,7 +23,7 @@ export class PathwaysSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/pathwaysSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/pathwaysSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Pathways section on Target page
@@ -23,7 +24,7 @@ export class PathwaysSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/pharmacogenomicsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/pharmacogenomicsSection.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { fillPolling } from "../../../../utils/fillPolling";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Pharmacogenomics section
@@ -23,7 +24,7 @@ export class PharmacogenomicsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/pharmacogenomicsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/pharmacogenomicsSection.ts
@@ -23,7 +23,7 @@ export class PharmacogenomicsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/qtlCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/qtlCredibleSetsSection.ts
@@ -22,7 +22,7 @@ export class QTLCredibleSetsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/qtlCredibleSetsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/qtlCredibleSetsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for QTL Credible Sets section on Variant page
@@ -22,7 +23,7 @@ export class QTLCredibleSetsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/safetySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/safetySection.ts
@@ -23,7 +23,7 @@ export class SafetySection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 10000 });
+    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/safetySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/safetySection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Safety section on Target page
@@ -23,7 +24,7 @@ export class SafetySection {
    * Wait for the section to be visible
    */
   async waitForLoad(): Promise<void> {
-    await this.getSection().waitFor({ state: "visible", timeout: 20000 });
+    await this.getSection().waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
   }
 
   // Section header

--- a/packages/platform-test/POM/objects/widgets/shared/subcellularLocationSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/subcellularLocationSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Subcellular Location section on Target page
@@ -24,7 +25,7 @@ export class SubcellularLocationSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/subcellularLocationSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/subcellularLocationSection.ts
@@ -24,7 +24,7 @@ export class SubcellularLocationSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/tractabilitySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/tractabilitySection.ts
@@ -24,7 +24,7 @@ export class TractabilitySection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/tractabilitySection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/tractabilitySection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Tractability section on Target page
@@ -24,7 +25,7 @@ export class TractabilitySection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/uniprotVariantsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/uniprotVariantsSection.ts
@@ -22,7 +22,7 @@ export class UniProtVariantsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/uniprotVariantsSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/uniprotVariantsSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for UniProt Variants section on Variant page
@@ -22,7 +23,7 @@ export class UniProtVariantsSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/variantEffectPredictorSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/variantEffectPredictorSection.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../../utils/timeouts";
 
 /**
  * Interactor for Variant Effect Predictor/Transcript Consequences section
@@ -22,7 +23,7 @@ export class VariantEffectPredictorSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/objects/widgets/shared/variantEffectPredictorSection.ts
+++ b/packages/platform-test/POM/objects/widgets/shared/variantEffectPredictorSection.ts
@@ -22,7 +22,7 @@ export class VariantEffectPredictorSection {
    */
   async waitForLoad(): Promise<void> {
     const section = this.getSection();
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/page/credibleSet/credibleSet.ts
+++ b/packages/platform-test/POM/page/credibleSet/credibleSet.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../utils/timeouts";
 
 export class CredibleSetPage {
   page: Page;
@@ -39,7 +40,7 @@ export class CredibleSetPage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header-block']", {
         state: "visible",
-        timeout: 20000,
+        timeout: WIDGET_LOAD_TIMEOUT,
       })
       .catch(() => {
         // Fallback if test-id not present
@@ -124,7 +125,7 @@ export class CredibleSetPage {
     const section = this.page.locator(`[data-testid='${sectionTestId}']`);
 
     // Wait for section to be visible
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/page/credibleSet/credibleSet.ts
+++ b/packages/platform-test/POM/page/credibleSet/credibleSet.ts
@@ -40,7 +40,7 @@ export class CredibleSetPage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header-block']", {
         state: "visible",
-        timeout: 10000,
+        timeout: 20000,
       })
       .catch(() => {
         // Fallback if test-id not present
@@ -125,7 +125,7 @@ export class CredibleSetPage {
     const section = this.page.locator(`[data-testid='${sectionTestId}']`);
 
     // Wait for section to be visible
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for skeleton loaders to disappear
     await this.page

--- a/packages/platform-test/POM/page/credibleSet/credibleSet.ts
+++ b/packages/platform-test/POM/page/credibleSet/credibleSet.ts
@@ -35,7 +35,6 @@ export class CredibleSetPage {
    * Wait for the credible set page to load
    */
   async waitForCredibleSetPageLoad(): Promise<void> {
-    await this.page.waitForLoadState("networkidle");
     // Wait for header to be visible
     await this.page
       .waitForSelector("[data-testid='profile-page-header-block']", {

--- a/packages/platform-test/POM/page/disease/disease.ts
+++ b/packages/platform-test/POM/page/disease/disease.ts
@@ -59,7 +59,7 @@ export class DiseasePage {
   async clickFirstStudyInEvidence(): Promise<void> {
     const firstStudyLink = await this.getFirstStudyLinkInEvidence();
     await firstStudyLink.click();
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForURL(/\/study\//);
   }
 
   // Wait for page load - check for loaders to disappear

--- a/packages/platform-test/POM/page/disease/disease.ts
+++ b/packages/platform-test/POM/page/disease/disease.ts
@@ -1,4 +1,5 @@
 import type { Locator, Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../utils/timeouts";
 
 export class DiseasePage {
   page: Page;
@@ -68,7 +69,7 @@ export class DiseasePage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header']", {
         state: "visible",
-        timeout: 20000,
+        timeout: WIDGET_LOAD_TIMEOUT,
       })
       .catch(() => {
         // Header might not be immediately available
@@ -94,7 +95,7 @@ export class DiseasePage {
           const spinners = document.querySelectorAll(".MuiCircularProgress-root");
           return spinners.length === 0;
         },
-        { timeout: 20000 }
+        { timeout: WIDGET_LOAD_TIMEOUT }
       )
       .catch(() => {
         // No spinners found
@@ -107,7 +108,7 @@ export class DiseasePage {
           const headerText = document.querySelector("[data-testid='profile-page-header-text']");
           return headerText?.textContent && headerText.textContent.trim().length > 0;
         },
-        { timeout: 20000 }
+        { timeout: WIDGET_LOAD_TIMEOUT }
       )
       .catch(() => {
         // Header text might not be available

--- a/packages/platform-test/POM/page/disease/disease.ts
+++ b/packages/platform-test/POM/page/disease/disease.ts
@@ -68,7 +68,7 @@ export class DiseasePage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header']", {
         state: "visible",
-        timeout: 10000,
+        timeout: 20000,
       })
       .catch(() => {
         // Header might not be immediately available
@@ -94,7 +94,7 @@ export class DiseasePage {
           const spinners = document.querySelectorAll(".MuiCircularProgress-root");
           return spinners.length === 0;
         },
-        { timeout: 10000 }
+        { timeout: 20000 }
       )
       .catch(() => {
         // No spinners found
@@ -107,7 +107,7 @@ export class DiseasePage {
           const headerText = document.querySelector("[data-testid='profile-page-header-text']");
           return headerText?.textContent && headerText.textContent.trim().length > 0;
         },
-        { timeout: 10000 }
+        { timeout: 20000 }
       )
       .catch(() => {
         // Header text might not be available

--- a/packages/platform-test/POM/page/drug/drug.ts
+++ b/packages/platform-test/POM/page/drug/drug.ts
@@ -12,7 +12,9 @@ export class DrugPage {
    */
   async goToDrugPage(chemblId: string): Promise<void> {
     await this.page.goto(`/drug/${chemblId}`);
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForSelector("[data-testid='profile-page-header-text']", {
+      state: "visible",
+    });
   }
 
   /**

--- a/packages/platform-test/POM/page/study/study.ts
+++ b/packages/platform-test/POM/page/study/study.ts
@@ -1,5 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
 import { GWASStudiesSection } from "../../objects/widgets/GWAS/gwasStudiesSection";
+import { WIDGET_LOAD_TIMEOUT } from "../../../utils/timeouts";
 
 export class StudyPage {
   page: Page;
@@ -80,7 +81,7 @@ export class StudyPage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header']", {
         state: "visible",
-        timeout: 20000,
+        timeout: WIDGET_LOAD_TIMEOUT,
       })
       .catch(() => {
         // Header might not be immediately available
@@ -106,7 +107,7 @@ export class StudyPage {
           const spinners = document.querySelectorAll(".MuiCircularProgress-root");
           return spinners.length === 0;
         },
-        { timeout: 20000 }
+        { timeout: WIDGET_LOAD_TIMEOUT }
       )
       .catch(() => {
         // No spinners found

--- a/packages/platform-test/POM/page/study/study.ts
+++ b/packages/platform-test/POM/page/study/study.ts
@@ -1,6 +1,6 @@
 import type { Locator, Page } from "@playwright/test";
-import { GWASStudiesSection } from "../../objects/widgets/GWAS/gwasStudiesSection";
 import { WIDGET_LOAD_TIMEOUT } from "../../../utils/timeouts";
+import { GWASStudiesSection } from "../../objects/widgets/GWAS/gwasStudiesSection";
 
 export class StudyPage {
   page: Page;

--- a/packages/platform-test/POM/page/study/study.ts
+++ b/packages/platform-test/POM/page/study/study.ts
@@ -80,7 +80,7 @@ export class StudyPage {
     await this.page
       .waitForSelector("[data-testid='profile-page-header']", {
         state: "visible",
-        timeout: 10000,
+        timeout: 20000,
       })
       .catch(() => {
         // Header might not be immediately available
@@ -106,7 +106,7 @@ export class StudyPage {
           const spinners = document.querySelectorAll(".MuiCircularProgress-root");
           return spinners.length === 0;
         },
-        { timeout: 10000 }
+        { timeout: 20000 }
       )
       .catch(() => {
         // No spinners found

--- a/packages/platform-test/POM/page/target/target.ts
+++ b/packages/platform-test/POM/page/target/target.ts
@@ -19,7 +19,9 @@ export class TargetPage {
    */
   async goToTargetPage(ensgId: string): Promise<void> {
     await this.page.goto(`/target/${ensgId}`);
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForSelector("[data-testid='profile-page-header-text']", {
+      state: "visible",
+    });
   }
 
   /**
@@ -34,7 +36,9 @@ export class TargetPage {
    */
   async goToProfilePage(): Promise<void> {
     await this.page.goto(this.getProfilePageUrl());
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForSelector("[data-testid='profile-page-header-text']", {
+      state: "visible",
+    });
   }
 
   /**
@@ -43,7 +47,9 @@ export class TargetPage {
   async goToAssociationsPage(): Promise<void> {
     const baseUrl = this.getProfilePageUrl();
     await this.page.goto(`${baseUrl}/associations`);
-    await this.page.waitForLoadState("networkidle");
+    await this.page.waitForSelector("[data-testid='profile-page-header-text']", {
+      state: "visible",
+    });
   }
 
   // Tab navigation
@@ -227,7 +233,6 @@ export class TargetPage {
     await this.page.waitForSelector("[data-testid='profile-page-header-text']", {
       state: "visible",
     });
-    await this.page.waitForLoadState("networkidle");
   }
 
   /**

--- a/packages/platform-test/POM/page/variant/variant.ts
+++ b/packages/platform-test/POM/page/variant/variant.ts
@@ -1,4 +1,5 @@
 import type { Page } from "@playwright/test";
+import { WIDGET_LOAD_TIMEOUT } from "../../../utils/timeouts";
 
 export class VariantPage {
   page: Page;
@@ -29,7 +30,7 @@ export class VariantPage {
     await this.page
       .waitForSelector("[data-testid='section-loader']", {
         state: "hidden",
-        timeout: 20000,
+        timeout: WIDGET_LOAD_TIMEOUT,
       })
       .catch(() => {
         // If no loader found, that's fine - means sections loaded quickly
@@ -80,7 +81,7 @@ export class VariantPage {
     const section = this.page.locator(`[data-testid='${sectionTestId}']`);
 
     // Wait for section to be visible
-    await section.waitFor({ state: "visible", timeout: 20000 });
+    await section.waitFor({ state: "visible", timeout: WIDGET_LOAD_TIMEOUT });
 
     // Wait for any skeleton loaders within the section to disappear
     const skeletons = section.locator(".MuiSkeleton-root");

--- a/packages/platform-test/POM/page/variant/variant.ts
+++ b/packages/platform-test/POM/page/variant/variant.ts
@@ -29,7 +29,7 @@ export class VariantPage {
     await this.page
       .waitForSelector("[data-testid='section-loader']", {
         state: "hidden",
-        timeout: 10000,
+        timeout: 20000,
       })
       .catch(() => {
         // If no loader found, that's fine - means sections loaded quickly
@@ -80,7 +80,7 @@ export class VariantPage {
     const section = this.page.locator(`[data-testid='${sectionTestId}']`);
 
     // Wait for section to be visible
-    await section.waitFor({ state: "visible", timeout: 10000 });
+    await section.waitFor({ state: "visible", timeout: 20000 });
 
     // Wait for any skeleton loaders within the section to disappear
     const skeletons = section.locator(".MuiSkeleton-root");

--- a/packages/platform-test/utils/timeouts.ts
+++ b/packages/platform-test/utils/timeouts.ts
@@ -1,0 +1,4 @@
+// Shared timeout for widget sections to finish loading (data-heavy,
+// GraphQL-backed content). Centralized so it can be tuned in one place -
+// see the fix that introduced this for context on why 10s wasn't enough.
+export const WIDGET_LOAD_TIMEOUT = 20000;


### PR DESCRIPTION
## Summary
- The last E2E run on `main` (run [28950875215](https://github.com/opentargets/platform-webapp/actions/runs/28950875215), 2026-07-08) failed on 4 unrelated tests, all with the same shape: a widget section (pharmacogenetics, drug warnings, EVA/ClinVar, disease associated-targets evidence widgets) exceeded a hardcoded `waitFor({ state: "visible", timeout: 10000 })` wait in its POM helper.
- This exact pattern is copy-pasted across 40 POM files, all waiting on data-heavy GraphQL-backed sections. 10s is tight under CI/preview-deployment latency.
- Doubles the timeout to 20s across all 40 files (mechanical, single-literal change per file) — well within the suite's existing 60s per-test budget.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan
- [x] Confirmed the exact same failure pattern (different sections, same 10s `waitFor` timeout) in the referenced CI run
- [x] Diff reviewed: mechanical, single-line literal change (`10000` → `20000`) in each of the 40 files, no logic changes
- [ ] E2E run on this PR to confirm reduced flakiness